### PR TITLE
Include the type of filter being applied in the UI

### DIFF
--- a/client/components/app/LazyBookshelf.vue
+++ b/client/components/app/LazyBookshelf.vue
@@ -91,7 +91,7 @@ export default {
     emptyMessage() {
       if (this.page === 'series') return `You have no series`
       if (this.page === 'collections') return "You haven't made any collections yet"
-      if (this.hasFilter) return `No Results for filter "${this.filterValue}"`
+      if (this.hasFilter) return `No Results for filter "${this.filterName}: ${this.filterValue}"`
       return 'No results'
     },
     entityName() {

--- a/client/components/controls/FilterSelect.vue
+++ b/client/components/controls/FilterSelect.vue
@@ -161,23 +161,29 @@ export default {
     selectedText() {
       if (!this.selected) return ''
       var parts = this.selected.split('.')
+      var filterName = this.selectItems.find((i) => i.value === parts[0]);
+      var filterValue = null;
       if (parts.length > 1) {
         var decoded = this.$decode(parts[1])
         if (decoded.startsWith('aut_')) {
           var author = this.authors.find((au) => au.id == decoded)
-          if (author) return author.name
-          return ''
-        }
-        if (decoded.startsWith('ser_')) {
+          if (author) filterValue = author.name;
+        } else if (decoded.startsWith('ser_')) {
           var series = this.series.find((se) => se.id == decoded)
-          if (series) return series.name
-          return ''
+          if (series) filterValue = series.name
+        } else {
+          filterValue = decoded;
         }
-        return decoded
       }
-      var _sel = this.selectItems.find((i) => i.value === this.selected)
-      if (!_sel) return ''
-      return _sel.text
+      if (filterName && filterValue) {
+        return `${filterName.text}: ${filterValue}`;
+      } else if (filterName) {
+        return filterName.text;
+      } else if (filterValue) {
+        return filterValue;
+      } else {
+        return ''
+      }
     },
     genres() {
       return this.filterData.genres || []


### PR DESCRIPTION
This PR updates a couple bits of UI to include the filter *name* as well as the filter value.

The old UI only showed the selected filter "value" in the filter dropdown, and in the "no items found" message.

![image](https://user-images.githubusercontent.com/91645868/163918459-cbfd992f-c4f6-43e5-8e5e-66ba4cb71273.png)

The new UI shows both the filter name *and* the filter value, making it clearer what's being filtered
![image](https://user-images.githubusercontent.com/91645868/163918398-d36c356f-834b-4d5d-aa80-60498e71f334.png)
