### PR TITLE
Add support for seasonal podcasts

### DIFF
--- a/client/components/controls/EpisodeSortSelect.vue
+++ b/client/components/controls/EpisodeSortSelect.vue
@@ -41,6 +41,10 @@ export default {
           value: 'title'
         },
         {
+          text: 'Season',
+          value: 'season'
+        },
+        {
           text: 'Episode',
           value: 'episode'
         },

--- a/client/components/modals/podcast/EditEpisode.vue
+++ b/client/components/modals/podcast/EditEpisode.vue
@@ -7,16 +7,16 @@
     </template>
     <div ref="wrapper" class="p-4 w-full text-sm py-2 rounded-lg bg-bg shadow-lg border border-black-300 relative overflow-hidden">
       <div class="flex flex-wrap">
-        <div class="w-1/3 p-1">
+        <div class="w-1/5 p-1">
           <ui-text-input-with-label v-model="newEpisode.season" label="Season" />
         </div>
-        <div class="w-1/3 p-1">
+        <div class="w-1/5 p-1">
           <ui-text-input-with-label v-model="newEpisode.episode" label="Episode" />
         </div>
-        <div class="w-1/3 p-1">
+        <div class="w-1/5 p-1">
           <ui-text-input-with-label v-model="newEpisode.episodeType" label="Episode Type" />
         </div>
-        <div class="w-1/3 p-1">
+        <div class="w-2/5 p-1">
           <ui-text-input-with-label v-model="pubDateInput" @input="updatePubDate" type="datetime-local" label="Pub Date" />
         </div>
         <div class="w-full p-1">

--- a/client/components/modals/podcast/EditEpisode.vue
+++ b/client/components/modals/podcast/EditEpisode.vue
@@ -8,6 +8,9 @@
     <div ref="wrapper" class="p-4 w-full text-sm py-2 rounded-lg bg-bg shadow-lg border border-black-300 relative overflow-hidden">
       <div class="flex flex-wrap">
         <div class="w-1/3 p-1">
+          <ui-text-input-with-label v-model="newEpisode.season" label="Season" />
+        </div>
+        <div class="w-1/3 p-1">
           <ui-text-input-with-label v-model="newEpisode.episode" label="Episode" />
         </div>
         <div class="w-1/3 p-1">
@@ -39,6 +42,7 @@ export default {
     return {
       processing: false,
       newEpisode: {
+        season: null,
         episode: null,
         episodeType: null,
         title: null,
@@ -92,6 +96,7 @@ export default {
       }
     },
     init() {
+      this.newEpisode.season = this.episode.season || ''
       this.newEpisode.episode = this.episode.episode || ''
       this.newEpisode.episodeType = this.episode.episodeType || ''
       this.newEpisode.title = this.episode.title || ''

--- a/client/components/tables/podcast/EpisodeTableRow.vue
+++ b/client/components/tables/podcast/EpisodeTableRow.vue
@@ -20,6 +20,7 @@
           <ui-tooltip :text="userIsFinished ? 'Mark as Not Finished' : 'Mark as Finished'" direction="top">
             <ui-read-icon-btn :disabled="isProcessingReadUpdate" :is-read="userIsFinished" borderless class="mx-1 mt-0.5" @click="toggleFinished" />
           </ui-tooltip>
+          <p v-if="episode.season" class="px-4 text-sm text-gray-300">Season #{{ episode.season }}</p>
           <p v-if="episode.episode" class="px-4 text-sm text-gray-300">Episode #{{ episode.episode }}</p>
           <p v-if="publishedAt" class="px-4 text-sm text-gray-300">Published {{ $formatDate(publishedAt, 'MMM do, yyyy') }}</p>
         </div>

--- a/server/objects/entities/PodcastEpisode.js
+++ b/server/objects/entities/PodcastEpisode.js
@@ -9,6 +9,7 @@ class PodcastEpisode {
     this.id = null
     this.index = null
 
+    this.season = null
     this.episode = null
     this.episodeType = null
     this.title = null
@@ -31,6 +32,7 @@ class PodcastEpisode {
     this.libraryItemId = episode.libraryItemId
     this.id = episode.id
     this.index = episode.index
+    this.season = episode.season
     this.episode = episode.episode
     this.episodeType = episode.episodeType
     this.title = episode.title
@@ -51,6 +53,7 @@ class PodcastEpisode {
       libraryItemId: this.libraryItemId,
       id: this.id,
       index: this.index,
+      season: this.season,
       episode: this.episode,
       episodeType: this.episodeType,
       title: this.title,
@@ -70,6 +73,7 @@ class PodcastEpisode {
       libraryItemId: this.libraryItemId,
       id: this.id,
       index: this.index,
+      season: this.season,
       episode: this.episode,
       episodeType: this.episodeType,
       title: this.title,
@@ -117,6 +121,7 @@ class PodcastEpisode {
     this.pubDate = data.pubDate || ''
     this.description = data.description || ''
     this.enclosure = data.enclosure ? { ...data.enclosure } : null
+    this.season = data.season || ''
     this.episode = data.episode || ''
     this.episodeType = data.episodeType || ''
     this.publishedAt = data.publishedAt || 0

--- a/server/utils/podcastUtils.js
+++ b/server/utils/podcastUtils.js
@@ -85,7 +85,7 @@ function extractEpisodeData(item) {
     episode.descriptionPlain = stripHtml(episode.description || '').result
   }
 
-  var arrayFields = ['title', 'pubDate', 'itunes:episodeType', 'season', 'itunes:episode', 'itunes:author', 'itunes:duration', 'itunes:explicit', 'itunes:subtitle']
+  var arrayFields = ['title', 'pubDate', 'itunes:episodeType', 'itunes:season', 'itunes:episode', 'itunes:author', 'itunes:duration', 'itunes:explicit', 'itunes:subtitle']
   arrayFields.forEach((key) => {
     var cleanKey = key.split(':').pop()
     episode[cleanKey] = extractFirstArrayItem(item, key)

--- a/server/utils/podcastUtils.js
+++ b/server/utils/podcastUtils.js
@@ -85,7 +85,7 @@ function extractEpisodeData(item) {
     episode.descriptionPlain = stripHtml(episode.description || '').result
   }
 
-  var arrayFields = ['title', 'pubDate', 'itunes:episodeType', 'itunes:episode', 'itunes:author', 'itunes:duration', 'itunes:explicit', 'itunes:subtitle']
+  var arrayFields = ['title', 'pubDate', 'itunes:episodeType', 'season', 'itunes:episode', 'itunes:author', 'itunes:duration', 'itunes:explicit', 'itunes:subtitle']
   arrayFields.forEach((key) => {
     var cleanKey = key.split(':').pop()
     episode[cleanKey] = extractFirstArrayItem(item, key)
@@ -101,6 +101,7 @@ function cleanEpisodeData(data) {
     descriptionPlain: data.descriptionPlain || '',
     pubDate: data.pubDate || '',
     episodeType: data.episodeType || '',
+    season: data.season || '',
     episode: data.episode || '',
     author: data.author || '',
     duration: data.duration || '',


### PR DESCRIPTION
Podcasts such as [Command Line Heroes](https://podcasts.apple.com/us/podcast/command-line-heroes/id1319947289) have multiple seasons in which each has it's own "Episode 1, ••• Episode n". This seeks to add support for this class of podcast series.

![image](https://user-images.githubusercontent.com/6561797/166706070-3d8db090-0d77-4d54-9e04-d6975637c5e6.png)
