### PR TITLE
Add npm commands to build local docker containers

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
     "build-win": "npm run client && pkg -t node16-win-x64 -o ./dist/win/audiobookshelf -C GZip .",
     "build-linux": "build/linuxpackager",
     "docker": "docker buildx build --platform linux/amd64,linux/arm64,linux/arm/v7 --push .  -t advplyr/audiobookshelf",
+    "docker-amd64-local":"docker buildx build --platform linux/amd64 --load .  -t advplyr/audiobookshelf-amd64-local",
+    "docker-arm64-local":"docker buildx build --platform linux/arm64 --load .  -t advplyr/audiobookshelf-arm64-local",
+    "docker-armv7-local":"docker buildx build --platform linux/arm/v7 --load .  -t advplyr/audiobookshelf-armv7-local",
     "deploy": "node dist/autodeploy"
   },
   "bin": "prod.js",


### PR DESCRIPTION
I wanted to spin up a local instance of ABS with the latest changes, so I added a few local build options for docker. `--load .` will automatically load the image in to your local docker image repo after building
```
✔≻ npm run docker-amd64-local

> audiobookshelf@2.0.21 docker-amd64-local
> docker buildx build --platform linux/amd64 --load .  -t advplyr/audiobookshelf-amd64-local

[+] Building 2.0s (16/16) FINISHED                                                                                                                                                           
 => [internal] load .dockerignore                                                                                                                                                       0.0s
 => => transferring context: 189B                                                                                                                                                       0.0s
 => [internal] load build definition from Dockerfile                                                                                                                                    0.1s
 => => transferring dockerfile: 636B                                                                                                                                                    0.0s
 => [internal] load metadata for docker.io/library/node:16-alpine                                                                                                                       0.8s
 => [build 1/5] FROM docker.io/library/node:16-alpine@sha256:c785e617c8d7015190c0d41af52cc69be8a16e3d9eb7cb21f0bb58bcfca14d6b                                                           0.0s
 => => resolve docker.io/library/node:16-alpine@sha256:c785e617c8d7015190c0d41af52cc69be8a16e3d9eb7cb21f0bb58bcfca14d6b                                                                 0.0s
 => [internal] load build context                                                                                                                                                       0.8s
 => => transferring context: 3.42MB                                                                                                                                                     0.7s
 => CACHED [stage-1 2/6] RUN apk update &&     apk add --no-cache --update     curl     tzdata     ffmpeg                                                                               0.0s
 => CACHED [build 2/5] WORKDIR /client                                                                                                                                                  0.0s
 => CACHED [build 3/5] COPY /client /client                                                                                                                                             0.0s
 => CACHED [build 4/5] RUN npm ci && npm cache clean --force                                                                                                                            0.0s
 => CACHED [build 5/5] RUN npm run generate                                                                                                                                             0.0s
 => CACHED [stage-1 3/6] COPY --from=build /client/dist /client/dist                                                                                                                    0.0s
 => CACHED [stage-1 4/6] COPY index.js package* /                                                                                                                                       0.0s
 => CACHED [stage-1 5/6] COPY server server                                                                                                                                             0.0s
 => CACHED [stage-1 6/6] RUN npm ci --only=production                                                                                                                                   0.0s
 => exporting to oci image format                                                                                                                                                       0.4s
 => => exporting layers                                                                                                                                                                 0.0s
 => => exporting manifest sha256:beded098fed9ef6be54664e0fe98a06f2977ff804914d28fac9d8986231b02ff                                                                                       0.0s
 => => exporting config sha256:cc555a23f74dc0c353227f778682b867c3d75ef308a28727b2c83da1de48450e                                                                                         0.0s
 => => sending tarball                                                                                                                                                                  0.3s
 => importing to docker                                                                                                                                                                 0.0s
```

Local image:
```
✔≻ docker images
REPOSITORY                           TAG               IMAGE ID       CREATED         SIZE
advplyr/audiobookshelf-amd64-local   latest            cc555a23f74d   4 minutes ago   250MB
```
