### PR TITLE
URGENT: Fix to serious bug

### DIFF
--- a/server/utils/scandir.js
+++ b/server/utils/scandir.js
@@ -330,10 +330,12 @@ async function getLibraryItemFileData(libraryMediaType, folder, libraryItemPath,
   var fileItems = []
 
   if (isSingleMediaItem) { // Single media item in root of folder
-    fileItems = [{
+    fileItems = [
+      {
       fullpath: libraryItemPath,
       path: libraryItemDir // actually the relPath (only filename here)
-    }]
+    }
+  ]
     libraryItemData = {
       path: libraryItemPath, // full path
       relPath: libraryItemDir, // only filename
@@ -366,7 +368,7 @@ async function getLibraryItemFileData(libraryMediaType, folder, libraryItemPath,
   for (let i = 0; i < fileItems.length; i++) {
     var fileItem = fileItems[i]
     var newLibraryFile = new LibraryFile()
-      // fileItem.path is the relative path
+    // fileItem.path is the relative path
     await newLibraryFile.setDataFromPath(fileItem.fullpath, fileItem.path)
     libraryItem.libraryFiles.push(newLibraryFile)
   }

--- a/server/utils/scandir.js
+++ b/server/utils/scandir.js
@@ -216,8 +216,9 @@ function getBookDataFromDir(folderPath, relPath, parseSubtitle = false) {
   // The  may contain various other pieces of metadata, these functions extract it.
   var [folder, narrators] = getNarrator(folder)
   if (series) { var [folder, sequence] = getSequence(folder) }
+  var [folder, sequence] = series ? getSequence(folder) : [folder, null]
   var [folder, publishedYear] = getPublishedYear(folder)
-  if (parseSubtitle) { var [title, subtitle] = getSubtitle(folder) } // Subtitle can be parsed from the title if user enabled
+  var [title, subtitle] = parseSubtitle ? getSubtitle(folder) : [folder, null]
 
   return {
     mediaMetadata: {


### PR DESCRIPTION
Following the refactor of getBookDataFromDir, if subtitle parsing is turned off, then the title is not imported at all. This fixes it and also resolves your confusion about variable scope.