### PR TITLE
Fixes reading multiline data from file tags

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "jsonwebtoken": "^8.5.1",
     "libgen": "^2.1.0",
     "njodb": "^0.4.27",
+    "node-ffprobe": "^3.0.0",
     "node-cron": "^3.0.0",
     "node-stream-zip": "^1.15.0",
     "podcast": "^1.3.0",

--- a/server/utils/prober.js
+++ b/server/utils/prober.js
@@ -1,4 +1,3 @@
-var Ffmpeg = require('fluent-ffmpeg')
 const ffprobe = require('node-ffprobe')
 const Path = require('path')
 


### PR DESCRIPTION
Swiched fluent-ffmpeg to node-ffprobe. Fluent's ffprobe implementation can't handle multiline tag data due to it's parsing process. There is open issue (https://github.com/fluent-ffmpeg/node-fluent-ffmpeg/issues/457) about problem and even PR(https://github.com/fluent-ffmpeg/node-fluent-ffmpeg/pull/476), but both are over 5 years old so I wouldn't hold my breath for that. 

node-ffprobe supports getting probe data using json format which keeps line changes. Not sure if this is best library for this but it won't have any dependencies and it does the job.

Tested with two mp3 files. One has metadata and one doesn't and it seemed to get same metadata as the old implementation. I advice you to do some testing if there is something that I didn't notice.