### PR TITLE
Fetch author photo from external URL

### DIFF
--- a/client/components/modals/authors/EditModal.vue
+++ b/client/components/modals/authors/EditModal.vue
@@ -25,8 +25,8 @@
                 <ui-text-input-with-label v-model="authorCopy.asin" :disabled="processing" label="ASIN" />
               </div>
             </div>
-            <div class="p-2" v-show="!author.imagePath">
-              <ui-text-input-with-label v-model="authorCopy.imageUrl" :disabled="processing" label="Photo URL" />
+            <div class="p-2">
+              <ui-text-input-with-label v-model="authorCopy.imagePath" :disabled="processing" label="Photo Path/URL" />
             </div>
             <div class="p-2">
               <ui-textarea-with-label v-model="authorCopy.description" :disabled="processing" label="Description" :rows="8" />
@@ -46,20 +46,13 @@
 
 <script>
 export default {
-  // props: {
-  //   value: Boolean,
-  //   author: {
-  //     type: Object,
-  //     default: () => {}
-  //   }
-  // },
   data() {
     return {
       authorCopy: {
         name: '',
         asin: '',
         description: '',
-        imageUrl: undefined
+        imagePath: ''
       },
       processing: false
     }
@@ -99,9 +92,10 @@ export default {
       this.authorCopy.name = this.author.name
       this.authorCopy.asin = this.author.asin
       this.authorCopy.description = this.author.description
+      this.authorCopy.imagePath = this.author.imagePath
     },
     async submitForm() {
-      var keysToCheck = ['name', 'asin', 'description', 'imageUrl']
+      var keysToCheck = ['name', 'asin', 'description', 'imagePath']
       var updatePayload = {}
       keysToCheck.forEach((key) => {
         if (this.authorCopy[key] !== this.author[key]) {
@@ -122,7 +116,6 @@ export default {
         if (result.updated) {
           this.$toast.success('Author updated')
           this.show = false
-          this.authorCopy.imageUrl = undefined
         } else this.$toast.info('No updates were needed')
       }
       this.processing = false

--- a/client/components/modals/authors/EditModal.vue
+++ b/client/components/modals/authors/EditModal.vue
@@ -25,6 +25,9 @@
                 <ui-text-input-with-label v-model="authorCopy.asin" :disabled="processing" label="ASIN" />
               </div>
             </div>
+            <div class="p-2" v-show="!author.imagePath">
+              <ui-text-input-with-label v-model="authorCopy.imageUrl" :disabled="processing" label="Photo URL" />
+            </div>
             <div class="p-2">
               <ui-textarea-with-label v-model="authorCopy.description" :disabled="processing" label="Description" :rows="8" />
             </div>
@@ -55,7 +58,8 @@ export default {
       authorCopy: {
         name: '',
         asin: '',
-        description: ''
+        description: '',
+        imageUrl: undefined
       },
       processing: false
     }
@@ -97,7 +101,7 @@ export default {
       this.authorCopy.description = this.author.description
     },
     async submitForm() {
-      var keysToCheck = ['name', 'asin', 'description']
+      var keysToCheck = ['name', 'asin', 'description', 'imageUrl']
       var updatePayload = {}
       keysToCheck.forEach((key) => {
         if (this.authorCopy[key] !== this.author[key]) {
@@ -118,6 +122,7 @@ export default {
         if (result.updated) {
           this.$toast.success('Author updated')
           this.show = false
+          this.authorCopy.imageUrl = undefined
         } else this.$toast.info('No updates were needed')
       }
       this.processing = false

--- a/server/controllers/AuthorController.js
+++ b/server/controllers/AuthorController.js
@@ -72,6 +72,17 @@ class AuthorController {
     var authorNameUpdate = payload.name !== undefined && payload.name !== req.author.name
 
     var hasUpdated = req.author.update(payload)
+
+    // Fetch author image from remote URL if no current image exists
+    if (payload.imageUrl !== undefined && !req.author.imagePath) {
+      var imageData = await this.authorFinder.saveAuthorImage(req.author.id, payload.imageUrl)
+      if (imageData) {
+        req.author.imagePath = imageData.path
+        req.author.relImagePath = imageData.relPath
+        hasUpdated = hasUpdated || true;
+      }
+    }
+
     if (hasUpdated) {
       if (authorNameUpdate) { // Update author name on all books
         var itemsWithAuthor = this.db.libraryItems.filter(li => li.mediaType === 'book' && li.media.metadata.hasAuthor(req.author.id))

--- a/server/finders/AuthorFinder.js
+++ b/server/finders/AuthorFinder.js
@@ -4,6 +4,7 @@ const Path = require('path')
 const Audnexus = require('../providers/Audnexus')
 
 const { downloadFile } = require('../utils/fileUtils')
+const filePerms = require('../utils/filePerms')
 
 class AuthorFinder {
   constructor() {
@@ -38,7 +39,11 @@ class AuthorFinder {
   async saveAuthorImage(authorId, url) {
     var authorDir = this.AuthorPath
     var relAuthorDir = Path.posix.join('/metadata', 'authors')
-    await fs.ensureDir(authorDir)
+
+    if (!await fs.pathExists(authorDir)) {
+      await fs.ensureDir(authorDir)
+      await filePerms.setDefault(authorDir)
+    }
 
     var imageExtension = url.toLowerCase().split('.').pop()
     var ext = imageExtension === 'png' ? 'png' : 'jpg'


### PR DESCRIPTION
At the moment, there is no easy way to add a photo for an author, if one isn't found during a (quick)match

This PR adds a new text field 'Photo URL' on the author edit modal, shown only if there is no existing image for an author. When submitted the image is saved from the URL provided, using the existing AuthorFinder.saveAuthorImage() method.

![2022-06-18 17-01-08](https://user-images.githubusercontent.com/781215/174447289-bfb8ceb7-2429-4282-8471-913a76db8ff9.gif)

