### PR TITLE
Update some instances of mkdir to ensureDir (#698)

### DIFF
--- a/server/Server.js
+++ b/server/Server.js
@@ -139,7 +139,8 @@ class Server {
     await this.checkUserMediaProgress() // Remove invalid user item progress
     await this.purgeMetadata() // Remove metadata folders without library item
     await this.cacheManager.ensureCachePaths()
-
+    await this.abMergeManager.ensureDownloadDirPath()
+    
     await this.backupManager.init()
     await this.logManager.init()
     this.podcastManager.init()

--- a/server/managers/AbMergeManager.js
+++ b/server/managers/AbMergeManager.js
@@ -73,9 +73,10 @@ class AbMergeManager {
 
 
     try {
-      await fs.mkdir(download.dirpath)
+      await fs.ensureDir(download.dirpath)
     } catch (error) {
       Logger.error(`[AbMergeManager] Failed to make directory ${download.dirpath}`)
+      Logger.debug(`[AbMergeManager] Make directory error: ${error}`)
       var downloadJson = download.toJSON()
       this.clientEmitter(user.id, 'abmerge_failed', downloadJson)
       return

--- a/server/managers/AbMergeManager.js
+++ b/server/managers/AbMergeManager.js
@@ -91,7 +91,6 @@ class AbMergeManager {
 
     try {
       await fs.mkdir(download.dirpath)
-      Logger.error(`[AbMergeManager] Failed to make directory ${download.dirpath}`)
     } catch (error) {
       Logger.error(`[AbMergeManager] Failed to make directory ${download.dirpath}`)
       Logger.debug(`[AbMergeManager] Make directory error: ${error}`)

--- a/server/managers/AbMergeManager.js
+++ b/server/managers/AbMergeManager.js
@@ -65,7 +65,7 @@ class AbMergeManager {
     } catch (error) {
       return false
     }
-  }z
+  }
 
   async startAudiobookMerge(user, libraryItem) {
     var downloadId = getId('abmerge')

--- a/server/managers/AbMergeManager.js
+++ b/server/managers/AbMergeManager.js
@@ -16,9 +16,26 @@ class AbMergeManager {
     this.clientEmitter = clientEmitter
 
     this.downloadDirPath = Path.join(global.MetadataPath, 'downloads')
+    this.downloadDirPathExist = false
 
     this.pendingDownloads = []
     this.downloads = []
+  }
+
+  async ensureDownloadDirPath() { // Creates download path if necessary and sets owner and permissions
+    if (this.downloadDirPathExist) return
+
+    var pathCreated = false
+    if (!(await fs.pathExists(this.downloadDirPath))) {
+      await fs.mkdir(this.downloadDirPath)
+      pathCreated = true
+    }
+
+    if (pathCreated) {
+      await filePerms.setDefault(this.downloadDirPath)
+    }
+
+    this.downloadDirPathExist = true
   }
 
   getDownload(downloadId) {
@@ -48,7 +65,7 @@ class AbMergeManager {
     } catch (error) {
       return false
     }
-  }
+  }z
 
   async startAudiobookMerge(user, libraryItem) {
     var downloadId = getId('abmerge')
@@ -73,7 +90,8 @@ class AbMergeManager {
 
 
     try {
-      await fs.ensureDir(download.dirpath)
+      await fs.mkdir(download.dirpath)
+      Logger.error(`[AbMergeManager] Failed to make directory ${download.dirpath}`)
     } catch (error) {
       Logger.error(`[AbMergeManager] Failed to make directory ${download.dirpath}`)
       Logger.debug(`[AbMergeManager] Make directory error: ${error}`)

--- a/server/managers/CacheManager.js
+++ b/server/managers/CacheManager.js
@@ -19,17 +19,17 @@ class CacheManager {
 
     var pathsCreated = false
     if (!(await fs.pathExists(this.CachePath))) {
-      await fs.ensureDir(this.CachePath)
+      await fs.mkdir(this.CachePath)
       pathsCreated = true
     }
 
     if (!(await fs.pathExists(this.CoverCachePath))) {
-      await fs.ensureDir(this.CoverCachePath)
+      await fs.mkdir(this.CoverCachePath)
       pathsCreated = true
     }
 
     if (!(await fs.pathExists(this.ImageCachePath))) {
-      await fs.ensureDir(this.ImageCachePath)
+      await fs.mkdir(this.ImageCachePath)
       pathsCreated = true
     }
 

--- a/server/managers/CacheManager.js
+++ b/server/managers/CacheManager.js
@@ -19,17 +19,17 @@ class CacheManager {
 
     var pathsCreated = false
     if (!(await fs.pathExists(this.CachePath))) {
-      await fs.mkdir(this.CachePath)
+      await fs.ensureDir(this.CachePath)
       pathsCreated = true
     }
 
     if (!(await fs.pathExists(this.CoverCachePath))) {
-      await fs.mkdir(this.CoverCachePath)
+      await fs.ensureDir(this.CoverCachePath)
       pathsCreated = true
     }
 
     if (!(await fs.pathExists(this.ImageCachePath))) {
-      await fs.mkdir(this.ImageCachePath)
+      await fs.ensureDir(this.ImageCachePath)
       pathsCreated = true
     }
 


### PR DESCRIPTION
This PR resolves #698.

mkdir was being used instead of [ensureDirs, or mkdirs or mkdirp](https://github.com/jprichardson/node-fs-extra/blob/master/docs/ensureDir.md). AbMergeManager doesn't precreate the Downloads folder structure it needes -- updating it to use ensureDirs handles creating the entire path needed when a merge attempt gets kicked off.

I also did a driveby and updated mkdir for CacheManager to also leverage ensureDirs. CacheManager was a bit safer already, but if the first mkdir had failed for any reason, the resulting ones would have failed as well, resulting in a server crash at startup. While changing these to ensureDir doesn't necessarily guarantee whatever might cause the first creation to fail won't happen again on these subsequent attempts, it will at least mean that we'll try and recreate the entire structure needed a few times.

