### PR TITLE
Add options to skip matching media items if they already have an ASIN/ISBN

### DIFF
--- a/client/components/modals/libraries/EditModal.vue
+++ b/client/components/modals/libraries/EditModal.vue
@@ -93,7 +93,9 @@ export default {
         icon: 'database',
         mediaType: 'book',
         settings: {
-          disableWatcher: false
+          disableWatcher: false,
+          skipMatchingMediaWithAsin: false,
+          skipMatchingMediaWithIsbn: false,
         }
       }
     },

--- a/client/components/modals/libraries/LibrarySettings.vue
+++ b/client/components/modals/libraries/LibrarySettings.vue
@@ -8,6 +8,18 @@
       </div>
       <p v-if="globalWatcherDisabled" class="text-xs text-warning">*Watcher is disabled globally in server settings</p>
     </div>
+    <div class="py-3">
+      <div class="flex items-center">
+        <ui-toggle-switch v-model="skipMatchingMediaWithAsin" @input="formUpdated" />
+        <p class="pl-4 text-lg">Skip matching books that already have an ASIN</p>
+      </div>
+    </div>
+    <div class="py-3">
+      <div class="flex items-center">
+        <ui-toggle-switch v-model="skipMatchingMediaWithIsbn" @input="formUpdated" />
+        <p class="pl-4 text-lg">Skip matching books that already have an ISBN</p>
+      </div>
+    </div>
   </div>
 </template>
 
@@ -23,7 +35,9 @@ export default {
   data() {
     return {
       provider: null,
-      disableWatcher: false
+      disableWatcher: false,
+      skipMatchingMediaWithAsin: false,
+      skipMatchingMediaWithIsbn: false,
     }
   },
   computed: {
@@ -45,7 +59,9 @@ export default {
     getLibraryData() {
       return {
         settings: {
-          disableWatcher: !!this.disableWatcher
+          disableWatcher: !!this.disableWatcher,
+          skipMatchingMediaWithAsin: !!this.skipMatchingMediaWithAsin,
+          skipMatchingMediaWithIsbn: !!this.skipMatchingMediaWithIsbn
         }
       }
     },
@@ -54,6 +70,8 @@ export default {
     },
     init() {
       this.disableWatcher = !!this.librarySettings.disableWatcher
+      this.skipMatchingMediaWithAsin = !!this.librarySettings.skipMatchingMediaWithAsin
+      this.skipMatchingMediaWithIsbn = !!this.librarySettings.skipMatchingMediaWithIsbn
     }
   },
   mounted() {

--- a/server/objects/settings/LibrarySettings.js
+++ b/server/objects/settings/LibrarySettings.js
@@ -4,6 +4,8 @@ const Logger = require('../../Logger')
 class LibrarySettings {
   constructor(settings) {
     this.disableWatcher = false
+    this.skipMatchingMediaWithAsin = false
+    this.skipMatchingMediaWithIsbn = false
 
     if (settings) {
       this.construct(settings)
@@ -12,11 +14,15 @@ class LibrarySettings {
 
   construct(settings) {
     this.disableWatcher = !!settings.disableWatcher
+    this.skipMatchingMediaWithAsin = !!settings.skipMatchingMediaWithAsin
+    this.skipMatchingMediaWithIsbn = !!settings.skipMatchingMediaWithIsbn
   }
 
   toJSON() {
     return {
-      disableWatcher: this.disableWatcher
+      disableWatcher: this.disableWatcher,
+      skipMatchingMediaWithAsin: this.skipMatchingMediaWithAsin,
+      skipMatchingMediaWithIsbn: this.skipMatchingMediaWithIsbn
     }
   }
 

--- a/server/scanner/Scanner.js
+++ b/server/scanner/Scanner.js
@@ -726,6 +726,21 @@ class Scanner {
 
     for (let i = 0; i < itemsInLibrary.length; i++) {
       var libraryItem = itemsInLibrary[i]
+
+      if (libraryItem.media.metadata.asin && library.settings.skipMatchingMediaWithAsin) {
+        Logger.debug(`[Scanner] matchLibraryItems: Skipping "${
+          libraryItem.media.metadata.title
+        }" because it already has an ASIN (${i + 1} of ${itemsInLibrary.length})`)
+        continue;
+      }
+
+      if (libraryItem.media.metadata.isbn && library.settings.skipMatchingMediaWithIsbn) {
+        Logger.debug(`[Scanner] matchLibraryItems: Skipping "${
+          libraryItem.media.metadata.title
+        }" because it already has an ISBN (${i + 1} of ${itemsInLibrary.length})`)
+        continue;
+      }
+
       Logger.debug(`[Scanner] matchLibraryItems: Quick matching "${libraryItem.media.metadata.title}" (${i + 1} of ${itemsInLibrary.length})`)
       var result = await this.quickMatchLibraryItem(libraryItem, { provider })
       if (result.warning) {


### PR DESCRIPTION
For very large media libraries, the library matcher can spend an inordinate amount of time re-querying info for books that have already been matched. This makes book matching take forever, and I'm also concerned that it could eventually lead to getting your IP blocked for abuse for repeatedly scanning thousands of books at a time.

This PR adds two new switches to the library settings, to skip matching books that already have an ISBN or ASIN set. This gives users more control over whether to skip matching books that have potentially already been matched.

![image](https://user-images.githubusercontent.com/91645868/165415595-b831bd3c-85c8-4d29-91e7-16b60fb4768e.png)

When the matcher can skip books that already have an ISBN/ASIN, it will log a messages will look like this:

```
[2022-04-27T00:33:28.293Z] DEBUG: [Scanner] matchLibraryItems: Skipping "Breakdown" because it already has an ASIN (1 of 6)
[2022-04-27T00:33:28.293Z] DEBUG: [Scanner] matchLibraryItems: Skipping "Bring Me Back" because it already has an ASIN (2 of 6)
[2022-04-27T00:33:28.294Z] DEBUG: [Scanner] matchLibraryItems: Skipping "Two Short Stories from H. E. Joyce" because it already has an ASIN (3 of 6)
[2022-04-27T00:33:28.294Z] DEBUG: [Scanner] matchLibraryItems: Quick matching "Behind Closed Doors" (4 of 6)
[2022-04-27T00:33:28.294Z] DEBUG: Book Search: title: "Behind Closed Doors", author: "B A Paris", provider: audible
[2022-04-27T00:33:28.295Z] DEBUG: [Audible] Search url: https://api.audible.com/1.0/catalog/products?response_groups=rating%2Cseries%2Ccontributors%2Cproduct_desc%2Cmedia%2Cproduct_extended_attrs&image_sizes=500%2C1024%2C2000&num_results=25&products_sort_by=Relevance&title=Behind+Closed+Doors&author=B+A+Paris
[2022-04-27T00:33:28.773Z] DEBUG: [Scanner] Updating details { asin: 'B01GW1OHVI' }
[2022-04-27T00:33:28.775Z] DEBUG: [BookMetadata] Key updated asin B01GW1OHVI
[2022-04-27T00:33:28.777Z] DEBUG: [LibraryItem] Success saving abmetadata to "C:\code\audiobookshelf\metadata\items\li_lsdbal4xc42idrxmaf\metadata.abs"
[2022-04-27T00:33:28.788Z] DEBUG: [DB] Library Items updated 1
[2022-04-27T00:33:28.789Z] DEBUG: [Scanner] matchLibraryItems: Skipping "The Hole" because it already has an ASIN (5 of 6)
[2022-04-27T00:33:28.789Z] DEBUG: [Scanner] matchLibraryItems: Skipping "Dilemma" because it already has an ASIN (6 of 6)
```
