### PR TITLE
Fix cover art not being generated for M4B export

### DIFF
--- a/server/managers/AbMergeManager.js
+++ b/server/managers/AbMergeManager.js
@@ -151,7 +151,7 @@ class AbMergeManager {
         input: coverPath,
         options: ['-f image2pipe']
       })
-      ffmpegOptions.push('-vf [2:v]crop=trunc(iw/2)*2:trunc(ih/2)*2')
+      ffmpegOptions.push('-c:v copy')
       ffmpegOptions.push('-map 2:v')
     }
 


### PR DESCRIPTION
This commit fixes an issue where cover art was not being generated properly when creating an M4B audiobook from MP3 files. Thanks to @advplyr for pointing out what the actual fix was for this

More context can be found in discord:
https://discord.com/channels/942908292873723984/981321213882282035/982777444631195681


These are available in the discord conversation as well, but here are what the covers look like now, in various forms:
![image](https://user-images.githubusercontent.com/13617455/172030412-eacffcfe-8a9a-422a-b691-c8d3af68249f.png)
![image](https://user-images.githubusercontent.com/13617455/172030416-b25cf78b-0410-49f3-9d80-2a41221ef03e.png)
![image](https://user-images.githubusercontent.com/13617455/172030420-32323e20-4a2c-4524-b5ba-e424e0185888.png)
![image](https://user-images.githubusercontent.com/13617455/172030422-c7a8df8f-7fa7-45c5-bdcc-efccfd3ff0ac.png)
