### PR TITLE
Fix library scanning failing

### DIFF
--- a/server/utils/prober.js
+++ b/server/utils/prober.js
@@ -88,8 +88,8 @@ function parseMediaStreamInfo(stream, all_streams, total_bit_rate) {
     codec_time_base: stream.codec_time_base || null,
     time_base: stream.time_base || null,
     bit_rate: tryGrabBitRate(stream, all_streams, total_bit_rate),
-    language: tryGrabTag(stream, 'language'),
-    title: tryGrabTag(stream, 'title')
+    language: tryGrabTags(stream, 'language'),
+    title: tryGrabTags(stream, 'title')
   }
   if (stream.tags) info.tags = stream.tags
 


### PR DESCRIPTION
Looks like #697 missed a reference update that caused scanning libraries to fail. This fixes that. Also confirmed there are no other references to `TryGrabTag` left