### PR TITLE
Fix placard sizes so "Continue Listening" fits

### DIFF
--- a/client/components/app/BookShelfRow.vue
+++ b/client/components/app/BookShelfRow.vue
@@ -25,7 +25,7 @@
       </div>
     </div>
 
-    <div class="absolute text-center categoryPlacard font-book transform z-30 bottom-0.5 left-4 md:left-8 w-36 rounded-md" style="height: 22px">
+    <div class="absolute text-center categoryPlacard font-book transform z-30 bottom-px left-4 md:left-8 w-44 rounded-md" style="height: 22px">
       <div class="w-full h-full shinyBlack flex items-center justify-center rounded-sm border">
         <p class="transform text-sm">{{ shelf.label }}</p>
       </div>


### PR DESCRIPTION
I noticed in the non-alternative view that "Continue Listening" was wrapping. This PR updates the placards to be large enough to not force a wrap. I also moved the placards down 1px so they align better with the shelf

Before:
![image](https://user-images.githubusercontent.com/13617455/174471612-4f7bda2f-0528-4b24-bdbd-c94313ad8e8b.png)

After:
![image](https://user-images.githubusercontent.com/13617455/174471619-477c6f37-90a1-4dbb-a88a-2c821bbe0649.png)
