### PR TITLE
Fix padding on "Remove All Library Items" button

### DIFF
--- a/client/pages/config/index.vue
+++ b/client/pages/config/index.vue
@@ -171,7 +171,7 @@
 
     <div class="flex items-center py-4">
       <ui-btn color="bg" small :padding-x="4" class="hidden lg:block mr-2" :loading="isPurgingCache" @click="purgeCache">Purge Cache</ui-btn>
-      <ui-btn color="bg" small :padding-x="4" class="hidden lg:block" :loading="isResettingLibraryItems" @click="resetLibraryItems">Remove All Library Items</ui-btn>
+      <ui-btn color="bg" small :padding-x="4" class="hidden lg:block mr-2" :loading="isResettingLibraryItems" @click="resetLibraryItems">Remove All Library Items</ui-btn>
       <div class="flex-grow" />
       <p class="pr-2 text-sm font-book text-yellow-400">
         Report bugs, request features, and contribute on


### PR DESCRIPTION
Noticed this button didn't have proper right padding.

Before:
![image](https://user-images.githubusercontent.com/13617455/174471857-733ca158-9b5c-4d47-a355-978b929034da.png)

After:
![image](https://user-images.githubusercontent.com/13617455/174471850-ef29ef39-d348-45dc-97d7-d5dd10d4eacb.png)
