### PR TITLE
Change: support more architectures in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,15 @@
-### STAGE 0: FFMPEG ###
-FROM jrottenberg/ffmpeg:4.1-alpine AS ffmpeg
-
-### STAGE 1: Build client ###
+### STAGE 0: Build client ###
 FROM node:12-alpine AS build
 WORKDIR /client
 COPY /client /client
 RUN npm install
 RUN npm run generate
 
-### STAGE 2: Build server ###
+### STAGE 1: Build server ###
 FROM node:12-alpine
+RUN apk update && apk add --no-cache --update ffmpeg
 ENV NODE_ENV=production
 COPY --from=build /client/dist /client/dist
-COPY --from=ffmpeg / /
 COPY index.js index.js
 COPY package.json package.json
 COPY server server


### PR DESCRIPTION
Hi, I wanted to run AudioBookShelf on my raspberry pi, but since `jrottenberg/ffmpeg` only offers x64 images it wasn't possible. 

I've changed the Dockerfile to install `ffmpeg` rather than copy it from an existing image, this way the image can be built for any platform that is supported by `node:12-alpine` (which is a lot).

I've tested this and the image is running fine on my RPi4. The only problem I've encountered was with ziplib not being available during server build phase, but the same problem is present when building the x64 version, so I guess it's fine ¯\\_(ツ)_/¯