### PR TITLE
Add support for leveraging chapter data directly from Overdrive mp3s during scanning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ test/
 /client/.nuxt/
 /client/dist/
 /dist/
+library/
 
 sw.*
 .DS_STORE

--- a/client/pages/audiobook/_id/chapters.vue
+++ b/client/pages/audiobook/_id/chapters.vue
@@ -142,45 +142,6 @@
         </div>
       </div>
     </modals-modal>
-
-    <modals-modal v-model="showImportOverdriveMediaMarkersModal" name="edit-book2" :width="500" :processing="findingChapters">
-      <template #outer>
-        <div class="absolute top-0 left-0 p-5 w-2/3 overflow-hidden pointer-events-none">
-          <p class="font-book text-3xl text-white truncate pointer-events-none">Find Chapters</p>
-        </div>
-      </template>
-      <div class="w-full h-full max-h-full text-sm rounded-lg bg-bg shadow-lg border border-black-300 relative">
-        <div v-if="!chapterData" class="flex p-20">
-          <ui-text-input-with-label v-model="asinInput" label="NOT ASIN" />
-          <ui-btn small color="primary" class="mt-5 ml-2" @click="findChapters">Find</ui-btn>
-        </div>
-        <div v-else class="w-full p-4">
-          <p class="mb-4">Duration found: {{ chapterData.runtimeLengthSec }}</p>
-          <div v-if="chapterData.runtimeLengthSec > mediaDuration" class="w-full bg-error bg-opacity-25 p-4 text-center mb-2 rounded border border-white border-opacity-10 text-gray-100 text-sm">
-            <p>Chapter data invalid duration<br />Your media duration is shorter than duration found</p>
-          </div>
-
-          <div class="flex py-0.5 text-xs font-semibold uppercase text-gray-300 mb-1">
-            <div class="w-24 px-2">Start</div>
-            <div class="flex-grow px-2">Title</div>
-          </div>
-          <div class="w-full max-h-80 overflow-y-auto my-2">
-            <div v-for="(chapter, index) in chapterData.chapters" :key="index" class="flex py-0.5 text-xs" :class="chapter.startOffsetSec > mediaDuration ? 'bg-error bg-opacity-20' : chapter.startOffsetSec + chapter.lengthMs / 1000 > mediaDuration ? 'bg-warning bg-opacity-20' : index % 2 === 0 ? 'bg-primary bg-opacity-30' : ''">
-              <div class="w-24 min-w-24 px-2">
-                <p class="font-mono">{{ $secondsToTimestamp(chapter.startOffsetSec) }}</p>
-              </div>
-              <div class="flex-grow px-2">
-                <p class="truncate max-w-sm">{{ chapter.title }}</p>
-              </div>
-            </div>
-          </div>
-          <div class="flex pt-2">
-            <div class="flex-grow" />
-            <ui-btn small color="success" @click="applyChapterData">Apply Chapters</ui-btn>
-          </div>
-        </div>
-      </div>
-    </modals-modal>
   </div>
 </template>
 

--- a/client/pages/audiobook/_id/chapters.vue
+++ b/client/pages/audiobook/_id/chapters.vue
@@ -398,7 +398,6 @@ export default {
             title: chap.title
           }
         })
-      console.log(`newChapters - ${JSON.stringify(this.newChapters)}`)
       this.showFindChaptersModal = false
       this.chapterData = null
     },

--- a/client/pages/audiobook/_id/chapters.vue
+++ b/client/pages/audiobook/_id/chapters.vue
@@ -437,6 +437,7 @@ export default {
             title: chap.title
           }
         })
+      console.log(`newChapters - ${JSON.stringify(this.newChapters)}`)
       this.showFindChaptersModal = false
       this.chapterData = null
     },
@@ -469,33 +470,68 @@ export default {
     },
     // overdrive
     generateChaptersFromOverdriveMediaMarkers() {
-      var parseString = require('xml2js').parseString;
-      var xml = this.overdriveMediaMarkers[0]
-      var parsedXML = {}
-      parseString(xml, function (err, result) {
-          parsedXML = result
-      });
+      var parseString = require('xml2js').parseString; // function to convert xml to JSON
+      var overdriveMediaMarkers = this.overdriveMediaMarkers // an array of XML. 1 Part.mp3 to 1 array index. Each index holds 1 XML that holds multiple chapters
+      //console.log(overdriveMediaMarkers)
+      
+      var parsedOverdriveMediaMarkers = [] // an array of objects. each object being a chapter with a name and time key. the values are arrays of strings
 
-      var index = 0
-      var newOChapters = parsedXML.Markers.Marker.map((marker) => {
-        return {
-          id: index++,
-          start: marker.Time[0],
-          end: 0,
-          title: marker.Name[0]
-        }
+      overdriveMediaMarkers.forEach(function (item, index) {     
+        var parsed_result
+        var holder
+        parseString(item, function (err, result) {
+          // result.Markers.Marker is the result of parsing the XML for the MediaMarker tags for the MP3 file (Part##.mp3)
+          // it is shaped like this:
+          // [
+          //   {
+          //     "Name": [
+          //       "Chapter 1:  "
+          //     ],
+          //     "Time": [
+          //       "0:00.000"
+          //     ]
+          //   },
+          //   {
+          //     "Name": [
+          //       "Chapter 2: "
+          //     ],
+          //     "Time": [
+          //       "15:51.000"
+          //     ]
+          //   }
+          // ]
+
+          parsed_result = result.Markers.Marker
+          
+          // The values for Name and Time in parsed results are returned as Arrays
+          // update them to be strings
+          parsed_result.forEach((item, index) => {
+            Object.keys(item).forEach(key => {
+              item[key] = item[key].toString()
+            })
+          })
+        })
+
+        parsedOverdriveMediaMarkers.push(parsed_result)
       })
-      console.log(newOChapters)
-      //console.log(this.overdriveMediaMarkers[0])
-      // console.log(JSON.stringify(x))
-      //console.log(parseString(this.overdriveMediaMarkers[0]))
-      // {
-      //   id:,
-      //   start:
-      //   end:
-      //   title:
-      // }
-      this.overdriveMediaMarkers
+
+      console.log(parsedOverdriveMediaMarkers.flat())
+
+      // go from an array of arrays of objects to an array of objects
+      parsedOverdriveMediaMarkers = parsedOverdriveMediaMarkers.flat()
+
+      // var index = 0
+      // var newOChapters = parsedXML.Markers.Marker.map((marker) => {
+      //   return {
+      //     id: index++,
+      //     start: marker.Time[0],
+      //     end: 0,
+      //     title: marker.Name[0]
+      //   }
+      // })
+      // console.log(newOChapters)
+
+      // this.overdriveMediaMarkers
     }
   },
   mounted() {

--- a/client/pages/config/index.vue
+++ b/client/pages/config/index.vue
@@ -104,6 +104,16 @@
       </div>
 
       <div class="flex items-center py-2">
+        <ui-toggle-switch v-model="newServerSettings.scannerPreferOverdriveMediaMarker" :disabled="updatingServerSettings" @input="(val) => updateSettingsKey('scannerPreferOverdriveMediaMarker', val)" />
+        <ui-tooltip :text="tooltips.scannerPreferOverdriveMediaMarker">
+          <p class="pl-4 text-lg">
+            Scanner prefer Overdrive Media Markers for chapters
+            <span class="material-icons icon-text">info_outlined</span>
+          </p>
+        </ui-tooltip>
+      </div>
+
+      <div class="flex items-center py-2">
         <ui-toggle-switch v-model="newServerSettings.scannerPreferOpfMetadata" :disabled="updatingServerSettings" @input="(val) => updateSettingsKey('scannerPreferOpfMetadata', val)" />
         <ui-tooltip :text="tooltips.scannerPreferOpfMetadata">
           <p class="pl-4 text-lg">
@@ -245,7 +255,8 @@ export default {
         storeCoverWithItem: 'By default covers are stored in /metadata/items, enabling this setting will store covers in your library item folder. Only one file named "cover" will be kept',
         storeMetadataWithItem: 'By default metadata files are stored in /metadata/items, enabling this setting will store metadata files in your library item folders. Uses .abs file extension',
         coverAspectRatio: 'Prefer to use square covers over standard 1.6:1 book covers',
-        enableEReader: 'E-reader is still a work in progress, but use this setting to open it up to all your users (or use the "Experimental Features" toggle below just for you)'
+        enableEReader: 'E-reader is still a work in progress, but use this setting to open it up to all your users (or use the "Experimental Features" toggle below just for you)',
+        scannerPreferOverdriveMediaMarker: 'MP3 files from Overdrive come with chapter timings embedded as custom metadata. Enabling this will use these tags for chapter timings automatically'
       },
       showConfirmPurgeCache: false
     }

--- a/server/controllers/PodcastController.js
+++ b/server/controllers/PodcastController.js
@@ -103,7 +103,7 @@ class PodcastController {
         Logger.error('Invalid podcast feed request response')
         return res.status(500).send('Bad response from feed request')
       }
-      Logger.debug(`[PdocastController] Podcast feed size ${(data.data.length / 1024 / 1024).toFixed(2)}MB`)
+      Logger.debug(`[PodcastController] Podcast feed size ${(data.data.length / 1024 / 1024).toFixed(2)}MB`)
       var payload = await parsePodcastRssFeedXml(data.data, false, includeRaw)
       if (!payload) {
         return res.status(500).send('Invalid podcast RSS feed')

--- a/server/objects/mediaTypes/Book.js
+++ b/server/objects/mediaTypes/Book.js
@@ -360,10 +360,12 @@ class Book {
     this.rebuildTracks()
   }
 
-  rebuildTracks() {
+  rebuildTracks(preferOverdriveMediaMarker = false) {
+    Logger.debug(`[Book] we are rebuilding the tracks!`)
+    Logger.debug(`[Book] preferOverdriveMediaMarker: ${preferOverdriveMediaMarker}`)
     this.audioFiles.sort((a, b) => a.index - b.index)
     this.missingParts = []
-    this.setChapters()
+    this.setChapters(preferOverdriveMediaMarker)
     this.checkUpdateMissingTracks()
   }
 
@@ -395,7 +397,103 @@ class Book {
     return wasUpdated
   }
 
-  setChapters() {
+  generateChaptersFromOverdriveMediaMarkers(overdriveMediaMarkers, includedAudioFiles) {
+    var parseString = require('xml2js').parseString; // function to convert xml to JSON
+    
+    var parsedOverdriveMediaMarkers = [] // an array of objects. each object being a chapter with a name and time key. the values are arrays of strings
+
+    overdriveMediaMarkers.forEach(function (item, index) {     
+      var parsed_result
+      parseString(item, function (err, result) {
+        // result.Markers.Marker is the result of parsing the XML for the MediaMarker tags for the MP3 file (Part##.mp3)
+        // it is shaped like this:
+        // [
+        //   {
+        //     "Name": [
+        //       "Chapter 1:  "
+        //     ],
+        //     "Time": [
+        //       "0:00.000"
+        //     ]
+        //   },
+        //   {
+        //     "Name": [
+        //       "Chapter 2: "
+        //     ],
+        //     "Time": [
+        //       "15:51.000"
+        //     ]
+        //   }
+        // ]
+
+        parsed_result = result.Markers.Marker
+        
+        // The values for Name and Time in parsed_results are returned as Arrays from parseString
+        // update them to be strings
+        parsed_result.forEach((item, index) => {
+          Object.keys(item).forEach(key => {
+            item[key] = item[key].toString()
+          })
+        })
+      })
+
+      parsedOverdriveMediaMarkers.push(parsed_result)
+    })
+
+    // go from an array of arrays of objects to an array of objects
+    // end result looks like:
+    // [
+    //   {
+    //     "Name": "Chapter 1:  The Worst Birthday",
+    //     "Time": "0:00.000"
+    //   },
+    //   {
+    //     "Name": "Chapter 2:  Dobby's Warning",
+    //     "Time": "15:51.000"
+    //   },
+    //   { redacted }
+    // ]
+    parsedOverdriveMediaMarkers = parsedOverdriveMediaMarkers
+
+    var index = 0
+    
+    var time = 0.0
+    
+
+    // actually generate the chapter object
+    // logic ported over from benonymity's OverdriveChapterizer:
+    //    https://github.com/benonymity/OverdriveChapterizer/blob/main/chapters.py
+    var length = 0.0
+    var newOChapters = []
+    const weirdChapterFilterRegex = /([(]\d|[cC]ontinued)/
+    includedAudioFiles.forEach((track, track_index) => {
+      parsedOverdriveMediaMarkers[track_index].forEach((chapter) => {
+        Logger.debug(`[Book] Attempting regex check for ${chapter.Name}!`)
+        if (weirdChapterFilterRegex.test(chapter.Name)) {
+          Logger.debug(`[Book] That shit weird yo`)
+          return
+        }
+        time = chapter.Time.split(":")
+        time = length + parseFloat(time[0]) * 60 + parseFloat(time[1])
+        newOChapters.push(
+          {
+            id: index++,
+            start: time,
+            end: length,
+            title: chapter.Name
+          }
+        )
+      })
+      length += track.duration
+    })
+
+    Logger.debug(`[Book] newOChapters: ${JSON.stringify(newOChapters)}`)
+    return newOChapters
+  }
+
+
+  setChapters(preferOverdriveMediaMarker = false) {
+    Logger.debug('[Book] inside setChapters!')
     // If 1 audio file without chapters, then no chapters will be set
     var includedAudioFiles = this.audioFiles.filter(af => !af.exclude)
     if (includedAudioFiles.length === 1) {
@@ -407,44 +505,55 @@ class Book {
       this.chapters = []
       var currChapterId = 0
       var currStartTime = 0
-      includedAudioFiles.forEach((file) => {
-        // If audio file has chapters use chapters
-        if (file.chapters && file.chapters.length) {
-          file.chapters.forEach((chapter) => {
-            if (chapter.start > this.duration) {
-              Logger.warn(`[Book] Invalid chapter start time > duration`)
-            } else {
-              var chapterAlreadyExists = this.chapters.find(ch => ch.start === chapter.start)
-              if (!chapterAlreadyExists) {
-                var chapterDuration = chapter.end - chapter.start
-                if (chapterDuration > 0) {
-                  var title = `Chapter ${currChapterId}`
-                  if (chapter.title) {
-                    title += ` (${chapter.title})`
+      var overdriveMediaMarkers = includedAudioFiles.map((af) => af.metaTags.tagOverdriveMediaMarker).filter(notUndefined => notUndefined !== undefined) || []
+      Logger.debug(`[setChapters] overdriveMediaMarkers: ${JSON.stringify(overdriveMediaMarkers)}`)
+
+      // If preferOverdriveMediaMarker is set, try and use that first
+      if (preferOverdriveMediaMarker) {
+        Logger.debug(`[Book] preferring overdrive media markers! Lets generate em.`)
+        this.chapters = this.generateChaptersFromOverdriveMediaMarkers(overdriveMediaMarkers, includedAudioFiles)
+
+      } else {
+        includedAudioFiles.forEach((file) => {
+          //console.log(`audiofile MetaTags Overdrive: ${JSON.stringify(file.metaTags.tagOverdriveMediaMarker)}}`)
+          // If audio file has chapters use chapters
+            if (file.chapters && file.chapters.length) {
+              file.chapters.forEach((chapter) => {
+                if (chapter.start > this.duration) {
+                  Logger.warn(`[Book] Invalid chapter start time > duration`)
+                } else {
+                  var chapterAlreadyExists = this.chapters.find(ch => ch.start === chapter.start)
+                  if (!chapterAlreadyExists) {
+                    var chapterDuration = chapter.end - chapter.start
+                    if (chapterDuration > 0) {
+                      var title = `Chapter ${currChapterId}`
+                      if (chapter.title) {
+                        title += ` (${chapter.title})`
+                      }
+                      var endTime = Math.min(this.duration, currStartTime + chapterDuration)
+                      this.chapters.push({
+                        id: currChapterId++,
+                        start: currStartTime,
+                        end: endTime,
+                        title
+                      })
+                      currStartTime += chapterDuration
+                    }
                   }
-                  var endTime = Math.min(this.duration, currStartTime + chapterDuration)
-                  this.chapters.push({
-                    id: currChapterId++,
-                    start: currStartTime,
-                    end: endTime,
-                    title
-                  })
-                  currStartTime += chapterDuration
                 }
-              }
-            }
-          })
-        } else if (file.duration) {
-          // Otherwise just use track has chapter
-          this.chapters.push({
-            id: currChapterId++,
-            start: currStartTime,
-            end: currStartTime + file.duration,
-            title: file.metadata.filename ? Path.basename(file.metadata.filename, Path.extname(file.metadata.filename)) : `Chapter ${currChapterId}`
-          })
-          currStartTime += file.duration
-        }
-      })
+              })
+            } else if (file.duration) {
+              // Otherwise just use track has chapter
+              this.chapters.push({
+                id: currChapterId++,
+                start: currStartTime,
+                end: currStartTime + file.duration,
+                title: file.metadata.filename ? Path.basename(file.metadata.filename, Path.extname(file.metadata.filename)) : `Chapter ${currChapterId}`
+              })
+              currStartTime += file.duration
+          }
+        })
+      }
     }
   }
 

--- a/server/objects/mediaTypes/Book.js
+++ b/server/objects/mediaTypes/Book.js
@@ -357,6 +357,7 @@ class Book {
       return audioFile
     })
 
+    Logger.debug(`[Book] WE ARE INSIDE UPDATE AUDIO TRACKS ========================`)
     this.rebuildTracks()
   }
 
@@ -495,7 +496,6 @@ class Book {
     var markers = audioFiles.map((af) => af.metaTags.tagOverdriveMediaMarker).filter(notUndefined => notUndefined !== undefined).filter(elem => { return elem !== null }) || [] 
     return markers
   }
-
 
   setChapters(preferOverdriveMediaMarker = false) {
     // If 1 audio file without chapters, then no chapters will be set

--- a/server/objects/mediaTypes/Book.js
+++ b/server/objects/mediaTypes/Book.js
@@ -363,7 +363,6 @@ class Book {
 
   rebuildTracks(preferOverdriveMediaMarker) {
     Logger.debug(`[Book] Tracks being rebuilt...!`)
-    Logger.debug(`[Book] preferOverdriveMediaMarker: ${JSON.stringify(preferOverdriveMediaMarker)}`)
     this.audioFiles.sort((a, b) => a.index - b.index)
     this.missingParts = []
     this.setChapters(preferOverdriveMediaMarker)
@@ -418,7 +417,6 @@ class Book {
       var currChapterId = 0
       var currStartTime = 0
       includedAudioFiles.forEach((file) => {
-        //console.log(`audiofile MetaTags Overdrive: ${JSON.stringify(file.metaTags.tagOverdriveMediaMarker)}}`)
         // If audio file has chapters use chapters
         if (file.chapters && file.chapters.length) {
           file.chapters.forEach((chapter) => {

--- a/server/objects/mediaTypes/Book.js
+++ b/server/objects/mediaTypes/Book.js
@@ -358,12 +358,11 @@ class Book {
       return audioFile
     })
 
-    Logger.debug(`[Book] WE ARE INSIDE UPDATE AUDIO TRACKS ========================`)
     this.rebuildTracks()
   }
 
   rebuildTracks(preferOverdriveMediaMarker) {
-    Logger.debug(`[Book] we are rebuilding the tracks!`)
+    Logger.debug(`[Book] Tracks being rebuilt...!`)
     Logger.debug(`[Book] preferOverdriveMediaMarker: ${JSON.stringify(preferOverdriveMediaMarker)}`)
     this.audioFiles.sort((a, b) => a.index - b.index)
     this.missingParts = []

--- a/server/objects/mediaTypes/Book.js
+++ b/server/objects/mediaTypes/Book.js
@@ -3,6 +3,7 @@ const Logger = require('../../Logger')
 const BookMetadata = require('../metadata/BookMetadata')
 const { areEquivalent, copyValue } = require('../../utils/index')
 const { parseOpfMetadataXML } = require('../../utils/parsers/parseOpfMetadata')
+const { getOverdriveMediaMarkersFromFiles, parseOverdriveMediaMarkers } = require('../../utils/parsers/parseOverdriveMediaMarkers')
 const abmetadataGenerator = require('../../utils/abmetadataGenerator')
 const { readTextFile } = require('../../utils/fileUtils')
 const AudioFile = require('../files/AudioFile')
@@ -398,116 +399,17 @@ class Book {
     return wasUpdated
   }
 
-  generateChaptersFromOverdriveMediaMarkers(overdriveMediaMarkers, includedAudioFiles) {
-    var parseString = require('xml2js').parseString; // function to convert xml to JSON
-    
-    var parsedOverdriveMediaMarkers = [] // an array of objects. each object being a chapter with a name and time key. the values are arrays of strings
-
-    overdriveMediaMarkers.forEach(function (item, index) {     
-      var parsed_result
-      parseString(item, function (err, result) {
-        // result.Markers.Marker is the result of parsing the XML for the MediaMarker tags for the MP3 file (Part##.mp3)
-        // it is shaped like this:
-        // [
-        //   {
-        //     "Name": [
-        //       "Chapter 1:  "
-        //     ],
-        //     "Time": [
-        //       "0:00.000"
-        //     ]
-        //   },
-        //   {
-        //     "Name": [
-        //       "Chapter 2: "
-        //     ],
-        //     "Time": [
-        //       "15:51.000"
-        //     ]
-        //   }
-        // ]
-
-        parsed_result = result.Markers.Marker
-        
-        // The values for Name and Time in parsed_results are returned as Arrays from parseString
-        // update them to be strings
-        parsed_result.forEach((item, index) => {
-          Object.keys(item).forEach(key => {
-            item[key] = item[key].toString()
-          })
-        })
-      })
-
-      parsedOverdriveMediaMarkers.push(parsed_result)
-    })
-
-    // go from an array of arrays of objects to an array of objects
-    // end result looks like:
-    // [
-    //   {
-    //     "Name": "Chapter 1:  The Worst Birthday",
-    //     "Time": "0:00.000"
-    //   },
-    //   {
-    //     "Name": "Chapter 2:  Dobby's Warning",
-    //     "Time": "15:51.000"
-    //   },
-    //   { redacted }
-    // ]
-    parsedOverdriveMediaMarkers = parsedOverdriveMediaMarkers
-
-    var index = 0
-    
-    var time = 0.0
-    
-
-    // actually generate the chapter object
-    // logic ported over from benonymity's OverdriveChapterizer:
-    //    https://github.com/benonymity/OverdriveChapterizer/blob/main/chapters.py
-    var length = 0.0
-    var newOChapters = []
-    const weirdChapterFilterRegex = /([(]\d|[cC]ontinued)/
-    includedAudioFiles.forEach((track, track_index) => {
-      parsedOverdriveMediaMarkers[track_index].forEach((chapter) => {
-        Logger.debug(`[Book] Attempting regex check for ${chapter.Name}!`)
-        if (weirdChapterFilterRegex.test(chapter.Name)) {
-          Logger.debug(`[Book] That shit weird yo`)
-          return
-        }
-        time = chapter.Time.split(":")
-        time = length + parseFloat(time[0]) * 60 + parseFloat(time[1])
-        newOChapters.push(
-          {
-            id: index++,
-            start: time,
-            end: length,
-            title: chapter.Name
-          }
-        )
-      })
-      length += track.duration
-    })
-
-    Logger.debug(`[Book] newOChapters: ${JSON.stringify(newOChapters)}`)
-    return newOChapters
-  }
-
-  getOverdriveMediaMarkers(audioFiles) {
-    var markers = audioFiles.map((af) => af.metaTags.tagOverdriveMediaMarker).filter(notUndefined => notUndefined !== undefined).filter(elem => { return elem !== null }) || [] 
-    return markers
-  }
-
   setChapters(preferOverdriveMediaMarker = false) {
     // If 1 audio file without chapters, then no chapters will be set
     var includedAudioFiles = this.audioFiles.filter(af => !af.exclude)
 
-    var overdriveMediaMarkers = this.getOverdriveMediaMarkers(includedAudioFiles)
+    var overdriveMediaMarkers = getOverdriveMediaMarkersFromFiles(includedAudioFiles)
 
     // If preferOverdriveMediaMarker is set, try and use that first
     //  fallback to non-overdrive chapters if there are no Overdrive Media Markers available
     if (preferOverdriveMediaMarker && (overdriveMediaMarkers.length > 0)) {
       Logger.debug(`[Book] preferring overdrive media markers! Lets generate em.`)
-      this.chapters = this.generateChaptersFromOverdriveMediaMarkers(overdriveMediaMarkers, includedAudioFiles)
+      this.chapters = parseOverdriveMediaMarkers(overdriveMediaMarkers, includedAudioFiles)
     } else {
       if (includedAudioFiles.length === 1) {
         // 1 audio file with chapters

--- a/server/objects/metadata/AudioMetaTags.js
+++ b/server/objects/metadata/AudioMetaTags.js
@@ -20,6 +20,7 @@ class AudioMetaTags {
     this.tagIsbn = null
     this.tagLanguage = null
     this.tagASIN = null
+    this.tagOverdriveMediaMarker = null
 
     if (metadata) {
       this.construct(metadata)
@@ -58,6 +59,7 @@ class AudioMetaTags {
     this.tagIsbn = metadata.tagIsbn || null
     this.tagLanguage = metadata.tagLanguage || null
     this.tagASIN = metadata.tagASIN || null
+    this.tagOverdriveMediaMarker = metadata.tagOverdriveMediaMarker || null
   }
 
   // Data parsed in prober.js
@@ -82,6 +84,7 @@ class AudioMetaTags {
     this.tagIsbn = payload.file_tag_isbn || null
     this.tagLanguage = payload.file_tag_language || null
     this.tagASIN = payload.file_tag_asin || null
+    this.tagOverdriveMediaMarker = payload.file_tag_overdrive_media_marker || null
   }
 
   updateData(payload) {
@@ -105,7 +108,8 @@ class AudioMetaTags {
       tagEncodedBy: payload.file_tag_encodedby || null,
       tagIsbn: payload.file_tag_isbn || null,
       tagLanguage: payload.file_tag_language || null,
-      tagASIN: payload.file_tag_asin || null
+      tagASIN: payload.file_tag_asin || null,
+      tagOverdriveMediaMarker: payload.file_tag_overdrive_media_marker || null,
     }
 
     var hasUpdates = false

--- a/server/objects/metadata/BookMetadata.js
+++ b/server/objects/metadata/BookMetadata.js
@@ -262,6 +262,10 @@ class BookMetadata {
       {
         tag: 'tagASIN',
         key: 'asin'
+      },
+      {
+        tag: 'tagOverdriveMediaMarker',
+        key: 'overdriveMediaMarker'
       }
     ]
 

--- a/server/objects/settings/ServerSettings.js
+++ b/server/objects/settings/ServerSettings.js
@@ -13,6 +13,7 @@ class ServerSettings {
     this.scannerPreferOpfMetadata = false
     this.scannerPreferMatchedMetadata = false
     this.scannerDisableWatcher = false 
+    this.scannerPreferOverdriveMediaMarker = false
 
     // Metadata - choose to store inside users library item folder
     this.storeCoverWithItem = false
@@ -65,6 +66,7 @@ class ServerSettings {
     this.scannerPreferOpfMetadata = !!settings.scannerPreferOpfMetadata
     this.scannerPreferMatchedMetadata = !!settings.scannerPreferMatchedMetadata
     this.scannerDisableWatcher = !!settings.scannerDisableWatcher
+    this.scannerPreferOverdriveMediaMarker = !!settings.scannerPreferOverdriveMediaMarker
 
     this.storeCoverWithItem = !!settings.storeCoverWithItem
     if (settings.storeCoverWithBook != undefined) { // storeCoverWithBook was old name of setting < v2
@@ -111,6 +113,7 @@ class ServerSettings {
       scannerPreferOpfMetadata: this.scannerPreferOpfMetadata,
       scannerPreferMatchedMetadata: this.scannerPreferMatchedMetadata,
       scannerDisableWatcher: this.scannerDisableWatcher,
+      scannerPreferOverdriveMediaMarker: this.scannerPreferOverdriveMediaMarker,
       storeCoverWithItem: this.storeCoverWithItem,
       storeMetadataWithItem: this.storeMetadataWithItem,
       rateLimitLoginRequests: this.rateLimitLoginRequests,

--- a/server/scanner/LibraryScan.js
+++ b/server/scanner/LibraryScan.js
@@ -34,6 +34,7 @@ class LibraryScan {
   get forceRescan() { return !!this._scanOptions.forceRescan }
   get preferAudioMetadata() { return !!this._scanOptions.preferAudioMetadata }
   get preferOpfMetadata() { return !!this._scanOptions.preferOpfMetadata }
+  get preferOverdriveMediaMarker() { return !!this._scanOptions.preferOverdriveMediaMarker }
   get findCovers() { return !!this._scanOptions.findCovers }
   get timestamp() {
     return (new Date()).toISOString()

--- a/server/scanner/MediaFileScanner.js
+++ b/server/scanner/MediaFileScanner.js
@@ -196,9 +196,6 @@ class MediaFileScanner {
   }
 
   async scanMediaFiles(mediaLibraryFiles, scanData, libraryItem, preferAudioMetadata, preferOverdriveMediaMarker, libraryScan = null) {
-    Logger.debug('[scanMediaFiles] inside scan media files!')
-    Logger.debug(`[scanMediaFiles] libraryScan: ${JSON.stringify(libraryScan)}`)
-
     var hasUpdated = false
 
     var mediaScanResult = await this.executeMediaFileScans(libraryItem.mediaType, mediaLibraryFiles, scanData)
@@ -221,23 +218,18 @@ class MediaFileScanner {
 
       // Book: Adding audio files to book media
       if (libraryItem.mediaType === 'book') {
-        Logger.debug('Its a book!')
         if (newAudioFiles.length) {
-          Logger.debug('[MediaFileScanner] newAudioFiles.length was true?')
           // Single Track Audiobooks
           if (totalAudioFilesToInclude === 1) {
-            Logger.debug('[MediaFileScanner] totalAudioFilesToInclude === 1')
             var af = mediaScanResult.audioFiles[0]
             af.index = 1
             libraryItem.media.addAudioFile(af)
             hasUpdated = true
           } else {
-            Logger.debug('[MediaFileScanner] totalAudioFilesToInclude === 1 WAS FALSE')
             this.runSmartTrackOrder(libraryItem, mediaScanResult.audioFiles)
             hasUpdated = true
           }
         } else {
-          Logger.debug('[MediaFileScanner] Only updating metadata?')
           // Only update metadata not index
           mediaScanResult.audioFiles.forEach((af) => {
             var existingAF = libraryItem.media.findFileWithInode(af.ino)
@@ -257,7 +249,6 @@ class MediaFileScanner {
 
         if (hasUpdated) {
           Logger.debug('[MediaFileScanner] hasUpdated is true! Going to rebuild tracks now...')
-          Logger.debug(`[MediaFileScanner] preferOverdriveMediaMarker: ${JSON.stringify(preferOverdriveMediaMarker)}`)
           libraryItem.media.rebuildTracks(preferOverdriveMediaMarker)
         }
       } else { // Podcast Media Type
@@ -275,7 +266,6 @@ class MediaFileScanner {
         // Update audio file metadata for audio files already there
         existingAudioFiles.forEach((af) => {
           var peAudioFile = libraryItem.media.findFileWithInode(af.ino)
-          Logger.debug(`[MediaFileScanner] peAudioFile: ${JSON.stringify(peAudioFile)}`)
           if (peAudioFile.updateFromScan && peAudioFile.updateFromScan(af)) {
             hasUpdated = true
           }

--- a/server/scanner/MediaFileScanner.js
+++ b/server/scanner/MediaFileScanner.js
@@ -195,7 +195,7 @@ class MediaFileScanner {
     }
   }
 
-  async scanMediaFiles(mediaLibraryFiles, scanData, libraryItem, preferAudioMetadata, libraryScan = null) {
+  async scanMediaFiles(mediaLibraryFiles, scanData, libraryItem, preferAudioMetadata, preferOverdriveMediaMarker, libraryScan = null) {
     Logger.debug('[scanMediaFiles] inside scan media files!')
     Logger.debug(`[scanMediaFiles] libraryScan: ${JSON.stringify(libraryScan)}`)
 
@@ -257,8 +257,8 @@ class MediaFileScanner {
 
         if (hasUpdated) {
           Logger.debug('[MediaFileScanner] hasUpdated is true! Going to rebuild tracks now...')
-          Logger.debug(`[MediaFileScanner] libraryScan: ${JSON.stringify(libraryScan)}`)
-          libraryItem.media.rebuildTracks(libraryScan.scanOptions.preferOverdriveMediaMarker)
+          Logger.debug(`[MediaFileScanner] preferOverdriveMediaMarker: ${JSON.stringify(preferOverdriveMediaMarker)}`)
+          libraryItem.media.rebuildTracks(preferOverdriveMediaMarker)
         }
       } else { // Podcast Media Type
         var existingAudioFiles = mediaScanResult.audioFiles.filter(af => libraryItem.media.findFileWithInode(af.ino))

--- a/server/scanner/MediaFileScanner.js
+++ b/server/scanner/MediaFileScanner.js
@@ -248,7 +248,6 @@ class MediaFileScanner {
         }
 
         if (hasUpdated) {
-          Logger.debug('[MediaFileScanner] hasUpdated is true! Going to rebuild tracks now...')
           libraryItem.media.rebuildTracks(preferOverdriveMediaMarker)
         }
       } else { // Podcast Media Type

--- a/server/scanner/ScanOptions.js
+++ b/server/scanner/ScanOptions.js
@@ -9,6 +9,7 @@ class ScanOptions {
     this.preferAudioMetadata = false
     this.preferOpfMetadata = false
     this.preferMatchedMetadata = false
+    this.preferOverdriveMediaMarker = false
 
     if (options) {
       this.construct(options)
@@ -34,7 +35,8 @@ class ScanOptions {
       storeCoverWithItem: this.storeCoverWithItem,
       preferAudioMetadata: this.preferAudioMetadata,
       preferOpfMetadata: this.preferOpfMetadata,
-      preferMatchedMetadata: this.preferMatchedMetadata
+      preferMatchedMetadata: this.preferMatchedMetadata,
+      preferOverdriveMediaMarker: this.preferOverdriveMediaMarker
     }
   }
 
@@ -47,6 +49,7 @@ class ScanOptions {
     this.preferAudioMetadata = serverSettings.scannerPreferAudioMetadata
     this.preferOpfMetadata = serverSettings.scannerPreferOpfMetadata
     this.scannerPreferMatchedMetadata = serverSettings.scannerPreferMatchedMetadata
+    this.preferOverdriveMediaMarker = serverSettings.scannerPreferOverdriveMediaMarker
   }
 }
 module.exports = ScanOptions

--- a/server/scanner/Scanner.js
+++ b/server/scanner/Scanner.js
@@ -316,7 +316,7 @@ class Scanner {
 
   async scanNewLibraryItemDataChunk(newLibraryItemsData, libraryScan) {
     var newLibraryItems = await Promise.all(newLibraryItemsData.map((lid) => {
-      return this.scanNewLibraryItem(lid, libraryScan.libraryMediaType, libraryScan.preferAudioMetadata, libraryScan.preferOpfMetadata, libraryScan.findCovers, libraryScan.preferOverdriveMediaMarker, libraryScan)
+      return this.scanNewLibraryItem(lid, libraryScan.libraryMediaType, libraryScan.preferAudioMetadata, libraryScan.preferOpfMetadata, libraryScan.findCovers, libraryScan.scanOptions.preferOverdriveMediaMarker, libraryScan)
     }))
     newLibraryItems = newLibraryItems.filter(li => li) // Filter out nulls
 

--- a/server/scanner/Scanner.js
+++ b/server/scanner/Scanner.js
@@ -62,7 +62,6 @@ class Scanner {
   }
 
   async scanLibraryItem(libraryMediaType, folder, libraryItem) {
-    Logger.debug(`[Scanner] SCANNING ITEMS JOE`)
     // TODO: Support for single media item
     var libraryItemData = await getLibraryItemFileData(libraryMediaType, folder, libraryItem.path, false, this.db.serverSettings)
     if (!libraryItemData) {
@@ -81,7 +80,6 @@ class Scanner {
     // Scan all audio files
     if (libraryItem.hasAudioFiles) {
       var libraryAudioFiles = libraryItem.libraryFiles.filter(lf => lf.fileType === 'audio')
-      Logger.debug(`[Scanner] //scan all audio files -- This is this.db.serverSettings.scannerPreferOverdriveMediaMarker: ${this.db.serverSettings.scannerPreferOverdriveMediaMarker}`)
       if (await MediaFileScanner.scanMediaFiles(libraryAudioFiles, libraryItemData, libraryItem, this.db.serverSettings.scannerPreferAudioMetadata, this.db.serverSettings.scannerPreferOverdriveMediaMarker)) {
         hasUpdated = true
       }

--- a/server/scanner/Scanner.js
+++ b/server/scanner/Scanner.js
@@ -309,7 +309,6 @@ class Scanner {
   }
 
   async scanNewLibraryItemDataChunk(newLibraryItemsData, libraryScan) {
-    Logger.debug(`LIBRARYSCAN: ${JSON.stringify(libraryScan)}`)
     var newLibraryItems = await Promise.all(newLibraryItemsData.map((lid) => {
       return this.scanNewLibraryItem(lid, libraryScan.libraryMediaType, libraryScan.preferAudioMetadata, libraryScan.preferOpfMetadata, libraryScan.findCovers, libraryScan.preferOverdriveMediaMarker, libraryScan)
     }))

--- a/server/scanner/Scanner.js
+++ b/server/scanner/Scanner.js
@@ -315,8 +315,9 @@ class Scanner {
   }
 
   async scanNewLibraryItemDataChunk(newLibraryItemsData, libraryScan) {
+    Logger.debug(`LIBRARYSCAN: ${JSON.stringify(libraryScan)}`)
     var newLibraryItems = await Promise.all(newLibraryItemsData.map((lid) => {
-      return this.scanNewLibraryItem(lid, libraryScan.libraryMediaType, libraryScan.preferAudioMetadata, libraryScan.preferOpfMetadata, libraryScan.findCovers, libraryScan.scanOptions.preferOverdriveMediaMarker, libraryScan)
+      return this.scanNewLibraryItem(lid, libraryScan.libraryMediaType, libraryScan.preferAudioMetadata, libraryScan.preferOpfMetadata, libraryScan.findCovers, libraryScan.preferOverdriveMediaMarker, libraryScan)
     }))
     newLibraryItems = newLibraryItems.filter(li => li) // Filter out nulls
 
@@ -343,10 +344,10 @@ class Scanner {
     // forceRescan all existing audio files - will probe and update ID3 tag metadata
     var existingAudioFiles = existingLibraryFiles.filter(lf => lf.fileType === 'audio')
     if (libraryScan.scanOptions.forceRescan && existingAudioFiles.length) {
-      Logger.debug(`[Scanner] // forceRescan all existing audio files -- this is libraryScan.preferOverdriveMediaMarker: ${libraryScan.scanOptions.preferOverdriveMediaMarker}`)
+      Logger.debug(`[Scanner] // forceRescan all existing audio files -- this is libraryScan.preferOverdriveMediaMarker: ${libraryScan.preferOverdriveMediaMarker}`)
       Logger.debug(`[Scanner] // forceRescan all existing audio files -- this is libraryScan: ${JSON.stringify(libraryScan)}`)
 
-      if (await MediaFileScanner.scanMediaFiles(existingAudioFiles, scanData, libraryItem, libraryScan.preferAudioMetadata, libraryScan.scanOptions.preferOverdriveMediaMarker, libraryScan)) {
+      if (await MediaFileScanner.scanMediaFiles(existingAudioFiles, scanData, libraryItem, libraryScan.preferAudioMetadata, libraryScan.preferOverdriveMediaMarker, libraryScan)) {
         hasUpdated = true
       }
     }
@@ -354,8 +355,8 @@ class Scanner {
     var newAudioFiles = newLibraryFiles.filter(lf => lf.fileType === 'audio')
     var removedAudioFiles = filesRemoved.filter(lf => lf.fileType === 'audio')
     if (newAudioFiles.length || removedAudioFiles.length) {
-      Logger.debug(`[Scanner] // Scan new audio files -- this is libraryScan.preferOverdriveMediaMarker: ${libraryScan.scanOptions.preferOverdriveMediaMarker}`)
-      if (await MediaFileScanner.scanMediaFiles(newAudioFiles, scanData, libraryItem, libraryScan.preferAudioMetadata, libraryScan.scanOptions.preferOverdriveMediaMarker, libraryScan)) {
+      Logger.debug(`[Scanner] // Scan new audio files -- this is libraryScan.preferOverdriveMediaMarker: ${libraryScan.preferOverdriveMediaMarker}`)
+      if (await MediaFileScanner.scanMediaFiles(newAudioFiles, scanData, libraryItem, libraryScan.preferAudioMetadata, libraryScan.preferOverdriveMediaMarker, libraryScan)) {
         hasUpdated = true
       }
     }

--- a/server/scanner/Scanner.js
+++ b/server/scanner/Scanner.js
@@ -114,7 +114,6 @@ class Scanner {
   }
 
   async scan(library, options = {}) {
-    Logger.debug('[scan] inside of scan')
     if (this.isLibraryScanning(library.id)) {
       Logger.error(`[Scanner] Already scanning ${library.id}`)
       return
@@ -127,7 +126,6 @@ class Scanner {
 
     var scanOptions = new ScanOptions()
     scanOptions.setData(options, this.db.serverSettings)
-    Logger.debug(`[Scanner] scanOptions: ${JSON.stringify(scanOptions)}`)
 
     var libraryScan = new LibraryScan()
     libraryScan.setData(library, scanOptions)
@@ -166,8 +164,6 @@ class Scanner {
 
   async scanLibrary(libraryScan) {
     var libraryItemDataFound = []
-
-    Logger.debug(`[scanLibrary] libraryScan: ${JSON.stringify(libraryScan)}`)
 
     // Scan each library
     for (let i = 0; i < libraryScan.folders.length; i++) {
@@ -342,9 +338,6 @@ class Scanner {
     // forceRescan all existing audio files - will probe and update ID3 tag metadata
     var existingAudioFiles = existingLibraryFiles.filter(lf => lf.fileType === 'audio')
     if (libraryScan.scanOptions.forceRescan && existingAudioFiles.length) {
-      Logger.debug(`[Scanner] // forceRescan all existing audio files -- this is libraryScan.preferOverdriveMediaMarker: ${libraryScan.preferOverdriveMediaMarker}`)
-      Logger.debug(`[Scanner] // forceRescan all existing audio files -- this is libraryScan: ${JSON.stringify(libraryScan)}`)
-
       if (await MediaFileScanner.scanMediaFiles(existingAudioFiles, scanData, libraryItem, libraryScan.preferAudioMetadata, libraryScan.preferOverdriveMediaMarker, libraryScan)) {
         hasUpdated = true
       }
@@ -353,7 +346,6 @@ class Scanner {
     var newAudioFiles = newLibraryFiles.filter(lf => lf.fileType === 'audio')
     var removedAudioFiles = filesRemoved.filter(lf => lf.fileType === 'audio')
     if (newAudioFiles.length || removedAudioFiles.length) {
-      Logger.debug(`[Scanner] // Scan new audio files -- this is libraryScan.preferOverdriveMediaMarker: ${libraryScan.preferOverdriveMediaMarker}`)
       if (await MediaFileScanner.scanMediaFiles(newAudioFiles, scanData, libraryItem, libraryScan.preferAudioMetadata, libraryScan.preferOverdriveMediaMarker, libraryScan)) {
         hasUpdated = true
       }
@@ -397,7 +389,6 @@ class Scanner {
 
     var mediaFiles = libraryItemData.libraryFiles.filter(lf => lf.fileType === 'audio' || lf.fileType === 'video')
     if (mediaFiles.length) {
-      Logger.debug(`[Scanner] // :399 -- this is preferOverdriveMediaMarker: ${preferOverdriveMediaMarker}`)
       await MediaFileScanner.scanMediaFiles(mediaFiles, libraryItemData, libraryItem, preferAudioMetadata, preferOverdriveMediaMarker, libraryScan)
     }
 
@@ -760,7 +751,6 @@ class Scanner {
   }
 
   async matchLibraryItems(library) {
-    Logger.debug("SCANNING!")
     if (library.mediaType === 'podcast') {
       Logger.error(`[Scanner] matchLibraryItems: Match all not supported for podcasts yet`)
       return

--- a/server/scanner/Scanner.js
+++ b/server/scanner/Scanner.js
@@ -62,6 +62,7 @@ class Scanner {
   }
 
   async scanLibraryItem(libraryMediaType, folder, libraryItem) {
+    Logger.debug(`[Scanner] SCANNING ITEMS JOE`)
     // TODO: Support for single media item
     var libraryItemData = await getLibraryItemFileData(libraryMediaType, folder, libraryItem.path, false, this.db.serverSettings)
     if (!libraryItemData) {
@@ -114,6 +115,7 @@ class Scanner {
   }
 
   async scan(library, options = {}) {
+    Logger.debug('[scan] inside of scan')
     if (this.isLibraryScanning(library.id)) {
       Logger.error(`[Scanner] Already scanning ${library.id}`)
       return
@@ -126,6 +128,7 @@ class Scanner {
 
     var scanOptions = new ScanOptions()
     scanOptions.setData(options, this.db.serverSettings)
+    Logger.debug(`[Scanner] scanOptions: ${JSON.stringify(scanOptions)}`)
 
     var libraryScan = new LibraryScan()
     libraryScan.setData(library, scanOptions)
@@ -164,6 +167,8 @@ class Scanner {
 
   async scanLibrary(libraryScan) {
     var libraryItemDataFound = []
+
+    Logger.debug(`[scanLibrary] libraryScan: ${JSON.stringify(libraryScan)}`)
 
     // Scan each library
     for (let i = 0; i < libraryScan.folders.length; i++) {
@@ -750,6 +755,7 @@ class Scanner {
   }
 
   async matchLibraryItems(library) {
+    Logger.debug("SCANNING!")
     if (library.mediaType === 'podcast') {
       Logger.error(`[Scanner] matchLibraryItems: Match all not supported for podcasts yet`)
       return

--- a/server/scanner/Scanner.js
+++ b/server/scanner/Scanner.js
@@ -81,7 +81,7 @@ class Scanner {
     // Scan all audio files
     if (libraryItem.hasAudioFiles) {
       var libraryAudioFiles = libraryItem.libraryFiles.filter(lf => lf.fileType === 'audio')
-      if (await MediaFileScanner.scanMediaFiles(libraryAudioFiles, libraryItemData, libraryItem, this.db.serverSettings.scannerPreferAudioMetadata)) {
+      if (await MediaFileScanner.scanMediaFiles(libraryAudioFiles, libraryItemData, libraryItem, this.db.serverSettings.scannerPreferAudioMetadata, this.db.serverSettings.scannerPreferOverdriveMediaMarker)) {
         hasUpdated = true
       }
 
@@ -315,7 +315,7 @@ class Scanner {
 
   async scanNewLibraryItemDataChunk(newLibraryItemsData, libraryScan) {
     var newLibraryItems = await Promise.all(newLibraryItemsData.map((lid) => {
-      return this.scanNewLibraryItem(lid, libraryScan.libraryMediaType, libraryScan.preferAudioMetadata, libraryScan.preferOpfMetadata, libraryScan.findCovers, libraryScan)
+      return this.scanNewLibraryItem(lid, libraryScan.libraryMediaType, libraryScan.preferAudioMetadata, libraryScan.preferOpfMetadata, libraryScan.findCovers, libraryScan.preferOverdriveMediaMarker, libraryScan)
     }))
     newLibraryItems = newLibraryItems.filter(li => li) // Filter out nulls
 
@@ -342,7 +342,7 @@ class Scanner {
     // forceRescan all existing audio files - will probe and update ID3 tag metadata
     var existingAudioFiles = existingLibraryFiles.filter(lf => lf.fileType === 'audio')
     if (libraryScan.scanOptions.forceRescan && existingAudioFiles.length) {
-      if (await MediaFileScanner.scanMediaFiles(existingAudioFiles, scanData, libraryItem, libraryScan.preferAudioMetadata, libraryScan)) {
+      if (await MediaFileScanner.scanMediaFiles(existingAudioFiles, scanData, libraryItem, libraryScan.preferAudioMetadata, libraryScan.preferOverdriveMediaMarker, libraryScan)) {
         hasUpdated = true
       }
     }
@@ -350,7 +350,7 @@ class Scanner {
     var newAudioFiles = newLibraryFiles.filter(lf => lf.fileType === 'audio')
     var removedAudioFiles = filesRemoved.filter(lf => lf.fileType === 'audio')
     if (newAudioFiles.length || removedAudioFiles.length) {
-      if (await MediaFileScanner.scanMediaFiles(newAudioFiles, scanData, libraryItem, libraryScan.preferAudioMetadata, libraryScan)) {
+      if (await MediaFileScanner.scanMediaFiles(newAudioFiles, scanData, libraryItem, libraryScan.preferAudioMetadata, libraryScan.preferOverdriveMediaMarker, libraryScan)) {
         hasUpdated = true
       }
     }
@@ -384,7 +384,7 @@ class Scanner {
     return hasUpdated ? libraryItem : null
   }
 
-  async scanNewLibraryItem(libraryItemData, libraryMediaType, preferAudioMetadata, preferOpfMetadata, findCovers, libraryScan = null) {
+  async scanNewLibraryItem(libraryItemData, libraryMediaType, preferAudioMetadata, preferOpfMetadata, findCovers, preferOverdriveMediaMarker, libraryScan = null) {
     if (libraryScan) libraryScan.addLog(LogLevel.DEBUG, `Scanning new library item "${libraryItemData.path}"`)
     else Logger.debug(`[Scanner] Scanning new item "${libraryItemData.path}"`)
 
@@ -393,7 +393,7 @@ class Scanner {
 
     var mediaFiles = libraryItemData.libraryFiles.filter(lf => lf.fileType === 'audio' || lf.fileType === 'video')
     if (mediaFiles.length) {
-      await MediaFileScanner.scanMediaFiles(mediaFiles, libraryItemData, libraryItem, preferAudioMetadata, libraryScan)
+      await MediaFileScanner.scanMediaFiles(mediaFiles, libraryItemData, libraryItem, preferAudioMetadata, preferOverdriveMediaMarker, libraryScan)
     }
 
     await libraryItem.syncFiles(preferOpfMetadata)
@@ -613,7 +613,7 @@ class Scanner {
     var libraryItemData = await getLibraryItemFileData(libraryMediaType, folder, fullPath, isSingleMediaItem, this.db.serverSettings)
     if (!libraryItemData) return null
     var serverSettings = this.db.serverSettings
-    return this.scanNewLibraryItem(libraryItemData, libraryMediaType, serverSettings.scannerPreferAudioMetadata, serverSettings.scannerPreferOpfMetadata, serverSettings.scannerFindCovers)
+    return this.scanNewLibraryItem(libraryItemData, libraryMediaType, serverSettings.scannerPreferAudioMetadata, serverSettings.scannerPreferOpfMetadata, serverSettings.scannerFindCovers, serverSettings.scannerPreferOverdriveMediaMarker)
   }
 
   async searchForCover(libraryItem, libraryScan = null) {

--- a/server/scanner/Scanner.js
+++ b/server/scanner/Scanner.js
@@ -81,6 +81,7 @@ class Scanner {
     // Scan all audio files
     if (libraryItem.hasAudioFiles) {
       var libraryAudioFiles = libraryItem.libraryFiles.filter(lf => lf.fileType === 'audio')
+      Logger.debug(`[Scanner] //scan all audio files -- This is this.db.serverSettings.scannerPreferOverdriveMediaMarker: ${this.db.serverSettings.scannerPreferOverdriveMediaMarker}`)
       if (await MediaFileScanner.scanMediaFiles(libraryAudioFiles, libraryItemData, libraryItem, this.db.serverSettings.scannerPreferAudioMetadata, this.db.serverSettings.scannerPreferOverdriveMediaMarker)) {
         hasUpdated = true
       }
@@ -342,7 +343,10 @@ class Scanner {
     // forceRescan all existing audio files - will probe and update ID3 tag metadata
     var existingAudioFiles = existingLibraryFiles.filter(lf => lf.fileType === 'audio')
     if (libraryScan.scanOptions.forceRescan && existingAudioFiles.length) {
-      if (await MediaFileScanner.scanMediaFiles(existingAudioFiles, scanData, libraryItem, libraryScan.preferAudioMetadata, libraryScan.preferOverdriveMediaMarker, libraryScan)) {
+      Logger.debug(`[Scanner] // forceRescan all existing audio files -- this is libraryScan.preferOverdriveMediaMarker: ${libraryScan.scanOptions.preferOverdriveMediaMarker}`)
+      Logger.debug(`[Scanner] // forceRescan all existing audio files -- this is libraryScan: ${JSON.stringify(libraryScan)}`)
+
+      if (await MediaFileScanner.scanMediaFiles(existingAudioFiles, scanData, libraryItem, libraryScan.preferAudioMetadata, libraryScan.scanOptions.preferOverdriveMediaMarker, libraryScan)) {
         hasUpdated = true
       }
     }
@@ -350,7 +354,8 @@ class Scanner {
     var newAudioFiles = newLibraryFiles.filter(lf => lf.fileType === 'audio')
     var removedAudioFiles = filesRemoved.filter(lf => lf.fileType === 'audio')
     if (newAudioFiles.length || removedAudioFiles.length) {
-      if (await MediaFileScanner.scanMediaFiles(newAudioFiles, scanData, libraryItem, libraryScan.preferAudioMetadata, libraryScan.preferOverdriveMediaMarker, libraryScan)) {
+      Logger.debug(`[Scanner] // Scan new audio files -- this is libraryScan.preferOverdriveMediaMarker: ${libraryScan.scanOptions.preferOverdriveMediaMarker}`)
+      if (await MediaFileScanner.scanMediaFiles(newAudioFiles, scanData, libraryItem, libraryScan.preferAudioMetadata, libraryScan.scanOptions.preferOverdriveMediaMarker, libraryScan)) {
         hasUpdated = true
       }
     }
@@ -393,6 +398,7 @@ class Scanner {
 
     var mediaFiles = libraryItemData.libraryFiles.filter(lf => lf.fileType === 'audio' || lf.fileType === 'video')
     if (mediaFiles.length) {
+      Logger.debug(`[Scanner] // :399 -- this is preferOverdriveMediaMarker: ${preferOverdriveMediaMarker}`)
       await MediaFileScanner.scanMediaFiles(mediaFiles, libraryItemData, libraryItem, preferAudioMetadata, preferOverdriveMediaMarker, libraryScan)
     }
 

--- a/server/utils/parsers/parseOverdriveMediaMarkers.js
+++ b/server/utils/parsers/parseOverdriveMediaMarkers.js
@@ -53,11 +53,11 @@ module.exports.parseOverdriveMediaMarkers = (overdriveMediaMarkers, includedAudi
     // end result looks like:
     // [
     //   {
-    //     "Name": "Chapter 1:  The Worst Birthday",
+    //     "Name": "Chapter 1",
     //     "Time": "0:00.000"
     //   },
     //   {
-    //     "Name": "Chapter 2:  Dobby's Warning",
+    //     "Name": "Chapter 2",
     //     "Time": "15:51.000"
     //   },
     //   { redacted }

--- a/server/utils/parsers/parseOverdriveMediaMarkers.js
+++ b/server/utils/parsers/parseOverdriveMediaMarkers.js
@@ -1,53 +1,16 @@
 const Logger = require('../../Logger')
 
-// given an array of audioFiles, return an array of unparsed MediaMarkers
-module.exports.getOverdriveMediaMarkersFromFiles = (audioFiles) => {
-    var markers = audioFiles.map((af) => af.metaTags.tagOverdriveMediaMarker).filter(notUndefined => notUndefined !== undefined).filter(elem => { return elem !== null }) || [] 
+// given a list of audio files, extract all of the Overdrive Media Markers metaTags, and return an array of them as XML
+function overdriveMediaMarkers(includedAudioFiles) {
+    var markers = includedAudioFiles.map((af) => af.metaTags.tagOverdriveMediaMarker).filter(notUndefined => notUndefined !== undefined).filter(elem => { return elem !== null }) || []
     return markers
 }
 
-module.exports.parseOverdriveMediaMarkers = (overdriveMediaMarkers, includedAudioFiles) => {
+// given the array of Overdrive Media Markers from generateOverdriveMediaMarkers()
+//  parse and clean them in to something a bit more usable
+function cleanOverdriveMediaMarkers(overdriveMediaMarkers) {
     var parseString = require('xml2js').parseString; // function to convert xml to JSON
-    
-    var parsedOverdriveMediaMarkers = [] // an array of objects. each object being a chapter with a name and time key. the values are arrays of strings
-
-    overdriveMediaMarkers.forEach(function (item, index) {     
-      var parsed_result
-      parseString(item, function (err, result) {
-        // result.Markers.Marker is the result of parsing the XML for the MediaMarker tags for the MP3 file (Part##.mp3)
-        // it is shaped like this:
-        // [
-        //   {
-        //     "Name": [
-        //       "Chapter 1:  "
-        //     ],
-        //     "Time": [
-        //       "0:00.000"
-        //     ]
-        //   },
-        //   {
-        //     "Name": [
-        //       "Chapter 2: "
-        //     ],
-        //     "Time": [
-        //       "15:51.000"
-        //     ]
-        //   }
-        // ]
-
-        parsed_result = result.Markers.Marker
-        
-        // The values for Name and Time in parsed_results are returned as Arrays from parseString
-        // update them to be strings
-        parsed_result.forEach((item, index) => {
-          Object.keys(item).forEach(key => {
-            item[key] = item[key].toString()
-          })
-        })
-      })
-
-      parsedOverdriveMediaMarkers.push(parsed_result)
-    })
+    var parsedOverdriveMediaMarkers = []
 
     // go from an array of arrays of objects to an array of objects
     // end result looks like:
@@ -62,40 +25,89 @@ module.exports.parseOverdriveMediaMarkers = (overdriveMediaMarkers, includedAudi
     //   },
     //   { redacted }
     // ]
-    parsedOverdriveMediaMarkers = parsedOverdriveMediaMarkers
+    overdriveMediaMarkers.forEach(function (item, index) {
+        var parsed_result
+        parseString(item, function (err, result) {
+            // result.Markers.Marker is the result of parsing the XML for the MediaMarker tags for the MP3 file (Part##.mp3)
+            // it is shaped like this:
+            // [
+            //   {
+            //     "Name": [
+            //       "Chapter 1:  "
+            //     ],
+            //     "Time": [
+            //       "0:00.000"
+            //     ]
+            //   },
+            //   {
+            //     "Name": [
+            //       "Chapter 2: "
+            //     ],
+            //     "Time": [
+            //       "15:51.000"
+            //     ]
+            //   }
+            // ]
 
-    var index = 0
-    
-    var time = 0.0
-    
+            parsed_result = result.Markers.Marker
 
+            // The values for Name and Time in parsed_results are returned as Arrays from parseString
+            // update them to be strings
+            parsed_result.forEach((item, index) => {
+                Object.keys(item).forEach(key => {
+                    item[key] = item[key].toString()
+                })
+            })
+        })
+
+        parsedOverdriveMediaMarkers.push(parsed_result)
+    })
+
+    return parsedOverdriveMediaMarkers
+}
+
+// The function that actually generates the Chapters object that we update ABS with
+function generateParsedChapters(includedAudioFiles, cleanedOverdriveMediaMarkers) {
     // actually generate the chapter object
     // logic ported over from benonymity's OverdriveChapterizer:
     //    https://github.com/benonymity/OverdriveChapterizer/blob/main/chapters.py
     var length = 0.0
-    var newOChapters = []
+    var index = 0
+    var time = 0.0
+    var newChapters = []
     const weirdChapterFilterRegex = /([(]\d|[cC]ontinued)/
     includedAudioFiles.forEach((track, track_index) => {
-      parsedOverdriveMediaMarkers[track_index].forEach((chapter) => {
-        Logger.debug(`[parseOverdriveMediaMarkers] Attempting regex check for ${chapter.Name}!`)
-        if (weirdChapterFilterRegex.test(chapter.Name)) {
-          Logger.debug(`[parseOverdriveMediaMarkers] That shit weird yo`)
-          return
-        }
-        time = chapter.Time.split(":")
-        time = length + parseFloat(time[0]) * 60 + parseFloat(time[1])
-        newOChapters.push(
-          {
-            id: index++,
-            start: time,
-            end: length,
-            title: chapter.Name
-          }
-        )
-      })
-      length += track.duration
+        cleanedOverdriveMediaMarkers[track_index].forEach((chapter) => {
+            Logger.debug(`[parseOverdriveMediaMarkers] Attempting regex check for ${chapter.Name}...`)
+            if (weirdChapterFilterRegex.test(chapter.Name)) {
+                Logger.debug(`[parseOverdriveMediaMarkers] Regex matched. Skipping ${chapter.Name}!`)
+                return
+            }
+            time = chapter.Time.split(":")
+            time = length + parseFloat(time[0]) * 60 + parseFloat(time[1])
+            newChapters.push(
+                {
+                    id: index++,
+                    start: time,
+                    end: length,
+                    title: chapter.Name
+                }
+            )
+        })
+        length += track.duration
     })
 
-    Logger.debug(`[parseOverdriveMediaMarkers] newOChapters: ${JSON.stringify(newOChapters)}`)
-    return newOChapters
+    return newChapters
+}
+
+module.exports.overdriveMediaMarkersExist = (includedAudioFiles) => {
+    return overdriveMediaMarkers(includedAudioFiles).length > 1
+}
+
+module.exports.parseOverdriveMediaMarkersAsChapters = (includedAudioFiles) => {
+    Logger.info('[parseOverdriveMediaMarkers] Parsing of Overdrive Media Markers started')
+    var cleanedOverdriveMediaMarkers = cleanOverdriveMediaMarkers(overdriveMediaMarkers(includedAudioFiles))
+    var parsedChapters = generateParsedChapters(includedAudioFiles, cleanedOverdriveMediaMarkers)
+    
+    return parsedChapters
 }

--- a/server/utils/parsers/parseOverdriveMediaMarkers.js
+++ b/server/utils/parsers/parseOverdriveMediaMarkers.js
@@ -1,113 +1,148 @@
 const Logger = require('../../Logger')
 
 // given a list of audio files, extract all of the Overdrive Media Markers metaTags, and return an array of them as XML
-function overdriveMediaMarkers(includedAudioFiles) {
+function extractOverdriveMediaMarkers(includedAudioFiles) {
+    Logger.debug('[parseOverdriveMediaMarkers] Extracting overdrive media markers')
     var markers = includedAudioFiles.map((af) => af.metaTags.tagOverdriveMediaMarker).filter(notUndefined => notUndefined !== undefined).filter(elem => { return elem !== null }) || []
+
     return markers
 }
 
 // given the array of Overdrive Media Markers from generateOverdriveMediaMarkers()
 //  parse and clean them in to something a bit more usable
 function cleanOverdriveMediaMarkers(overdriveMediaMarkers) {
+    Logger.debug('[parseOverdriveMediaMarkers] Cleaning up overdrive media markers')
+    /*
+    returns an array of arrays of objects. Each inner array corresponds to an audio track, with it's objects being a chapter:
+    [
+      [
+       {
+        "Name": "Chapter 1",
+        "Time": "0:00.000"
+      },
+      {
+        "Name": "Chapter 2",
+        "Time": "15:51.000"
+      },
+      { etc }
+      ]
+    ]
+    */
+
     var parseString = require('xml2js').parseString; // function to convert xml to JSON
     var parsedOverdriveMediaMarkers = []
 
-    // go from an array of arrays of objects to an array of objects
-    // end result looks like:
-    // [
-    //   {
-    //     "Name": "Chapter 1",
-    //     "Time": "0:00.000"
-    //   },
-    //   {
-    //     "Name": "Chapter 2",
-    //     "Time": "15:51.000"
-    //   },
-    //   { redacted }
-    // ]
     overdriveMediaMarkers.forEach(function (item, index) {
         var parsed_result
         parseString(item, function (err, result) {
-            // result.Markers.Marker is the result of parsing the XML for the MediaMarker tags for the MP3 file (Part##.mp3)
-            // it is shaped like this:
-            // [
-            //   {
-            //     "Name": [
-            //       "Chapter 1:  "
-            //     ],
-            //     "Time": [
-            //       "0:00.000"
-            //     ]
-            //   },
-            //   {
-            //     "Name": [
-            //       "Chapter 2: "
-            //     ],
-            //     "Time": [
-            //       "15:51.000"
-            //     ]
-            //   }
-            // ]
+            /*  
+            result.Markers.Marker is the result of parsing the XML for the MediaMarker tags for the MP3 file (Part##.mp3)
+            it is shaped like this, and needs further cleaning below:
+            [
+                {
+                    "Name": [
+                        "Chapter 1:  "
+                    ],
+                    "Time": [
+                        "0:00.000"
+                    ]
+                },
+                { 
+                    ANOTHER CHAPTER
+                },
+            ]
+            */
 
-            parsed_result = result.Markers.Marker
-
-            // The values for Name and Time in parsed_results are returned as Arrays from parseString
-            // update them to be strings
-            parsed_result.forEach((item, index) => {
-                Object.keys(item).forEach(key => {
-                    item[key] = item[key].toString()
-                })
-            })
+            // The values for Name and Time in results.Markers.Marker are returned as Arrays from parseString and should be strings
+            parsed_result = objectValuesArrayToString(result.Markers.Marker)
         })
 
         parsedOverdriveMediaMarkers.push(parsed_result)
     })
 
-    return parsedOverdriveMediaMarkers
+    return removeExtraChapters(parsedOverdriveMediaMarkers)
+}
+
+// given an array of objects, convert any values that are arrays to strings
+function objectValuesArrayToString(arrayOfObjects) {
+    Logger.debug('[parseOverdriveMediaMarkers] Converting Marker object values from arrays to strings')
+    arrayOfObjects.forEach((item) => {
+        Object.keys(item).forEach(key => {
+            item[key] = item[key].toString()
+        })
+    })
+
+    return arrayOfObjects
+}
+
+// Overdrive sometimes has weird chapters and subchapters defined
+//  These aren't necessary, so lets remove them
+function removeExtraChapters(parsedOverdriveMediaMarkers) {
+    Logger.debug('[parseOverdriveMediaMarkers] Removing any unnecessary chapters')
+    const weirdChapterFilterRegex = /([(]\d|[cC]ontinued)/
+    var cleaned = []
+    parsedOverdriveMediaMarkers.forEach(function (item) {
+        cleaned.push(item.filter(chapter => !weirdChapterFilterRegex.test(chapter.Name)))
+    })
+
+    return cleaned
+}
+
+// Given a set of chapters from generateParsedChapters, add the end time to each one
+function addChapterEndTimes(chapters, totalAudioDuration) {
+    Logger.debug('[parseOverdriveMediaMarkers] Adding chapter end times')
+    chapters.forEach((chapter, chapter_index) => {
+        if (chapter_index < chapters.length - 1) {
+            chapter.end = chapters[chapter_index + 1].start
+        } else {
+            chapter.end = totalAudioDuration
+        }
+    })
+
+    return chapters
 }
 
 // The function that actually generates the Chapters object that we update ABS with
 function generateParsedChapters(includedAudioFiles, cleanedOverdriveMediaMarkers) {
-    // actually generate the chapter object
+    Logger.debug('[parseOverdriveMediaMarkers] Generating new chapters for ABS')
     // logic ported over from benonymity's OverdriveChapterizer:
     //    https://github.com/benonymity/OverdriveChapterizer/blob/main/chapters.py
+    var parsedChapters = []
     var length = 0.0
     var index = 0
     var time = 0.0
-    var newChapters = []
-    const weirdChapterFilterRegex = /([(]\d|[cC]ontinued)/
+
+    // cleanedOverdriveMediaMarkers is an array of array of objects, where the inner array matches to the included audio files tracks
+    //     this allows us to leverage the individual track durations when calculating the start times of chapters in tracks after the first (using length)
     includedAudioFiles.forEach((track, track_index) => {
         cleanedOverdriveMediaMarkers[track_index].forEach((chapter) => {
-            Logger.debug(`[parseOverdriveMediaMarkers] Attempting regex check for ${chapter.Name}...`)
-            if (weirdChapterFilterRegex.test(chapter.Name)) {
-                Logger.debug(`[parseOverdriveMediaMarkers] Regex matched. Skipping ${chapter.Name}!`)
-                return
-            }
             time = chapter.Time.split(":")
             time = length + parseFloat(time[0]) * 60 + parseFloat(time[1])
-            newChapters.push(
-                {
-                    id: index++,
-                    start: time,
-                    end: length,
-                    title: chapter.Name
-                }
-            )
+            var newChapterData = {
+                id: index++,
+                start: time,
+                title: chapter.Name
+            }
+            parsedChapters.push(newChapterData)
         })
         length += track.duration
     })
 
-    return newChapters
+    parsedChapters = addChapterEndTimes(parsedChapters, length) // we need all the start times sorted out before we can add the end times
+
+    return parsedChapters
 }
 
 module.exports.overdriveMediaMarkersExist = (includedAudioFiles) => {
-    return overdriveMediaMarkers(includedAudioFiles).length > 1
+    return extractOverdriveMediaMarkers(includedAudioFiles).length > 1
 }
 
 module.exports.parseOverdriveMediaMarkersAsChapters = (includedAudioFiles) => {
     Logger.info('[parseOverdriveMediaMarkers] Parsing of Overdrive Media Markers started')
-    var cleanedOverdriveMediaMarkers = cleanOverdriveMediaMarkers(overdriveMediaMarkers(includedAudioFiles))
+
+    var overdriveMediaMarkers = extractOverdriveMediaMarkers(includedAudioFiles)
+    var cleanedOverdriveMediaMarkers = cleanOverdriveMediaMarkers(overdriveMediaMarkers)
     var parsedChapters = generateParsedChapters(includedAudioFiles, cleanedOverdriveMediaMarkers)
-    
+
     return parsedChapters
 }

--- a/server/utils/parsers/parseOverdriveMediaMarkers.js
+++ b/server/utils/parsers/parseOverdriveMediaMarkers.js
@@ -1,0 +1,101 @@
+const Logger = require('../../Logger')
+
+// given an array of audioFiles, return an array of unparsed MediaMarkers
+module.exports.getOverdriveMediaMarkersFromFiles = (audioFiles) => {
+    var markers = audioFiles.map((af) => af.metaTags.tagOverdriveMediaMarker).filter(notUndefined => notUndefined !== undefined).filter(elem => { return elem !== null }) || [] 
+    return markers
+}
+
+module.exports.parseOverdriveMediaMarkers = (overdriveMediaMarkers, includedAudioFiles) => {
+    var parseString = require('xml2js').parseString; // function to convert xml to JSON
+    
+    var parsedOverdriveMediaMarkers = [] // an array of objects. each object being a chapter with a name and time key. the values are arrays of strings
+
+    overdriveMediaMarkers.forEach(function (item, index) {     
+      var parsed_result
+      parseString(item, function (err, result) {
+        // result.Markers.Marker is the result of parsing the XML for the MediaMarker tags for the MP3 file (Part##.mp3)
+        // it is shaped like this:
+        // [
+        //   {
+        //     "Name": [
+        //       "Chapter 1:  "
+        //     ],
+        //     "Time": [
+        //       "0:00.000"
+        //     ]
+        //   },
+        //   {
+        //     "Name": [
+        //       "Chapter 2: "
+        //     ],
+        //     "Time": [
+        //       "15:51.000"
+        //     ]
+        //   }
+        // ]
+
+        parsed_result = result.Markers.Marker
+        
+        // The values for Name and Time in parsed_results are returned as Arrays from parseString
+        // update them to be strings
+        parsed_result.forEach((item, index) => {
+          Object.keys(item).forEach(key => {
+            item[key] = item[key].toString()
+          })
+        })
+      })
+
+      parsedOverdriveMediaMarkers.push(parsed_result)
+    })
+
+    // go from an array of arrays of objects to an array of objects
+    // end result looks like:
+    // [
+    //   {
+    //     "Name": "Chapter 1:  The Worst Birthday",
+    //     "Time": "0:00.000"
+    //   },
+    //   {
+    //     "Name": "Chapter 2:  Dobby's Warning",
+    //     "Time": "15:51.000"
+    //   },
+    //   { redacted }
+    // ]
+    parsedOverdriveMediaMarkers = parsedOverdriveMediaMarkers
+
+    var index = 0
+    
+    var time = 0.0
+    
+
+    // actually generate the chapter object
+    // logic ported over from benonymity's OverdriveChapterizer:
+    //    https://github.com/benonymity/OverdriveChapterizer/blob/main/chapters.py
+    var length = 0.0
+    var newOChapters = []
+    const weirdChapterFilterRegex = /([(]\d|[cC]ontinued)/
+    includedAudioFiles.forEach((track, track_index) => {
+      parsedOverdriveMediaMarkers[track_index].forEach((chapter) => {
+        Logger.debug(`[parseOverdriveMediaMarkers] Attempting regex check for ${chapter.Name}!`)
+        if (weirdChapterFilterRegex.test(chapter.Name)) {
+          Logger.debug(`[parseOverdriveMediaMarkers] That shit weird yo`)
+          return
+        }
+        time = chapter.Time.split(":")
+        time = length + parseFloat(time[0]) * 60 + parseFloat(time[1])
+        newOChapters.push(
+          {
+            id: index++,
+            start: time,
+            end: length,
+            title: chapter.Name
+          }
+        )
+      })
+      length += track.duration
+    })
+
+    Logger.debug(`[parseOverdriveMediaMarkers] newOChapters: ${JSON.stringify(newOChapters)}`)
+    return newOChapters
+}

--- a/server/utils/prober.js
+++ b/server/utils/prober.js
@@ -192,6 +192,7 @@ function parseTags(format, verbose) {
     file_tag_movement: tryGrabTags(format, 'movement', 'mvin'),
     file_tag_genre1: tryGrabTags(format, 'tmp_genre1', 'genre1'),
     file_tag_genre2: tryGrabTags(format, 'tmp_genre2', 'genre2'),
+    file_tag_overdrive_media_marker: tryGrabTags(format, 'OverDrive MediaMarkers'),
   }
   for (const key in tags) {
     if (!tags[key]) {


### PR DESCRIPTION
Overdrive MP3s come in multiple parts when downloaded from Overdrive with each part containing a certain number of chapters. Each part also includes a special metadata tag, called `OverDrive MediaMarkers` that describes the timestamps for those chapters (relative to the part) in an XML format.

This PR adds support to ABS to natively parse the `OverDrive MediaMarkers` metadata, and offer the option to use it to populate the chapter metadata in ABS during scanning. Users can toggle this functionality as a server setting from the server settings UI. 

Once enabled, it behaves similarly to other metadata scanning:
- For existing books, it requires a force re-scan (either individual, or at the library level) to apply
- For new books, it will take place automatically upon a regular scan, a force re-scan, or the automated watcher scan
- For new and existing books that do not have this meta tag, ABS will fall back to the standard chapter logic

 
**Future Work**
There are two things I'd like to look at in future PRs:
1. I'm not super happy with how `Book` is now having to be made aware of server settings. I'd like to continue extracting out the logic for setChapters further, and creating `server/parsers/chapters`, which will hold different ways for us to parse and generate chapter information. This will then also allow us to handle decision logic on which parser further up in one of the scanners, outside of `Book`, and inject it directly as a dependency.
2. Bringing this to the client-side experience. Particularly the edit-chapter page, to allow users to leverage this on a per-book basis without having to enable it globally

