### PR TITLE
Gracefully handle unexpected end of file when listing backup files

### DIFF
--- a/server/managers/BackupManager.js
+++ b/server/managers/BackupManager.js
@@ -141,6 +141,9 @@ class BackupManager {
             if (error.message === "Bad archive") {
               Logger.warn(`[BackupManager] Backup appears to be corrupted: ${fullFilePath}`)
               continue;
+            } else if (error.message === "unexpected end of file") {
+              Logger.warn(`[BackupManager] Backup appears to be corrupted: ${fullFilePath}`)
+              continue;
             } else {
               throw error
             }


### PR DESCRIPTION
A few weeks ago I added some logic to handle one kind of backup file corruption when listing backups in #555. Today when looking at my backups, I found that there's another type of error that should also be handled. Namely, when a backup file is unexpectedly truncated.