### PR TITLE
Update Settings page UI

### DIFF
--- a/client/pages/config/index.vue
+++ b/client/pages/config/index.vue
@@ -5,9 +5,9 @@
         <h1 class="text-xl">Settings</h1>
       </div>
 
-      <div class="sm:flex">
-        <div id="firstcolumn" class="flex-1">
-          <div>
+      <div class="lg:flex">
+        <div class="flex-1">
+          <div class="pt-4">
             <h2 class="font-semibold">General</h2>
           </div>
           <div class="flex items-end py-2">
@@ -34,7 +34,7 @@
             <ui-toggle-switch v-model="newServerSettings.sortingIgnorePrefix" :disabled="updatingServerSettings" @input="(val) => updateSettingsKey('sortingIgnorePrefix', val)" />
             <ui-tooltip :text="tooltips.sortingIgnorePrefix">
               <p class="pl-4">
-                Ignore prefixes when sorting title and series
+                Ignore prefixes when sorting
                 <span class="material-icons icon-text text-sm">info_outlined</span>
               </p>
             </ui-tooltip>
@@ -48,7 +48,7 @@
             <p class="pl-4">Chromecast support</p>
           </div>
 
-          <div class="mt-4">
+          <div class="pt-4">
             <h2 class="font-semibold">Display</h2>
           </div>
 
@@ -73,13 +73,13 @@
           </div>
 
           <div class="flex items-center py-2">
-            <p class="pr-4 ">Date Format</p>
+            <p class="pr-4">Date Format</p>
             <ui-dropdown v-model="newServerSettings.dateFormat" :items="dateFormats" small class="max-w-40" @input="(val) => updateSettingsKey('dateFormat', val)" />
           </div>
         </div>
 
-        <div id="secondcolumn" class="flex-1">
-          <div>
+        <div class="flex-1">
+          <div class="pt-4">
             <h2 class="font-semibold">Scanner</h2>
           </div>
 
@@ -108,20 +108,20 @@
           </div>
 
           <div class="flex items-center py-2">
-            <ui-toggle-switch v-model="newServerSettings.scannerPreferAudioMetadata" :disabled="updatingServerSettings" @input="(val) => updateSettingsKey('scannerPreferAudioMetadata', val)" />
-            <ui-tooltip :text="tooltips.scannerPreferAudioMetadata">
+            <ui-toggle-switch v-model="newServerSettings.scannerPreferOverdriveMediaMarker" :disabled="updatingServerSettings" @input="(val) => updateSettingsKey('scannerPreferOverdriveMediaMarker', val)" />
+            <ui-tooltip :text="tooltips.scannerPreferOverdriveMediaMarker">
               <p class="pl-4">
-                Prefer audio metadata
+                Use Overdrive Media Markers for chapters
                 <span class="material-icons icon-text text-sm">info_outlined</span>
               </p>
             </ui-tooltip>
           </div>
 
           <div class="flex items-center py-2">
-            <ui-toggle-switch v-model="newServerSettings.scannerPreferOverdriveMediaMarker" :disabled="updatingServerSettings" @input="(val) => updateSettingsKey('scannerPreferOverdriveMediaMarker', val)" />
-            <ui-tooltip :text="tooltips.scannerPreferOverdriveMediaMarker">
+            <ui-toggle-switch v-model="newServerSettings.scannerPreferAudioMetadata" :disabled="updatingServerSettings" @input="(val) => updateSettingsKey('scannerPreferAudioMetadata', val)" />
+            <ui-tooltip :text="tooltips.scannerPreferAudioMetadata">
               <p class="pl-4">
-                Prefer Overdrive Media Markers for chapters
+                Prefer audio metadata
                 <span class="material-icons icon-text text-sm">info_outlined</span>
               </p>
             </ui-tooltip>
@@ -157,7 +157,7 @@
             </ui-tooltip>
           </div>
 
-          <div class="mt-4">
+          <div class="pt-4">
             <h2 class="font-semibold">Experimental Features</h2>
           </div>
 
@@ -184,7 +184,6 @@
               </p>
             </ui-tooltip>
           </div>
-
         </div>
       </div>
     </div>
@@ -231,10 +230,10 @@
 
     <prompt-dialog v-model="showConfirmPurgeCache" :width="675">
       <div class="px-4 w-full text-sm py-6 rounded-lg bg-bg shadow-lg border border-black-300">
-        <p class="text-error  font-semibold">Important Notice!</p>
-        <p class=" my-2 text-center">Purge cache will delete the entire directory at <span class="font-mono">/metadata/cache</span>.</p>
+        <p class="text-error font-semibold">Important Notice!</p>
+        <p class="my-2 text-center">Purge cache will delete the entire directory at <span class="font-mono">/metadata/cache</span>.</p>
 
-        <p class=" text-center mb-8">Are you sure you want to remove the cache directory?</p>
+        <p class="text-center mb-8">Are you sure you want to remove the cache directory?</p>
         <div class="flex px-1 items-center">
           <ui-btn color="primary" @click="showConfirmPurgeCache = false">Nevermind</ui-btn>
           <div class="flex-grow" />
@@ -268,7 +267,7 @@ export default {
         storeCoverWithItem: 'By default covers are stored in /metadata/items, enabling this setting will store covers in your library item folder. Only one file named "cover" will be kept',
         storeMetadataWithItem: 'By default metadata files are stored in /metadata/items, enabling this setting will store metadata files in your library item folders. Uses .abs file extension',
         coverAspectRatio: 'Prefer to use square covers over standard 1.6:1 book covers',
-        enableEReader: 'E-reader is still a work in progress, but use this setting to open it up to all your users (or use the "Experimental Features" toggle below just for you)',
+        enableEReader: 'E-reader is still a work in progress, but use this setting to open it up to all your users (or use the "Experimental Features" toggle just for use by you)',
         scannerPreferOverdriveMediaMarker: 'MP3 files from Overdrive come with chapter timings embedded as custom metadata. Enabling this will use these tags for chapter timings automatically'
       },
       showConfirmPurgeCache: false

--- a/client/pages/config/index.vue
+++ b/client/pages/config/index.vue
@@ -1,20 +1,21 @@
 <template>
   <div>
     <!-- <div class="h-0.5 bg-primary bg-opacity-50 w-full" /> -->
-    <div class="sm:flex bg-bg rounded-md shadow-lg border border-white border-opacity-5 p-4 mb-8" style="background-color: ">
+    
+    <div class="bg-bg rounded-md shadow-lg border border-white border-opacity-5 p-4 mb-8" style="background-color: ">
+    <div class="" style="background-color: ">
+      <h1 class="text-xl mb-2">Settings</h1>
+    </div>
 
+    <div class="sm:flex">
       <div id="firstcolumn" class="flex-1" style="background-color: ">
-        <div class="mb-2">
-          <h1 class="text-xl">Settings</h1>
-        </div>
-
-        <div class="mb-2">
-          <h1 class="text-xl font-semibold">General</h1>
+        <div class="">
+          <h2 class="font-semibold">General</h2>
         </div>
           <div class="flex items-center py-2">
             <ui-toggle-switch v-model="newServerSettings.storeCoverWithItem" :disabled="updatingServerSettings" @input="(val) => updateSettingsKey('storeCoverWithItem', val)" />
             <ui-tooltip :text="tooltips.storeCoverWithItem">
-              <p class="pl-4 text-lg">
+              <p class="pl-4">
                 Store covers with item
                 <span class="material-icons icon-text">info_outlined</span>
               </p>
@@ -24,7 +25,7 @@
           <div class="flex items-center py-2">
             <ui-toggle-switch v-model="newServerSettings.storeMetadataWithItem" :disabled="updatingServerSettings" @input="(val) => updateSettingsKey('storeMetadataWithItem', val)" />
             <ui-tooltip :text="tooltips.storeMetadataWithItem">
-              <p class="pl-4 text-lg">
+              <p class="pl-4">
                 Store metadata with item
                 <span class="material-icons icon-text">info_outlined</span>
               </p>
@@ -34,7 +35,7 @@
           <div class="flex items-center py-2">
             <ui-toggle-switch v-model="newServerSettings.sortingIgnorePrefix" :disabled="updatingServerSettings" @input="(val) => updateSettingsKey('sortingIgnorePrefix', val)" />
             <ui-tooltip :text="tooltips.sortingIgnorePrefix">
-              <p class="pl-4 text-lg">
+              <p class="pl-4">
                 Ignore prefixes when sorting title and series
                 <span class="material-icons icon-text">info_outlined</span>
               </p>
@@ -46,17 +47,17 @@
 
           <div class="flex items-center py-2">
             <ui-toggle-switch v-model="newServerSettings.chromecastEnabled" :disabled="updatingServerSettings" @input="(val) => updateSettingsKey('chromecastEnabled', val)" />
-            <p class="pl-4 text-lg">Enable Chromecast</p>
+            <p class="pl-4">Enable Chromecast</p>
           </div>
 
-        <div class="flex items-center mb-2 mt-8">
-          <h1 class="text-xl font-semibold">Display</h1>
+        <div class="mt-4">
+          <h2 class="font-semibold">Display</h2>
         </div>
 
         <div class="flex items-center py-2">
           <ui-toggle-switch v-model="useSquareBookCovers" :disabled="updatingServerSettings" @input="updateBookCoverAspectRatio" />
           <ui-tooltip :text="tooltips.coverAspectRatio">
-            <p class="pl-4 text-lg">
+            <p class="pl-4">
               Use square book covers
               <span class="material-icons icon-text">info_outlined</span>
             </p>
@@ -66,7 +67,7 @@
         <div class="flex items-center py-2">
           <ui-toggle-switch v-model="useAlternativeBookshelfView" :disabled="updatingServerSettings" @input="updateAlternativeBookshelfView" />
           <ui-tooltip :text="tooltips.bookshelfView">
-            <p class="pl-4 text-lg">
+            <p class="pl-4">
               Use alternative bookshelf view
               <span class="material-icons icon-text">info_outlined</span>
             </p>
@@ -74,20 +75,20 @@
         </div>
 
         <div class="flex items-center py-2">
-          <p class="pr-4 text-lg">Date Format</p>
+          <p class="pr-4 ">Date Format</p>
           <ui-dropdown v-model="newServerSettings.dateFormat" :items="dateFormats" small class="max-w-40" @input="(val) => updateSettingsKey('dateFormat', val)" />
         </div>
       </div>
 
       <div id="secondcolumn" class="flex-1" style="background-color: ">
-        <div class="flex items-center mb-2 mt-8">
-          <h1 class="text-xl font-semibold">Scanner</h1>
+        <div class="">
+          <h2 class="font-semibold">Scanner</h2>
         </div>
 
         <div class="flex items-center py-2">
           <ui-toggle-switch v-model="newServerSettings.scannerParseSubtitle" :disabled="updatingServerSettings" @input="(val) => updateSettingsKey('scannerParseSubtitle', val)" />
           <ui-tooltip :text="tooltips.scannerParseSubtitle">
-            <p class="pl-4 text-lg">
+            <p class="pl-4">
               Scanner parse subtitles
               <span class="material-icons icon-text">info_outlined</span>
             </p>
@@ -97,7 +98,7 @@
         <div class="flex items-center py-2">
           <ui-toggle-switch v-model="newServerSettings.scannerFindCovers" :disabled="updatingServerSettings" @input="(val) => updateSettingsKey('scannerFindCovers', val)" />
           <ui-tooltip :text="tooltips.scannerFindCovers">
-            <p class="pl-4 text-lg">
+            <p class="pl-4">
               Scanner find covers
               <span class="material-icons icon-text">info_outlined</span>
             </p>
@@ -111,7 +112,7 @@
         <div class="flex items-center py-2">
           <ui-toggle-switch v-model="newServerSettings.scannerPreferAudioMetadata" :disabled="updatingServerSettings" @input="(val) => updateSettingsKey('scannerPreferAudioMetadata', val)" />
           <ui-tooltip :text="tooltips.scannerPreferAudioMetadata">
-            <p class="pl-4 text-lg">
+            <p class="pl-4">
               Scanner prefer audio metadata
               <span class="material-icons icon-text">info_outlined</span>
             </p>
@@ -121,7 +122,7 @@
         <div class="flex items-center py-2">
           <ui-toggle-switch v-model="newServerSettings.scannerPreferOverdriveMediaMarker" :disabled="updatingServerSettings" @input="(val) => updateSettingsKey('scannerPreferOverdriveMediaMarker', val)" />
           <ui-tooltip :text="tooltips.scannerPreferOverdriveMediaMarker">
-            <p class="pl-4 text-lg">
+            <p class="pl-4">
               Scanner prefer Overdrive Media Markers for chapters
               <span class="material-icons icon-text">info_outlined</span>
             </p>
@@ -131,7 +132,7 @@
         <div class="flex items-center py-2">
           <ui-toggle-switch v-model="newServerSettings.scannerPreferOpfMetadata" :disabled="updatingServerSettings" @input="(val) => updateSettingsKey('scannerPreferOpfMetadata', val)" />
           <ui-tooltip :text="tooltips.scannerPreferOpfMetadata">
-            <p class="pl-4 text-lg">
+            <p class="pl-4">
               Scanner prefer OPF metadata
               <span class="material-icons icon-text">info_outlined</span>
             </p>
@@ -141,7 +142,7 @@
         <div class="flex items-center py-2">
           <ui-toggle-switch v-model="newServerSettings.scannerPreferMatchedMetadata" :disabled="updatingServerSettings" @input="(val) => updateSettingsKey('scannerPreferMatchedMetadata', val)" />
           <ui-tooltip :text="tooltips.scannerPreferMatchedMetadata">
-            <p class="pl-4 text-lg">
+            <p class="pl-4">
               Scanner prefer matched metadata
               <span class="material-icons icon-text">info_outlined</span>
             </p>
@@ -151,22 +152,22 @@
         <div class="flex items-center py-2">
           <ui-toggle-switch v-model="newServerSettings.scannerDisableWatcher" :disabled="updatingServerSettings" @input="(val) => updateSettingsKey('scannerDisableWatcher', val)" />
           <ui-tooltip :text="tooltips.scannerDisableWatcher">
-            <p class="pl-4 text-lg">
+            <p class="pl-4">
               Disable Watcher
               <span class="material-icons icon-text">info_outlined</span>
             </p>
           </ui-tooltip>
         </div>
 
-        <div class="flex items-center mb-2 mt-8">
-          <h1 class="text-xl font-semibold">Experimental Features</h1>
+        <div class="mt-4">
+          <h2 class="font-semibold">Experimental Features</h2>
         </div>
 
         <div>
           <div class="flex items-center">
             <ui-toggle-switch v-model="showExperimentalFeatures" />
             <ui-tooltip :text="tooltips.experimentalFeatures">
-              <p class="pl-4 text-lg">
+              <p class="pl-4">
                 Experimental Features
                 <a href="https://github.com/advplyr/audiobookshelf/discussions/75" target="_blank">
                   <span class="material-icons icon-text">info_outlined</span>
@@ -179,13 +180,14 @@
         <div class="flex items-center py-2">
           <ui-toggle-switch v-model="newServerSettings.enableEReader" :disabled="updatingServerSettings" @input="(val) => updateSettingsKey('enableEReader', val)" />
           <ui-tooltip :text="tooltips.enableEReader">
-            <p class="pl-4 text-lg">
+            <p class="pl-4">
               Enable e-reader for all users
               <span class="material-icons icon-text">info_outlined</span>
             </p>
           </ui-tooltip>
         </div>
-        
+
+      </div>
       </div>
     </div>
 
@@ -232,10 +234,10 @@
 
     <prompt-dialog v-model="showConfirmPurgeCache" :width="675">
       <div class="px-4 w-full text-sm py-6 rounded-lg bg-bg shadow-lg border border-black-300">
-        <p class="text-error text-lg font-semibold">Important Notice!</p>
-        <p class="text-lg my-2 text-center">Purge cache will delete the entire directory at <span class="font-mono">/metadata/cache</span>.</p>
+        <p class="text-error  font-semibold">Important Notice!</p>
+        <p class=" my-2 text-center">Purge cache will delete the entire directory at <span class="font-mono">/metadata/cache</span>.</p>
 
-        <p class="text-lg text-center mb-8">Are you sure you want to remove the cache directory?</p>
+        <p class=" text-center mb-8">Are you sure you want to remove the cache directory?</p>
         <div class="flex px-1 items-center">
           <ui-btn color="primary" @click="showConfirmPurgeCache = false">Nevermind</ui-btn>
           <div class="flex-grow" />

--- a/client/pages/config/index.vue
+++ b/client/pages/config/index.vue
@@ -1,23 +1,21 @@
 <template>
   <div>
-    <!-- <div class="h-0.5 bg-primary bg-opacity-50 w-full" /> -->
-    
-    <div class="bg-bg rounded-md shadow-lg border border-white border-opacity-5 p-4 mb-8" style="background-color: ">
-    <div class="" style="background-color: ">
-      <h1 class="text-xl mb-2">Settings</h1>
-    </div>
+    <div class="bg-bg rounded-md shadow-lg border border-white border-opacity-5 p-4 mb-2">
+      <div class="mb-2">
+        <h1 class="text-xl">Settings</h1>
+      </div>
 
-    <div class="sm:flex">
-      <div id="firstcolumn" class="flex-1" style="background-color: ">
-        <div class="">
-          <h2 class="font-semibold">General</h2>
-        </div>
-          <div class="flex items-center py-2">
+      <div class="sm:flex">
+        <div id="firstcolumn" class="flex-1">
+          <div>
+            <h2 class="font-semibold">General</h2>
+          </div>
+          <div class="flex items-end py-2">
             <ui-toggle-switch v-model="newServerSettings.storeCoverWithItem" :disabled="updatingServerSettings" @input="(val) => updateSettingsKey('storeCoverWithItem', val)" />
             <ui-tooltip :text="tooltips.storeCoverWithItem">
               <p class="pl-4">
                 Store covers with item
-                <span class="material-icons icon-text">info_outlined</span>
+                <span class="material-icons icon-text text-sm">info_outlined</span>
               </p>
             </ui-tooltip>
           </div>
@@ -27,7 +25,7 @@
             <ui-tooltip :text="tooltips.storeMetadataWithItem">
               <p class="pl-4">
                 Store metadata with item
-                <span class="material-icons icon-text">info_outlined</span>
+                <span class="material-icons icon-text text-sm">info_outlined</span>
               </p>
             </ui-tooltip>
           </div>
@@ -37,7 +35,7 @@
             <ui-tooltip :text="tooltips.sortingIgnorePrefix">
               <p class="pl-4">
                 Ignore prefixes when sorting title and series
-                <span class="material-icons icon-text">info_outlined</span>
+                <span class="material-icons icon-text text-sm">info_outlined</span>
               </p>
             </ui-tooltip>
           </div>
@@ -47,147 +45,147 @@
 
           <div class="flex items-center py-2">
             <ui-toggle-switch v-model="newServerSettings.chromecastEnabled" :disabled="updatingServerSettings" @input="(val) => updateSettingsKey('chromecastEnabled', val)" />
-            <p class="pl-4">Enable Chromecast</p>
+            <p class="pl-4">Chromecast support</p>
           </div>
 
-        <div class="mt-4">
-          <h2 class="font-semibold">Display</h2>
-        </div>
+          <div class="mt-4">
+            <h2 class="font-semibold">Display</h2>
+          </div>
 
-        <div class="flex items-center py-2">
-          <ui-toggle-switch v-model="useSquareBookCovers" :disabled="updatingServerSettings" @input="updateBookCoverAspectRatio" />
-          <ui-tooltip :text="tooltips.coverAspectRatio">
-            <p class="pl-4">
-              Use square book covers
-              <span class="material-icons icon-text">info_outlined</span>
-            </p>
-          </ui-tooltip>
-        </div>
-
-        <div class="flex items-center py-2">
-          <ui-toggle-switch v-model="useAlternativeBookshelfView" :disabled="updatingServerSettings" @input="updateAlternativeBookshelfView" />
-          <ui-tooltip :text="tooltips.bookshelfView">
-            <p class="pl-4">
-              Use alternative bookshelf view
-              <span class="material-icons icon-text">info_outlined</span>
-            </p>
-          </ui-tooltip>
-        </div>
-
-        <div class="flex items-center py-2">
-          <p class="pr-4 ">Date Format</p>
-          <ui-dropdown v-model="newServerSettings.dateFormat" :items="dateFormats" small class="max-w-40" @input="(val) => updateSettingsKey('dateFormat', val)" />
-        </div>
-      </div>
-
-      <div id="secondcolumn" class="flex-1" style="background-color: ">
-        <div class="">
-          <h2 class="font-semibold">Scanner</h2>
-        </div>
-
-        <div class="flex items-center py-2">
-          <ui-toggle-switch v-model="newServerSettings.scannerParseSubtitle" :disabled="updatingServerSettings" @input="(val) => updateSettingsKey('scannerParseSubtitle', val)" />
-          <ui-tooltip :text="tooltips.scannerParseSubtitle">
-            <p class="pl-4">
-              Scanner parse subtitles
-              <span class="material-icons icon-text">info_outlined</span>
-            </p>
-          </ui-tooltip>
-        </div>
-
-        <div class="flex items-center py-2">
-          <ui-toggle-switch v-model="newServerSettings.scannerFindCovers" :disabled="updatingServerSettings" @input="(val) => updateSettingsKey('scannerFindCovers', val)" />
-          <ui-tooltip :text="tooltips.scannerFindCovers">
-            <p class="pl-4">
-              Scanner find covers
-              <span class="material-icons icon-text">info_outlined</span>
-            </p>
-          </ui-tooltip>
-          <div class="flex-grow" />
-        </div>
-        <div v-if="newServerSettings.scannerFindCovers" class="w-44 ml-14 mb-2">
-          <ui-dropdown v-model="newServerSettings.scannerCoverProvider" small :items="providers" label="Cover Provider" @input="updateScannerCoverProvider" :disabled="updatingServerSettings" />
-        </div>
-
-        <div class="flex items-center py-2">
-          <ui-toggle-switch v-model="newServerSettings.scannerPreferAudioMetadata" :disabled="updatingServerSettings" @input="(val) => updateSettingsKey('scannerPreferAudioMetadata', val)" />
-          <ui-tooltip :text="tooltips.scannerPreferAudioMetadata">
-            <p class="pl-4">
-              Scanner prefer audio metadata
-              <span class="material-icons icon-text">info_outlined</span>
-            </p>
-          </ui-tooltip>
-        </div>
-
-        <div class="flex items-center py-2">
-          <ui-toggle-switch v-model="newServerSettings.scannerPreferOverdriveMediaMarker" :disabled="updatingServerSettings" @input="(val) => updateSettingsKey('scannerPreferOverdriveMediaMarker', val)" />
-          <ui-tooltip :text="tooltips.scannerPreferOverdriveMediaMarker">
-            <p class="pl-4">
-              Scanner prefer Overdrive Media Markers for chapters
-              <span class="material-icons icon-text">info_outlined</span>
-            </p>
-          </ui-tooltip>
-        </div>
-
-        <div class="flex items-center py-2">
-          <ui-toggle-switch v-model="newServerSettings.scannerPreferOpfMetadata" :disabled="updatingServerSettings" @input="(val) => updateSettingsKey('scannerPreferOpfMetadata', val)" />
-          <ui-tooltip :text="tooltips.scannerPreferOpfMetadata">
-            <p class="pl-4">
-              Scanner prefer OPF metadata
-              <span class="material-icons icon-text">info_outlined</span>
-            </p>
-          </ui-tooltip>
-        </div>
-
-        <div class="flex items-center py-2">
-          <ui-toggle-switch v-model="newServerSettings.scannerPreferMatchedMetadata" :disabled="updatingServerSettings" @input="(val) => updateSettingsKey('scannerPreferMatchedMetadata', val)" />
-          <ui-tooltip :text="tooltips.scannerPreferMatchedMetadata">
-            <p class="pl-4">
-              Scanner prefer matched metadata
-              <span class="material-icons icon-text">info_outlined</span>
-            </p>
-          </ui-tooltip>
-        </div>
-
-        <div class="flex items-center py-2">
-          <ui-toggle-switch v-model="newServerSettings.scannerDisableWatcher" :disabled="updatingServerSettings" @input="(val) => updateSettingsKey('scannerDisableWatcher', val)" />
-          <ui-tooltip :text="tooltips.scannerDisableWatcher">
-            <p class="pl-4">
-              Disable Watcher
-              <span class="material-icons icon-text">info_outlined</span>
-            </p>
-          </ui-tooltip>
-        </div>
-
-        <div class="mt-4">
-          <h2 class="font-semibold">Experimental Features</h2>
-        </div>
-
-        <div>
-          <div class="flex items-center">
-            <ui-toggle-switch v-model="showExperimentalFeatures" />
-            <ui-tooltip :text="tooltips.experimentalFeatures">
+          <div class="flex items-center py-2">
+            <ui-toggle-switch v-model="useSquareBookCovers" :disabled="updatingServerSettings" @input="updateBookCoverAspectRatio" />
+            <ui-tooltip :text="tooltips.coverAspectRatio">
               <p class="pl-4">
-                Experimental Features
-                <a href="https://github.com/advplyr/audiobookshelf/discussions/75" target="_blank">
-                  <span class="material-icons icon-text">info_outlined</span>
-                </a>
+                Square book covers
+                <span class="material-icons icon-text text-sm">info_outlined</span>
               </p>
             </ui-tooltip>
           </div>
+
+          <div class="flex items-center py-2">
+            <ui-toggle-switch v-model="useAlternativeBookshelfView" :disabled="updatingServerSettings" @input="updateAlternativeBookshelfView" />
+            <ui-tooltip :text="tooltips.bookshelfView">
+              <p class="pl-4">
+                Alternative bookshelf view
+                <span class="material-icons icon-text text-sm">info_outlined</span>
+              </p>
+            </ui-tooltip>
+          </div>
+
+          <div class="flex items-center py-2">
+            <p class="pr-4 ">Date Format</p>
+            <ui-dropdown v-model="newServerSettings.dateFormat" :items="dateFormats" small class="max-w-40" @input="(val) => updateSettingsKey('dateFormat', val)" />
+          </div>
         </div>
 
-        <div class="flex items-center py-2">
-          <ui-toggle-switch v-model="newServerSettings.enableEReader" :disabled="updatingServerSettings" @input="(val) => updateSettingsKey('enableEReader', val)" />
-          <ui-tooltip :text="tooltips.enableEReader">
-            <p class="pl-4">
-              Enable e-reader for all users
-              <span class="material-icons icon-text">info_outlined</span>
-            </p>
-          </ui-tooltip>
-        </div>
+        <div id="secondcolumn" class="flex-1">
+          <div>
+            <h2 class="font-semibold">Scanner</h2>
+          </div>
 
-      </div>
+          <div class="flex items-center py-2">
+            <ui-toggle-switch v-model="newServerSettings.scannerParseSubtitle" :disabled="updatingServerSettings" @input="(val) => updateSettingsKey('scannerParseSubtitle', val)" />
+            <ui-tooltip :text="tooltips.scannerParseSubtitle">
+              <p class="pl-4">
+                Parse subtitles
+                <span class="material-icons icon-text text-sm">info_outlined</span>
+              </p>
+            </ui-tooltip>
+          </div>
+
+          <div class="flex items-center py-2">
+            <ui-toggle-switch v-model="newServerSettings.scannerFindCovers" :disabled="updatingServerSettings" @input="(val) => updateSettingsKey('scannerFindCovers', val)" />
+            <ui-tooltip :text="tooltips.scannerFindCovers">
+              <p class="pl-4">
+                Find covers
+                <span class="material-icons icon-text text-sm">info_outlined</span>
+              </p>
+            </ui-tooltip>
+            <div class="flex-grow" />
+          </div>
+          <div v-if="newServerSettings.scannerFindCovers" class="w-44 ml-14 mb-2">
+            <ui-dropdown v-model="newServerSettings.scannerCoverProvider" small :items="providers" label="Cover Provider" @input="updateScannerCoverProvider" :disabled="updatingServerSettings" />
+          </div>
+
+          <div class="flex items-center py-2">
+            <ui-toggle-switch v-model="newServerSettings.scannerPreferAudioMetadata" :disabled="updatingServerSettings" @input="(val) => updateSettingsKey('scannerPreferAudioMetadata', val)" />
+            <ui-tooltip :text="tooltips.scannerPreferAudioMetadata">
+              <p class="pl-4">
+                Prefer audio metadata
+                <span class="material-icons icon-text text-sm">info_outlined</span>
+              </p>
+            </ui-tooltip>
+          </div>
+
+          <div class="flex items-center py-2">
+            <ui-toggle-switch v-model="newServerSettings.scannerPreferOverdriveMediaMarker" :disabled="updatingServerSettings" @input="(val) => updateSettingsKey('scannerPreferOverdriveMediaMarker', val)" />
+            <ui-tooltip :text="tooltips.scannerPreferOverdriveMediaMarker">
+              <p class="pl-4">
+                Prefer Overdrive Media Markers for chapters
+                <span class="material-icons icon-text text-sm">info_outlined</span>
+              </p>
+            </ui-tooltip>
+          </div>
+
+          <div class="flex items-center py-2">
+            <ui-toggle-switch v-model="newServerSettings.scannerPreferOpfMetadata" :disabled="updatingServerSettings" @input="(val) => updateSettingsKey('scannerPreferOpfMetadata', val)" />
+            <ui-tooltip :text="tooltips.scannerPreferOpfMetadata">
+              <p class="pl-4">
+                Prefer OPF metadata
+                <span class="material-icons icon-text text-sm">info_outlined</span>
+              </p>
+            </ui-tooltip>
+          </div>
+
+          <div class="flex items-center py-2">
+            <ui-toggle-switch v-model="newServerSettings.scannerPreferMatchedMetadata" :disabled="updatingServerSettings" @input="(val) => updateSettingsKey('scannerPreferMatchedMetadata', val)" />
+            <ui-tooltip :text="tooltips.scannerPreferMatchedMetadata">
+              <p class="pl-4">
+                Prefer matched metadata
+                <span class="material-icons icon-text text-sm">info_outlined</span>
+              </p>
+            </ui-tooltip>
+          </div>
+
+          <div class="flex items-center py-2">
+            <ui-toggle-switch v-model="newServerSettings.scannerDisableWatcher" :disabled="updatingServerSettings" @input="(val) => updateSettingsKey('scannerDisableWatcher', val)" />
+            <ui-tooltip :text="tooltips.scannerDisableWatcher">
+              <p class="pl-4">
+                Disable Watcher
+                <span class="material-icons icon-text text-sm">info_outlined</span>
+              </p>
+            </ui-tooltip>
+          </div>
+
+          <div class="mt-4">
+            <h2 class="font-semibold">Experimental Features</h2>
+          </div>
+
+          <div class="flex items-center py-2">
+            <div class="flex items-center">
+              <ui-toggle-switch v-model="showExperimentalFeatures" />
+              <ui-tooltip :text="tooltips.experimentalFeatures">
+                <p class="pl-4">
+                  Experimental Features
+                  <a href="https://github.com/advplyr/audiobookshelf/discussions/75" target="_blank">
+                    <span class="material-icons icon-text text-sm">info_outlined</span>
+                  </a>
+                </p>
+              </ui-tooltip>
+            </div>
+          </div>
+
+          <div class="flex items-center py-2">
+            <ui-toggle-switch v-model="newServerSettings.enableEReader" :disabled="updatingServerSettings" @input="(val) => updateSettingsKey('enableEReader', val)" />
+            <ui-tooltip :text="tooltips.enableEReader">
+              <p class="pl-4">
+                Enable e-reader for all users
+                <span class="material-icons icon-text text-sm">info_outlined</span>
+              </p>
+            </ui-tooltip>
+          </div>
+
+        </div>
       </div>
     </div>
 
@@ -230,7 +228,6 @@
     </div>
 
     <div class="h-0.5 bg-primary bg-opacity-30 w-full" />
-
 
     <prompt-dialog v-model="showConfirmPurgeCache" :width="675">
       <div class="px-4 w-full text-sm py-6 rounded-lg bg-bg shadow-lg border border-black-300">

--- a/client/pages/config/index.vue
+++ b/client/pages/config/index.vue
@@ -1,169 +1,191 @@
 <template>
   <div>
     <!-- <div class="h-0.5 bg-primary bg-opacity-50 w-full" /> -->
+    <div class="sm:flex bg-bg rounded-md shadow-lg border border-white border-opacity-5 p-4 mb-8" style="background-color: ">
 
-    <div class="bg-bg rounded-md shadow-lg border border-white border-opacity-5 p-4 mb-8">
-      <div class="flex items-center mb-2">
-        <h1 class="text-xl font-semibold">Settings</h1>
-      </div>
+      <div id="firstcolumn" class="flex-1" style="background-color: ">
+        <div class="mb-2">
+          <h1 class="text-xl">Settings</h1>
+        </div>
 
-      <div class="flex items-center py-2">
-        <ui-toggle-switch v-model="newServerSettings.storeCoverWithItem" :disabled="updatingServerSettings" @input="(val) => updateSettingsKey('storeCoverWithItem', val)" />
-        <ui-tooltip :text="tooltips.storeCoverWithItem">
-          <p class="pl-4 text-lg">
-            Store covers with item
-            <span class="material-icons icon-text">info_outlined</span>
-          </p>
-        </ui-tooltip>
-      </div>
+        <div class="mb-2">
+          <h1 class="text-xl font-semibold">General</h1>
+        </div>
+          <div class="flex items-center py-2">
+            <ui-toggle-switch v-model="newServerSettings.storeCoverWithItem" :disabled="updatingServerSettings" @input="(val) => updateSettingsKey('storeCoverWithItem', val)" />
+            <ui-tooltip :text="tooltips.storeCoverWithItem">
+              <p class="pl-4 text-lg">
+                Store covers with item
+                <span class="material-icons icon-text">info_outlined</span>
+              </p>
+            </ui-tooltip>
+          </div>
 
-      <div class="flex items-center py-2">
-        <ui-toggle-switch v-model="newServerSettings.storeMetadataWithItem" :disabled="updatingServerSettings" @input="(val) => updateSettingsKey('storeMetadataWithItem', val)" />
-        <ui-tooltip :text="tooltips.storeMetadataWithItem">
-          <p class="pl-4 text-lg">
-            Store metadata with item
-            <span class="material-icons icon-text">info_outlined</span>
-          </p>
-        </ui-tooltip>
-      </div>
+          <div class="flex items-center py-2">
+            <ui-toggle-switch v-model="newServerSettings.storeMetadataWithItem" :disabled="updatingServerSettings" @input="(val) => updateSettingsKey('storeMetadataWithItem', val)" />
+            <ui-tooltip :text="tooltips.storeMetadataWithItem">
+              <p class="pl-4 text-lg">
+                Store metadata with item
+                <span class="material-icons icon-text">info_outlined</span>
+              </p>
+            </ui-tooltip>
+          </div>
 
-      <div class="flex items-center py-2">
-        <ui-toggle-switch v-model="newServerSettings.sortingIgnorePrefix" :disabled="updatingServerSettings" @input="(val) => updateSettingsKey('sortingIgnorePrefix', val)" />
-        <ui-tooltip :text="tooltips.sortingIgnorePrefix">
-          <p class="pl-4 text-lg">
-            Ignore prefixes when sorting title and series
-            <span class="material-icons icon-text">info_outlined</span>
-          </p>
-        </ui-tooltip>
-      </div>
-      <div v-if="newServerSettings.sortingIgnorePrefix" class="w-72 ml-14 mb-2">
-        <ui-multi-select v-model="newServerSettings.sortingPrefixes" small :items="newServerSettings.sortingPrefixes" label="Prefixes to Ignore (case insensitive)" @input="updateSortingPrefixes" :disabled="updatingServerSettings" />
-      </div>
+          <div class="flex items-center py-2">
+            <ui-toggle-switch v-model="newServerSettings.sortingIgnorePrefix" :disabled="updatingServerSettings" @input="(val) => updateSettingsKey('sortingIgnorePrefix', val)" />
+            <ui-tooltip :text="tooltips.sortingIgnorePrefix">
+              <p class="pl-4 text-lg">
+                Ignore prefixes when sorting title and series
+                <span class="material-icons icon-text">info_outlined</span>
+              </p>
+            </ui-tooltip>
+          </div>
+          <div v-if="newServerSettings.sortingIgnorePrefix" class="w-72 ml-14 mb-2">
+            <ui-multi-select v-model="newServerSettings.sortingPrefixes" small :items="newServerSettings.sortingPrefixes" label="Prefixes to Ignore (case insensitive)" @input="updateSortingPrefixes" :disabled="updatingServerSettings" />
+          </div>
 
-      <div class="flex items-center py-2">
-        <ui-toggle-switch v-model="newServerSettings.chromecastEnabled" :disabled="updatingServerSettings" @input="(val) => updateSettingsKey('chromecastEnabled', val)" />
-        <p class="pl-4 text-lg">Enable Chromecast</p>
-      </div>
+          <div class="flex items-center py-2">
+            <ui-toggle-switch v-model="newServerSettings.chromecastEnabled" :disabled="updatingServerSettings" @input="(val) => updateSettingsKey('chromecastEnabled', val)" />
+            <p class="pl-4 text-lg">Enable Chromecast</p>
+          </div>
 
-      <div class="flex items-center mb-2 mt-8">
-        <h1 class="text-xl font-semibold">Display Settings</h1>
-      </div>
+        <div class="flex items-center mb-2 mt-8">
+          <h1 class="text-xl font-semibold">Display</h1>
+        </div>
 
-      <div class="flex items-center py-2">
-        <ui-toggle-switch v-model="useSquareBookCovers" :disabled="updatingServerSettings" @input="updateBookCoverAspectRatio" />
-        <ui-tooltip :text="tooltips.coverAspectRatio">
-          <p class="pl-4 text-lg">
-            Use square book covers
-            <span class="material-icons icon-text">info_outlined</span>
-          </p>
-        </ui-tooltip>
-      </div>
+        <div class="flex items-center py-2">
+          <ui-toggle-switch v-model="useSquareBookCovers" :disabled="updatingServerSettings" @input="updateBookCoverAspectRatio" />
+          <ui-tooltip :text="tooltips.coverAspectRatio">
+            <p class="pl-4 text-lg">
+              Use square book covers
+              <span class="material-icons icon-text">info_outlined</span>
+            </p>
+          </ui-tooltip>
+        </div>
 
-      <div class="flex items-center py-2">
-        <ui-toggle-switch v-model="useAlternativeBookshelfView" :disabled="updatingServerSettings" @input="updateAlternativeBookshelfView" />
-        <ui-tooltip :text="tooltips.bookshelfView">
-          <p class="pl-4 text-lg">
-            Use alternative bookshelf view
-            <span class="material-icons icon-text">info_outlined</span>
-          </p>
-        </ui-tooltip>
-      </div>
+        <div class="flex items-center py-2">
+          <ui-toggle-switch v-model="useAlternativeBookshelfView" :disabled="updatingServerSettings" @input="updateAlternativeBookshelfView" />
+          <ui-tooltip :text="tooltips.bookshelfView">
+            <p class="pl-4 text-lg">
+              Use alternative bookshelf view
+              <span class="material-icons icon-text">info_outlined</span>
+            </p>
+          </ui-tooltip>
+        </div>
 
-      <div class="flex items-center py-2">
-        <p class="pr-4 text-lg">Date Format</p>
-        <ui-dropdown v-model="newServerSettings.dateFormat" :items="dateFormats" small class="max-w-40" @input="(val) => updateSettingsKey('dateFormat', val)" />
-      </div>
-
-      <div class="flex items-center mb-2 mt-8">
-        <h1 class="text-xl font-semibold">Scanner Settings</h1>
-      </div>
-
-      <div class="flex items-center py-2">
-        <ui-toggle-switch v-model="newServerSettings.scannerParseSubtitle" :disabled="updatingServerSettings" @input="(val) => updateSettingsKey('scannerParseSubtitle', val)" />
-        <ui-tooltip :text="tooltips.scannerParseSubtitle">
-          <p class="pl-4 text-lg">
-            Scanner parse subtitles
-            <span class="material-icons icon-text">info_outlined</span>
-          </p>
-        </ui-tooltip>
+        <div class="flex items-center py-2">
+          <p class="pr-4 text-lg">Date Format</p>
+          <ui-dropdown v-model="newServerSettings.dateFormat" :items="dateFormats" small class="max-w-40" @input="(val) => updateSettingsKey('dateFormat', val)" />
+        </div>
       </div>
 
-      <div class="flex items-center py-2">
-        <ui-toggle-switch v-model="newServerSettings.scannerFindCovers" :disabled="updatingServerSettings" @input="(val) => updateSettingsKey('scannerFindCovers', val)" />
-        <ui-tooltip :text="tooltips.scannerFindCovers">
-          <p class="pl-4 text-lg">
-            Scanner find covers
-            <span class="material-icons icon-text">info_outlined</span>
-          </p>
-        </ui-tooltip>
-        <div class="flex-grow" />
-      </div>
-      <div v-if="newServerSettings.scannerFindCovers" class="w-44 ml-14 mb-2">
-        <ui-dropdown v-model="newServerSettings.scannerCoverProvider" small :items="providers" label="Cover Provider" @input="updateScannerCoverProvider" :disabled="updatingServerSettings" />
-      </div>
+      <div id="secondcolumn" class="flex-1" style="background-color: ">
+        <div class="flex items-center mb-2 mt-8">
+          <h1 class="text-xl font-semibold">Scanner</h1>
+        </div>
 
-      <div class="flex items-center py-2">
-        <ui-toggle-switch v-model="newServerSettings.scannerPreferAudioMetadata" :disabled="updatingServerSettings" @input="(val) => updateSettingsKey('scannerPreferAudioMetadata', val)" />
-        <ui-tooltip :text="tooltips.scannerPreferAudioMetadata">
-          <p class="pl-4 text-lg">
-            Scanner prefer audio metadata
-            <span class="material-icons icon-text">info_outlined</span>
-          </p>
-        </ui-tooltip>
-      </div>
+        <div class="flex items-center py-2">
+          <ui-toggle-switch v-model="newServerSettings.scannerParseSubtitle" :disabled="updatingServerSettings" @input="(val) => updateSettingsKey('scannerParseSubtitle', val)" />
+          <ui-tooltip :text="tooltips.scannerParseSubtitle">
+            <p class="pl-4 text-lg">
+              Scanner parse subtitles
+              <span class="material-icons icon-text">info_outlined</span>
+            </p>
+          </ui-tooltip>
+        </div>
 
-      <div class="flex items-center py-2">
-        <ui-toggle-switch v-model="newServerSettings.scannerPreferOverdriveMediaMarker" :disabled="updatingServerSettings" @input="(val) => updateSettingsKey('scannerPreferOverdriveMediaMarker', val)" />
-        <ui-tooltip :text="tooltips.scannerPreferOverdriveMediaMarker">
-          <p class="pl-4 text-lg">
-            Scanner prefer Overdrive Media Markers for chapters
-            <span class="material-icons icon-text">info_outlined</span>
-          </p>
-        </ui-tooltip>
-      </div>
+        <div class="flex items-center py-2">
+          <ui-toggle-switch v-model="newServerSettings.scannerFindCovers" :disabled="updatingServerSettings" @input="(val) => updateSettingsKey('scannerFindCovers', val)" />
+          <ui-tooltip :text="tooltips.scannerFindCovers">
+            <p class="pl-4 text-lg">
+              Scanner find covers
+              <span class="material-icons icon-text">info_outlined</span>
+            </p>
+          </ui-tooltip>
+          <div class="flex-grow" />
+        </div>
+        <div v-if="newServerSettings.scannerFindCovers" class="w-44 ml-14 mb-2">
+          <ui-dropdown v-model="newServerSettings.scannerCoverProvider" small :items="providers" label="Cover Provider" @input="updateScannerCoverProvider" :disabled="updatingServerSettings" />
+        </div>
 
-      <div class="flex items-center py-2">
-        <ui-toggle-switch v-model="newServerSettings.scannerPreferOpfMetadata" :disabled="updatingServerSettings" @input="(val) => updateSettingsKey('scannerPreferOpfMetadata', val)" />
-        <ui-tooltip :text="tooltips.scannerPreferOpfMetadata">
-          <p class="pl-4 text-lg">
-            Scanner prefer OPF metadata
-            <span class="material-icons icon-text">info_outlined</span>
-          </p>
-        </ui-tooltip>
-      </div>
+        <div class="flex items-center py-2">
+          <ui-toggle-switch v-model="newServerSettings.scannerPreferAudioMetadata" :disabled="updatingServerSettings" @input="(val) => updateSettingsKey('scannerPreferAudioMetadata', val)" />
+          <ui-tooltip :text="tooltips.scannerPreferAudioMetadata">
+            <p class="pl-4 text-lg">
+              Scanner prefer audio metadata
+              <span class="material-icons icon-text">info_outlined</span>
+            </p>
+          </ui-tooltip>
+        </div>
 
-      <div class="flex items-center py-2">
-        <ui-toggle-switch v-model="newServerSettings.scannerPreferMatchedMetadata" :disabled="updatingServerSettings" @input="(val) => updateSettingsKey('scannerPreferMatchedMetadata', val)" />
-        <ui-tooltip :text="tooltips.scannerPreferMatchedMetadata">
-          <p class="pl-4 text-lg">
-            Scanner prefer matched metadata
-            <span class="material-icons icon-text">info_outlined</span>
-          </p>
-        </ui-tooltip>
-      </div>
+        <div class="flex items-center py-2">
+          <ui-toggle-switch v-model="newServerSettings.scannerPreferOverdriveMediaMarker" :disabled="updatingServerSettings" @input="(val) => updateSettingsKey('scannerPreferOverdriveMediaMarker', val)" />
+          <ui-tooltip :text="tooltips.scannerPreferOverdriveMediaMarker">
+            <p class="pl-4 text-lg">
+              Scanner prefer Overdrive Media Markers for chapters
+              <span class="material-icons icon-text">info_outlined</span>
+            </p>
+          </ui-tooltip>
+        </div>
 
-      <div class="flex items-center py-2">
-        <ui-toggle-switch v-model="newServerSettings.scannerDisableWatcher" :disabled="updatingServerSettings" @input="(val) => updateSettingsKey('scannerDisableWatcher', val)" />
-        <ui-tooltip :text="tooltips.scannerDisableWatcher">
-          <p class="pl-4 text-lg">
-            Disable Watcher
-            <span class="material-icons icon-text">info_outlined</span>
-          </p>
-        </ui-tooltip>
-      </div>
+        <div class="flex items-center py-2">
+          <ui-toggle-switch v-model="newServerSettings.scannerPreferOpfMetadata" :disabled="updatingServerSettings" @input="(val) => updateSettingsKey('scannerPreferOpfMetadata', val)" />
+          <ui-tooltip :text="tooltips.scannerPreferOpfMetadata">
+            <p class="pl-4 text-lg">
+              Scanner prefer OPF metadata
+              <span class="material-icons icon-text">info_outlined</span>
+            </p>
+          </ui-tooltip>
+        </div>
 
-      <div class="flex items-center mb-2 mt-8">
-        <h1 class="text-xl font-semibold">Experimental Feature Settings</h1>
-      </div>
+        <div class="flex items-center py-2">
+          <ui-toggle-switch v-model="newServerSettings.scannerPreferMatchedMetadata" :disabled="updatingServerSettings" @input="(val) => updateSettingsKey('scannerPreferMatchedMetadata', val)" />
+          <ui-tooltip :text="tooltips.scannerPreferMatchedMetadata">
+            <p class="pl-4 text-lg">
+              Scanner prefer matched metadata
+              <span class="material-icons icon-text">info_outlined</span>
+            </p>
+          </ui-tooltip>
+        </div>
 
-      <div class="flex items-center py-2">
-        <ui-toggle-switch v-model="newServerSettings.enableEReader" :disabled="updatingServerSettings" @input="(val) => updateSettingsKey('enableEReader', val)" />
-        <ui-tooltip :text="tooltips.enableEReader">
-          <p class="pl-4 text-lg">
-            Enable e-reader for all users
-            <span class="material-icons icon-text">info_outlined</span>
-          </p>
-        </ui-tooltip>
+        <div class="flex items-center py-2">
+          <ui-toggle-switch v-model="newServerSettings.scannerDisableWatcher" :disabled="updatingServerSettings" @input="(val) => updateSettingsKey('scannerDisableWatcher', val)" />
+          <ui-tooltip :text="tooltips.scannerDisableWatcher">
+            <p class="pl-4 text-lg">
+              Disable Watcher
+              <span class="material-icons icon-text">info_outlined</span>
+            </p>
+          </ui-tooltip>
+        </div>
+
+        <div class="flex items-center mb-2 mt-8">
+          <h1 class="text-xl font-semibold">Experimental Features</h1>
+        </div>
+
+        <div>
+          <div class="flex items-center">
+            <ui-toggle-switch v-model="showExperimentalFeatures" />
+            <ui-tooltip :text="tooltips.experimentalFeatures">
+              <p class="pl-4 text-lg">
+                Experimental Features
+                <a href="https://github.com/advplyr/audiobookshelf/discussions/75" target="_blank">
+                  <span class="material-icons icon-text">info_outlined</span>
+                </a>
+              </p>
+            </ui-tooltip>
+          </div>
+        </div>
+
+        <div class="flex items-center py-2">
+          <ui-toggle-switch v-model="newServerSettings.enableEReader" :disabled="updatingServerSettings" @input="(val) => updateSettingsKey('enableEReader', val)" />
+          <ui-tooltip :text="tooltips.enableEReader">
+            <p class="pl-4 text-lg">
+              Enable e-reader for all users
+              <span class="material-icons icon-text">info_outlined</span>
+            </p>
+          </ui-tooltip>
+        </div>
+        
       </div>
     </div>
 
@@ -207,23 +229,6 @@
 
     <div class="h-0.5 bg-primary bg-opacity-30 w-full" />
 
-    <div class="py-12 mb-4 opacity-60 hover:opacity-100">
-      <div class="flex items-center">
-        <div>
-          <div class="flex items-center">
-            <ui-toggle-switch v-model="showExperimentalFeatures" />
-            <ui-tooltip :text="tooltips.experimentalFeatures">
-              <p class="pl-4 text-lg">
-                Experimental Features
-                <a href="https://github.com/advplyr/audiobookshelf/discussions/75" target="_blank">
-                  <span class="material-icons icon-text">info_outlined</span>
-                </a>
-              </p>
-            </ui-tooltip>
-          </div>
-        </div>
-      </div>
-    </div>
 
     <prompt-dialog v-model="showConfirmPurgeCache" :width="675">
       <div class="px-4 w-full text-sm py-6 rounded-lg bg-bg shadow-lg border border-black-300">


### PR DESCRIPTION
This PR updates the settings page UI. This biggest changes here are a more distinct visual hierarchy of the content, as well as moving the content to 2 columns when above the small break-point to reduce scrolling. With the groupings introduced in 8ab0f164, I also streamlined the text to be less redundant, which helps with the cognitive load of looking at a bunch of text at once

**Before (desktop):**
![image](https://user-images.githubusercontent.com/13617455/174508725-87df5e7c-b692-4d09-8c6b-8af6dcf8e266.png)

**After (desktop):**
![image](https://user-images.githubusercontent.com/13617455/174508679-418e27c4-106b-4b29-bfb0-40387a5fff4e.png)

**Before (mobile-web):**
![image](https://user-images.githubusercontent.com/13617455/174508806-8709f705-a68b-45c4-b295-64a903de85a1.png)

**After (mobile-web):**
![image](https://user-images.githubusercontent.com/13617455/174508833-31a58014-d404-41ad-a42f-13965b13a5fd.png)
