### PR TITLE
Added an endpoint to serve different cover sizes

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "podcast": "^1.3.0",
     "read-chunk": "^3.1.0",
     "recursive-readdir-async": "^1.1.8",
+    "sharp": "^0.29.3",
     "socket.io": "^4.1.3",
     "string-strip-html": "^8.3.0",
     "watcher": "^1.2.0",

--- a/server/utils/resizeImage.js
+++ b/server/utils/resizeImage.js
@@ -1,0 +1,16 @@
+const sharp = require('sharp')
+const fs = require('fs')
+
+function resize(filePath, width, height) {
+  const readStream = fs.createReadStream(filePath);
+  let sharpie = sharp()
+  sharpie.toFormat('jpeg')
+
+  if (width || height) {
+    sharpie.resize(width, height)
+  }
+
+  return readStream.pipe(sharpie)
+}
+
+module.exports = resize;


### PR DESCRIPTION
I've been playing around with the api and I thought it would be useful to be able to serve cover images at whatever size the client might want. This should accomplish that.