### PR TITLE
Set description when quick matching media

### DIFF
--- a/server/scanner/Scanner.js
+++ b/server/scanner/Scanner.js
@@ -642,7 +642,7 @@ class Scanner {
     }
 
     // Update media metadata if not set OR overrideDetails flag
-    const detailKeysToUpdate = ['title', 'subtitle', 'narrator', 'publisher', 'publishedYear', 'asin', 'isbn']
+    const detailKeysToUpdate = ['title', 'subtitle', 'description', 'narrator', 'publisher', 'publishedYear', 'asin', 'isbn']
     const updatePayload = {}
     for (const key in matchData) {
       if (matchData[key] && detailKeysToUpdate.includes(key)) {


### PR DESCRIPTION
All the audiobook media providers seem to provide a `description` field, so we're just failing to apply it to the media item after it is looked up. This PR updates the list of updated properties to include `description`, so now doing a Quick Match or matching an entire library should also update media item descriptions if available.