### PR TITLE
Support embedding updated chapter metadata (issue #676)

### DIFF
--- a/server/managers/AudioMetadataManager.js
+++ b/server/managers/AudioMetadataManager.js
@@ -84,7 +84,7 @@ class AudioMetadataMangaer {
         Ffmpeg premapped id3 tags: https://wiki.multimedia.cx/index.php/FFmpeg_Metadata
       */
 
-      const ffmpegOptions = ['-c copy', '-map_metadata 1', `-metadata track=${audioFile.index}`, '-write_id3v2 1', '-movflags use_metadata_tags']
+      const ffmpegOptions = ['-c copy', '-map_chapters 1', '-map_metadata 1', `-metadata track=${audioFile.index}`, '-write_id3v2 1', '-movflags use_metadata_tags']
       var workerData = {
         inputs: ffmpegInputs,
         options: ffmpegOptions,


### PR DESCRIPTION
This commit resolves issue #676 . The embed metadata tool was missing the flag that tells ffmpeg to not only update the "top" metadata, but also the chapter metadata.

I tested this manually by adding a file to my library and testing before and after this change, and validating the change through ffprobe.