### PR TITLE
Update folder update logic to use new media path name

### DIFF
--- a/server/scanner/Scanner.js
+++ b/server/scanner/Scanner.js
@@ -518,7 +518,7 @@ class Scanner {
       var altDir = `${itemDir}/${firstNest}`
 
       var fullPath = Path.posix.join(folder.fullPath.replace(/\\/g, '/'), itemDir)
-      var childLibraryItem = this.db.libraryItems.find(li => li.path !== fullPath && li.fullPath.startsWith(fullPath))
+      var childLibraryItem = this.db.libraryItems.find(li => li.path !== fullPath && li.path.startsWith(fullPath))
       if (!childLibraryItem) {
         continue;
       }


### PR DESCRIPTION
I noticed the following exception from the scanner:

```
/server/njodb/index.js:103
        throw error;
        ^

TypeError: Cannot read properties of undefined (reading 'startsWith')
    at /server/scanner/Scanner.js:521:98
    at Array.find (<anonymous>)
    at Scanner.scanFolderUpdates (/server/scanner/Scanner.js:521:51)
    at Scanner.scanFilesChanged (/server/scanner/Scanner.js:501:42)
    at Server.filesChanged (/server/Server.js:266:24)
    at FolderWatcher.emit (node:events:526:28)
    at Timeout._onTimeout (/server/Watcher.js:194:12)
    at listOnTimeout (node:internal/timers:559:17)
    at processTimers (node:internal/timers:502:7)
```

This was after fixing the folder nesting of some audiobook files:

```
/audiobooks/B A Paris/                            
/audiobooks/B A Paris/Behind Closed Doors.mp3     
/audiobooks/B A Paris/Breakdown.mp3               
/audiobooks/B A Paris/Bring Me Back.mp3           
/audiobooks/B A Paris/Dilemma.mp3                 
```

Turned into (nesting MP3 files into book folders):

```
/audiobooks/B A Paris/                                                         
/audiobooks/B A Paris/Behind Closed Doors                                      
/audiobooks/B A Paris/Behind Closed Doors/Behind Closed Doors.mp3              
/audiobooks/B A Paris/Breakdown                                                
/audiobooks/B A Paris/Breakdown/Breakdown.mp3                                  
/audiobooks/B A Paris/Bring Me Back                                            
/audiobooks/B A Paris/Bring Me Back/Bring Me Back.mp3                          
/audiobooks/B A Paris/Dilemma                                                  
/audiobooks/B A Paris/Dilemma/Dilemma.mp3                                      
```

Based on the exception and the related code, it seems like there was perhaps a lingering reference to the old `fullPath` property name which has been [migrated](https://github.com/advplyr/audiobookshelf/blob/5d12cc3f2348f1067e86e0fe042abe1bca7b2408/server/utils/dbMigration.js#L171) to `path`.