### PR TITLE
Make maximum backup size configurable

### DIFF
--- a/client/pages/config/backups.vue
+++ b/client/pages/config/backups.vue
@@ -20,6 +20,12 @@
         <p class="pl-4 text-lg">Number of backups to keep</p>
       </div>
 
+      <div class="flex items-center py-2">
+        <ui-text-input type="number" v-model="maxBackupSize" no-spinner :disabled="updatingServerSettings" :padding-x="1" text-center class="w-10" @change="updateBackupsSettings" />
+
+        <p class="pl-4 text-lg">Maximum backup size (in GB)</p>
+      </div>
+
       <tables-backups-table />
     </div>
   </div>
@@ -32,6 +38,7 @@ export default {
       updatingServerSettings: false,
       dailyBackups: true,
       backupsToKeep: 2,
+      maxBackupSize: 1,
       newServerSettings: {}
     }
   },
@@ -53,13 +60,18 @@ export default {
   },
   methods: {
     updateBackupsSettings() {
+      if (isNaN(this.maxBackupSize) || this.maxBackupSize <= 0) {
+        this.$toast.error('Invalid maximum backup size')
+        return
+      }
       if (isNaN(this.backupsToKeep) || this.backupsToKeep <= 0 || this.backupsToKeep > 99) {
         this.$toast.error('Invalid number of backups to keep')
         return
       }
       var updatePayload = {
         backupSchedule: this.dailyBackups ? '0 1 * * *' : false,
-        backupsToKeep: Number(this.backupsToKeep)
+        backupsToKeep: Number(this.backupsToKeep),
+        maxBackupSize: Number(this.maxBackupSize)
       }
       this.updateServerSettings(updatePayload)
     },
@@ -81,6 +93,7 @@ export default {
 
       this.backupsToKeep = this.newServerSettings.backupsToKeep || 2
       this.dailyBackups = !!this.newServerSettings.backupSchedule
+      this.maxBackupSize = this.newServerSettings.maxBackupSize || 1
     }
   },
   mounted() {

--- a/client/pages/config/backups.vue
+++ b/client/pages/config/backups.vue
@@ -23,7 +23,9 @@
       <div class="flex items-center py-2">
         <ui-text-input type="number" v-model="maxBackupSize" no-spinner :disabled="updatingServerSettings" :padding-x="1" text-center class="w-10" @change="updateBackupsSettings" />
 
-        <p class="pl-4 text-lg">Maximum backup size (in GB)</p>
+        <ui-tooltip :text="maxBackupSizeTooltip">
+          <p class="pl-4 text-lg">Maximum backup size (in GB) <span class="material-icons icon-text">info_outlined</span></p>
+        </ui-tooltip>
       </div>
 
       <tables-backups-table />
@@ -53,6 +55,9 @@ export default {
   computed: {
     dailyBackupsTooltip() {
       return 'Runs at 1am every day (your server time). Saved in /metadata/backups.'
+    },
+    maxBackupSizeTooltip() {
+      return 'As a safeguard against misconfiguration, backups will fail if they exceed the configured size.'
     },
     serverSettings() {
       return this.$store.state.serverSettings

--- a/server/managers/BackupManager.js
+++ b/server/managers/BackupManager.js
@@ -260,7 +260,8 @@ class BackupManager {
         reject(err)
       })
       archive.on('progress', ({ fs: fsobj }) => {
-        if (fsobj.processedBytes > this.serverSettings.maxBackupSize * 1000 * 1000 * 1000) {
+        const maxBackupSizeInBytes = this.serverSettings.maxBackupSize * 1000 * 1000 * 1000 
+        if (fsobj.processedBytes > maxBackupSizeInBytes) {
           Logger.error(`[BackupManager] Archiver is too large - aborting to prevent endless loop, Bytes Processed: ${fsobj.processedBytes}`)
           archive.abort()
           setTimeout(() => {

--- a/server/managers/BackupManager.js
+++ b/server/managers/BackupManager.js
@@ -23,9 +23,6 @@ class BackupManager {
     this.scheduleTask = null
 
     this.backups = []
-
-    // If backup exceeds this value it will be aborted
-    this.MaxBytesBeforeAbort = 1000000000 // ~ 1GB
   }
 
   get serverSettings() {
@@ -263,7 +260,7 @@ class BackupManager {
         reject(err)
       })
       archive.on('progress', ({ fs: fsobj }) => {
-        if (fsobj.processedBytes > this.MaxBytesBeforeAbort) {
+        if (fsobj.processedBytes > this.serverSettings.maxBackupSize * 1000 * 1000 * 1000) {
           Logger.error(`[BackupManager] Archiver is too large - aborting to prevent endless loop, Bytes Processed: ${fsobj.processedBytes}`)
           archive.abort()
           setTimeout(() => {

--- a/server/objects/settings/ServerSettings.js
+++ b/server/objects/settings/ServerSettings.js
@@ -29,6 +29,7 @@ class ServerSettings {
     // this.backupSchedule = '0 1 * * *' // If false then auto-backups are disabled (default every day at 1am)
     this.backupSchedule = false
     this.backupsToKeep = 2
+    this.maxBackupSize = 1
     this.backupMetadataCovers = true
 
     // Logger
@@ -78,6 +79,7 @@ class ServerSettings {
 
     this.backupSchedule = settings.backupSchedule || false
     this.backupsToKeep = settings.backupsToKeep || 2
+    this.maxBackupSize  = settings.maxBackupSize || 1
     this.backupMetadataCovers = settings.backupMetadataCovers !== false
 
     this.loggerDailyLogsToKeep = settings.loggerDailyLogsToKeep || 7
@@ -114,6 +116,7 @@ class ServerSettings {
       rateLimitLoginWindow: this.rateLimitLoginWindow,
       backupSchedule: this.backupSchedule,
       backupsToKeep: this.backupsToKeep,
+      maxBackupSize: this.maxBackupSize,
       backupMetadataCovers: this.backupMetadataCovers,
       loggerDailyLogsToKeep: this.loggerDailyLogsToKeep,
       loggerScannerLogsToKeep: this.loggerScannerLogsToKeep,


### PR DESCRIPTION
On sufficiently large libraries, backups can start to fail because they hit the hardcoded 1GB backup limit. This PR makes that limit configurable so that users with large libraries can set a larger limit.

Screenshot of new UI:

![image](https://user-images.githubusercontent.com/91645868/164917010-f74c116f-0e6b-457e-afd2-b9739ae8a518.png)
