### PR TITLE
Fix: Series link from search goes straight to series

### DIFF
--- a/client/components/controls/GlobalSearch.vue
+++ b/client/components/controls/GlobalSearch.vue
@@ -40,7 +40,7 @@
           <p v-if="seriesResults.length" class="uppercase text-xs text-gray-400 mb-1 mt-3 px-1 font-semibold">Series</p>
           <template v-for="item in seriesResults">
             <li :key="item.series" class="text-gray-50 select-none relative cursor-pointer hover:bg-black-400 py-1" role="option">
-              <nuxt-link :to="`/library/${currentLibraryId}/bookshelf/series?series=${$encode(item.series)}`">
+              <nuxt-link :to="`/library/${currentLibraryId}/series/${$encode(item.series)}`">
                 <cards-series-search-card :series="item.series" :book-items="item.audiobooks" />
               </nuxt-link>
             </li>


### PR DESCRIPTION
Clicking on the series in the search result box now goes straight to the series instead of to the series library view.