### PR TITLE
Added isbn search

### DIFF
--- a/client/components/cards/AudiobookSearchCard.vue
+++ b/client/components/cards/AudiobookSearchCard.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex h-full px-1 overflow-hidden">
+  <div class="flex items-center h-full px-1 overflow-hidden">
     <covers-book-cover :audiobook="audiobook" :width="coverWidth" :book-cover-aspect-ratio="bookCoverAspectRatio" />
     <div class="flex-grow px-2 audiobookSearchCardContent">
       <p v-if="matchKey !== 'title'" class="truncate text-sm">{{ title }}</p>
@@ -10,7 +10,7 @@
       <p v-if="matchKey !== 'authorFL'" class="text-xs text-gray-200 truncate">by {{ authorFL }}</p>
       <p v-else class="truncate text-xs text-gray-200" v-html="matchHtml" />
 
-      <div v-if="matchKey === 'series' || matchKey === 'tags'" class="m-0 p-0 truncate" v-html="matchHtml" />
+      <div v-if="matchKey === 'series' || matchKey === 'tags' || matchKey === 'isbn'" class="m-0 p-0 truncate text-xs" v-html="matchHtml" />
     </div>
   </div>
 </template>
@@ -70,6 +70,7 @@ export default {
 
       if (this.matchKey === 'tags') return `<p class="truncate">Tags: ${html}</p>`
       if (this.matchKey === 'authorFL') return `by ${html}`
+      if (this.matchKey === 'isbn') return `<p class="truncate">ISBN: ${html}</p>`
       if (this.matchKey === 'series') return `<p class="truncate">Series: ${html}</p>`
       return `${html}`
     }

--- a/server/objects/Book.js
+++ b/server/objects/Book.js
@@ -278,8 +278,12 @@ class Book {
 
     // var authorMatch = this._author.toLowerCase().includes(search)
     var seriesMatch = this._series.toLowerCase().includes(search)
+    
+    // ISBN match has to be exact to prevent isbn matches to flood results. Remove dashes since isbn might have those
+    var isbnMatch = this.isbn.toLowerCase().replaceAll('-', '') === search.replaceAll('-', '')
 
-    var bookMatchKey = titleMatch ? 'title' : subtitleMatch ? 'subtitle' : authorsMatched.length ? 'authorFL' : seriesMatch ? 'series' : false
+    var bookMatchKey = titleMatch ? 'title' : subtitleMatch ? 'subtitle' : authorsMatched.length ? 'authorFL' : seriesMatch ? 'series' : isbnMatch ? 'isbn' : false
+
     var bookMatchText = bookMatchKey ? this[bookMatchKey] : ''
     return {
       book: bookMatchKey,

--- a/server/objects/Book.js
+++ b/server/objects/Book.js
@@ -278,9 +278,9 @@ class Book {
 
     // var authorMatch = this._author.toLowerCase().includes(search)
     var seriesMatch = this._series.toLowerCase().includes(search)
-    
+
     // ISBN match has to be exact to prevent isbn matches to flood results. Remove dashes since isbn might have those
-    var isbnMatch = this.isbn.toLowerCase().replaceAll('-', '') === search.replaceAll('-', '')
+    var isbnMatch = this.isbn.toLowerCase().replace(/-/g, '') === search.replace(/-/g, '')
 
     var bookMatchKey = titleMatch ? 'title' : subtitleMatch ? 'subtitle' : authorsMatched.length ? 'authorFL' : seriesMatch ? 'series' : isbnMatch ? 'isbn' : false
 

--- a/server/objects/Book.js
+++ b/server/objects/Book.js
@@ -43,6 +43,7 @@ class Book {
   get _authorsList() { return this._author.split(', ') }
   get _narratorsList() { return this._narrator.split(', ') }
   get _genres() { return this.genres || [] }
+  get _isbn() { return this.isbn || '' }
 
   get shouldSearchForCover() {
     if (this.cover) return false
@@ -280,7 +281,7 @@ class Book {
     var seriesMatch = this._series.toLowerCase().includes(search)
 
     // ISBN match has to be exact to prevent isbn matches to flood results. Remove dashes since isbn might have those
-    var isbnMatch = this.isbn.toLowerCase().replace(/-/g, '') === search.replace(/-/g, '')
+    var isbnMatch = this._isbn.toLowerCase().replace(/-/g, '') === search.replace(/-/g, '')
 
     var bookMatchKey = titleMatch ? 'title' : subtitleMatch ? 'subtitle' : authorsMatched.length ? 'authorFL' : seriesMatch ? 'series' : isbnMatch ? 'isbn' : false
 


### PR DESCRIPTION
Search now also searches books using isbn. ISBN match has to be exact to prevent isbn matches to flood results. 

I was thinking about two other approaches:
1. Only 10 and 13 character searches to be isbn searches since those are isbn lengths. This would limit using isbn field with other type of identify codes. I for one have some podcasts and other stuff that won't have isbn, but have guid instead.
2. Start searching isbn when search string is longer than 4,  because book name might have year in it. This might be good solution since not many books have more than 4 consecutive numbers so there would be no other results anyway. I don't know if there is use case for searching partial isbn. This would also require changes to client side search results list so you could see what part of isbn is matching. Since search only returns 12 books results would need to be ranked or sorted to some order, for example prefer matches from start of isbn.

Ended up with this proposed solution since I think it is good enough for most of people