### PR TITLE
Allowed the configuration of a "HOST" parameter to enable ipv6 support.

### DIFF
--- a/build/debian/DEBIAN/preinst
+++ b/build/debian/DEBIAN/preinst
@@ -6,6 +6,7 @@ FFMPEG_INSTALL_DIR="/usr/lib/audiobookshelf-ffmpeg/"
 DEFAULT_AUDIOBOOK_PATH="/usr/share/audiobookshelf/audiobooks"
 DEFAULT_DATA_PATH="/usr/share/audiobookshelf"
 DEFAULT_PORT=7331
+DEFAULT_HOST="0.0.0.0"
 
 CONFIG_PATH="/etc/default/audiobookshelf"
 
@@ -82,7 +83,8 @@ setup_config_interactive() {
   CONFIG_PATH=$DATA_PATH/config
   FFMPEG_PATH=/usr/lib/audiobookshelf-ffmpeg/ffmpeg
   FFPROBE_PATH=/usr/lib/audiobookshelf-ffmpeg/ffprobe
-  PORT=$PORT"
+  PORT=$PORT
+  HOST=$DEFAULT_HOST"
 
     echo "$config_text"
 
@@ -105,7 +107,8 @@ setup_config() {
   CONFIG_PATH=$DEFAULT_DATA_PATH/config
   FFMPEG_PATH=/usr/lib/audiobookshelf-ffmpeg/ffmpeg
   FFPROBE_PATH=/usr/lib/audiobookshelf-ffmpeg/ffprobe
-  PORT=$DEFAULT_PORT"
+  PORT=$DEFAULT_PORT
+  HOST=$DEFAULT_HOST"
 
     echo "$config_text"
 

--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ if (isDev) {
 }
 
 const PORT = process.env.PORT || 80
+const HOST = process.env.HOST || '0.0.0.0'
 const CONFIG_PATH = process.env.CONFIG_PATH || '/config'
 const AUDIOBOOK_PATH = process.env.AUDIOBOOK_PATH || '/audiobooks'
 const METADATA_PATH = process.env.METADATA_PATH || '/metadata'
@@ -24,5 +25,5 @@ const GID = process.env.AUDIOBOOKSHELF_GID || 100
 
 console.log('Config', CONFIG_PATH, METADATA_PATH, AUDIOBOOK_PATH)
 
-const Server = new server(PORT, UID, GID, CONFIG_PATH, METADATA_PATH, AUDIOBOOK_PATH)
+const Server = new server(PORT, HOST, UID, GID, CONFIG_PATH, METADATA_PATH, AUDIOBOOK_PATH)
 Server.start()

--- a/prod.js
+++ b/prod.js
@@ -2,7 +2,8 @@ const optionDefinitions = [
   { name: 'config', alias: 'c', type: String },
   { name: 'audiobooks', alias: 'a', type: String },
   { name: 'metadata', alias: 'm', type: String },
-  { name: 'port', alias: 'p', type: String }
+  { name: 'port', alias: 'p', type: String },
+  { name: 'host', alias: 'h', type: String }
 ]
 
 const commandLineArgs = require('command-line-args')

--- a/prod.js
+++ b/prod.js
@@ -21,6 +21,7 @@ var inputAudiobook = options.audiobooks ? Path.resolve(options.audiobooks) : nul
 var inputMetadata = options.metadata ? Path.resolve(options.metadata) : null
 
 const PORT = options.port || process.env.PORT || 3333
+const HOST = options.host || process.env.HOST || "0.0.0.0"
 const CONFIG_PATH = inputConfig || process.env.CONFIG_PATH || Path.resolve('config')
 const AUDIOBOOK_PATH = inputAudiobook || process.env.AUDIOBOOK_PATH || Path.resolve('audiobooks')
 const METADATA_PATH = inputMetadata || process.env.METADATA_PATH || Path.resolve('metadata')
@@ -29,5 +30,5 @@ const GID = 100
 
 console.log(process.env.NODE_ENV, 'Config', CONFIG_PATH, METADATA_PATH, AUDIOBOOK_PATH)
 
-const Server = new server(PORT, UID, GID, CONFIG_PATH, METADATA_PATH, AUDIOBOOK_PATH)
+const Server = new server(PORT, HOST, UID, GID, CONFIG_PATH, METADATA_PATH, AUDIOBOOK_PATH)
 Server.start()

--- a/server/Server.js
+++ b/server/Server.js
@@ -31,9 +31,9 @@ const CoverController = require('./CoverController')
 const CacheManager = require('./CacheManager')
 
 class Server {
-  constructor(PORT, UID, GID, CONFIG_PATH, METADATA_PATH, AUDIOBOOK_PATH) {
+  constructor(PORT, HOST, UID, GID, CONFIG_PATH, METADATA_PATH, AUDIOBOOK_PATH) {
     this.Port = PORT
-    this.Host = '0.0.0.0'
+    this.Host = HOST
     global.Uid = isNaN(UID) ? 0 : Number(UID)
     global.Gid = isNaN(GID) ? 0 : Number(GID)
     global.ConfigPath = Path.normalize(CONFIG_PATH)


### PR DESCRIPTION
My local network runs mostly on ipv6, so I would like to be able to adjust the listening host (to "::" for me) to enable the server to listen on both ipv4 and v6.  This also allows people to limit the server to listen on specific IPs if needed.