### PR TITLE
Handle corrupted backups gracefully and continue loading other backups

### DIFF
--- a/server/managers/BackupManager.js
+++ b/server/managers/BackupManager.js
@@ -131,8 +131,21 @@ class BackupManager {
         var filename = filesInDir[i]
         if (filename.endsWith('.audiobookshelf')) {
           var fullFilePath = Path.join(this.BackupPath, filename)
-          const zip = new StreamZip.async({ file: fullFilePath })
-          const data = await zip.entryData('details')
+
+          let zip = null
+          let data = null
+          try {
+            zip = new StreamZip.async({ file: fullFilePath })
+            data = await zip.entryData('details')
+          } catch (error) {
+            if (error.message === "Bad archive") {
+              Logger.warn(`[BackupManager] Backup appears to be corrupted: ${fullFilePath}`)
+              continue;
+            } else {
+              throw error
+            }
+          }
+
           var details = data.toString('utf8').split('\n')
 
           var backup = new Backup({ details, fullPath: fullFilePath })


### PR DESCRIPTION
I've been noticing that recent backups weren't being displayed in the UI, and was finally able to figure out why. When Audiobookshelf is finding backups, it has to load the archive to get info about the backup version etc. If the archive is corrupted, the following error is thrown and Audiobookshelf stops loading any remaining backups.

```
[ERROR: [BackupManager] Failed to load backups Error: Bad archive
    at FsRead.readUntilFoundCallback [as callback] (/node_modules/node-stream-zip/node_stream_zip.js:198:39)
    at FsRead.readCallback (/node_modules/node-stream-zip/node_stream_zip.js:996:25)
    at FSReqCallback.wrapper [as oncomplete] (node:fs:660:5)
```

To fix that issue, this PR adds an inner try/catch to handle that specific `Bad archive` error, log a message, and continue loading any other remaining backups. After applying that fix, 