### PR TITLE
Properly support multiple narrators when Matching (#719)

### DIFF
--- a/client/components/modals/item/tabs/Match.vue
+++ b/client/components/modals/item/tabs/Match.vue
@@ -428,7 +428,7 @@ export default {
             )
             updatePayload.metadata.authors = authorPayload
           } else if (key === 'narrator') {
-            updatePayload.metadata.narrators = [this.selectedMatch[key]]
+            updatePayload.metadata.narrators = this.selectedMatch[key].split(',').map((v) => v.trim())
           } else if (key === 'genres') {
             updatePayload.metadata.genres = this.selectedMatch[key].split(',').map((v) => v.trim())
           } else if (key === 'tags') {


### PR DESCRIPTION
This commit fixes #719 adds support for multiple narrators when matching. We were accidentally missing a split in the same way we handle it for genres and tags.

Screenshot of this fix with the ASIN data linked in #719:

![image](https://user-images.githubusercontent.com/13617455/173984724-880545d5-6ac2-4004-a0e3-c35e2b33a118.png)
