### PR TITLE
Update pills so that they handle multi-line properly

### DIFF
--- a/client/components/ui/MultiSelect.vue
+++ b/client/components/ui/MultiSelect.vue
@@ -4,7 +4,7 @@
     <div ref="wrapper" class="relative">
       <form @submit.prevent="submitForm">
         <div ref="inputWrapper" style="min-height: 36px" class="flex-wrap relative w-full shadow-sm flex items-center border border-gray-600 rounded px-2 py-1" :class="wrapperClass" @click.stop.prevent="clickWrapper" @mouseup.stop.prevent @mousedown.prevent>
-          <div v-for="item in selected" :key="item" class="rounded-full px-2 py-1 mx-0.5 text-xs bg-bg flex flex-nowrap whitespace-nowrap items-center relative">
+          <div v-for="item in selected" :key="item" class="rounded-full px-2 py-1 mx-0.5 text-xs bg-bg flex flex-nowrap break-all items-center relative">
             <div class="w-full h-full rounded-full absolute top-0 left-0 opacity-0 hover:opacity-100 px-1 bg-bg bg-opacity-75 flex items-center justify-end cursor-pointer">
               <span v-if="showEdit" class="material-icons text-white hover:text-warning" style="font-size: 1.1rem" @click.stop="editItem(item)">edit</span>
               <span class="material-icons text-white hover:text-error" style="font-size: 1.1rem" @click.stop="removeItem(item)">close</span>


### PR DESCRIPTION
In the unlikely chance that someone has quite a long entry for one of the fields that leverage pills, the current behavior is to have it run off out of the modal. This commit updates that to support breaking it to multiple lines.

Before (if long enough, it will just keep going off the modal/screen):
![image](https://user-images.githubusercontent.com/13617455/173996287-6cc34da4-29a8-4a6e-80f9-b19a755e33c1.png)

After:
![image](https://user-images.githubusercontent.com/13617455/173996406-e218becf-994f-4ed5-8cf2-7bd0af612d52.png)

After (with #732 ):
![image](https://user-images.githubusercontent.com/13617455/173996489-028a3342-a357-486b-b070-b43bee7a9821.png)



