### PR TITLE
Update UsersTable styling to match other tables

### DIFF
--- a/client/components/tables/UsersTable.vue
+++ b/client/components/tables/UsersTable.vue
@@ -191,10 +191,6 @@ export default {
   padding: 0px 8px;
 }
 
-#accounts tr:first-child {
-  background-color: #272727;
-}
-
 #accounts tr:nth-child(even) {
   background-color: #373838;
 }

--- a/client/components/tables/UsersTable.vue
+++ b/client/components/tables/UsersTable.vue
@@ -191,8 +191,16 @@ export default {
   padding: 0px 8px;
 }
 
+#accounts tr:first-child {
+  background-color: #272727;
+}
+
 #accounts tr:nth-child(even) {
-  background-color: #3a3a3a;
+  background-color: #373838;
+}
+
+#accounts tr:nth-child(odd) {
+  background-color: #2f2f2f;
 }
 
 #accounts tr:hover {
@@ -204,6 +212,6 @@ export default {
   font-weight: 600;
   padding-top: 5px;
   padding-bottom: 5px;
-  background-color: #333;
+  background-color: #272727
 }
 </style>


### PR DESCRIPTION
Continuing in the list of PRs to align all of these pages together, this one updates the Users table to have a matching visual UI to the Sessions table. This is just to make it match -- as mentioned in the sessions table PR, there is some good future PR work available here to extract all of this out so we aren't duplicating it across tables across pages.

Before:
![image](https://user-images.githubusercontent.com/13617455/174505669-022549fc-c77b-47b9-a220-0372f359784e.png)

After:
![image](https://user-images.githubusercontent.com/13617455/174505660-f8ffa662-16d1-404c-a025-53d135bee270.png)
