### PR TITLE
Log full path when warning about empty root

### DIFF
--- a/server/utils/scandir.js
+++ b/server/utils/scandir.js
@@ -144,7 +144,7 @@ async function scanFolder(libraryMediaType, folder, serverSettings = {}) {
   var libraryItemGrouping = groupFileItemsIntoLibraryItemDirs(libraryMediaType, fileItems)
 
   if (!Object.keys(libraryItemGrouping).length) {
-    Logger.error('Root path has no media folders', fileItems.length)
+    Logger.error(`Root path has no media folders: ${folderPath}`)
     return []
   }
 


### PR DESCRIPTION
When a library has a root folder containing no media items, a warning is logged when scanning.

```
[2022-04-25T22:28:15.859Z] ERROR: Root path has no media folders 0
```

However, that `0` isn't really helpful since we already know the root path is empty.

This PR updates the log message to instead log the folder path:

```
[2022-04-25T22:26:52.842Z] ERROR: Root path has no media folders: C:/code/audiobookshelf/audiobooks2
```