### PR TITLE
Update BookFinder.js: Retry Search with Clean Title and Author if No Books Found

### DIFF
--- a/server/finders/BookFinder.js
+++ b/server/finders/BookFinder.js
@@ -209,9 +209,13 @@ class BookFinder {
     }
 
     if (!books.length && !options.currentlyTryingCleaned) {
+      var cleanedTitle = this.cleanTitleForCompares(title)
+      var cleanedAuthor = this.cleanAuthorForCompares(author)
+      if (cleanedTitle == title && cleanedAuthor == author) return books
+
       Logger.debug(`Book Search, no matches.. checking cleaned title and author`)
       options.currentlyTryingCleaned = true
-      return this.search(provider, this.cleanTitleForCompares(title), this.cleanAuthorForCompares(author), isbn, asin, options)
+      return this.search(provider, cleanedTitle, cleanedAuthor, isbn, asin, options)
     }
 
     if (["google", "audible", "itunes"].includes(provider)) return books


### PR DESCRIPTION
I got the idea from @sxb1n9 and his PR here https://github.com/advplyr/audiobookshelf/pull/680

My audiobooks with (unabridged) in the title never get picked up by the search function. This will fix that as well as in cases like "Ender's Game (Ender's Saga)"

Pro: 
 - This won't run unless no books were found the first time around
 - This uses existing functions `cleanTitleForCompares` and `cleanAuthorForCompares`  

Con:
 - Twice the API calls if no books are found the first time around  


https://user-images.githubusercontent.com/39509289/174258568-614ff5cb-16ec-4cb4-8960-c31e91184b59.mp4
