### PR TITLE
Update Library Stats and Your Stats UIs to match other Settings UIs

### DIFF
--- a/client/pages/config/library-stats.vue
+++ b/client/pages/config/library-stats.vue
@@ -1,10 +1,9 @@
 <template>
-  <div>
-    <p class="text-xl">Stats for library {{ currentLibraryName }}</p>
-
+  <div class="bg-bg rounded-md shadow-lg border border-white border-opacity-5 p-4 mb-8">
+    <h1 class="text-xl">Stats for library {{ currentLibraryName }}</h1>
     <stats-preview-icons v-if="totalItems" :library-stats="libraryStats" />
 
-    <div class="flex md:flex-row flex-wrap justify-between flex-col mt-12">
+    <div class="flex md:flex-row flex-wrap justify-between flex-col mt-8">
       <div class="w-80 my-6 mx-auto">
         <h1 class="text-2xl mb-4 font-book">Top 5 Genres</h1>
         <p v-if="!top5Genres.length">No Genres</p>

--- a/client/pages/config/stats.vue
+++ b/client/pages/config/stats.vue
@@ -1,5 +1,7 @@
 <template>
-  <div>
+  <div class="bg-bg rounded-md shadow-lg border border-white border-opacity-5 p-4 mb-8">
+    <h1 class="text-xl">Stats for {{ username }}</h1>
+
     <div class="flex justify-center">
       <div class="flex p-2">
         <svg class="hidden sm:block h-14 w-14 lg:h-18 lg:w-18" viewBox="0 0 24 24">
@@ -83,6 +85,9 @@ export default {
   computed: {
     user() {
       return this.$store.state.user.user
+    },
+    username() {
+      return this.user.username
     },
     currentLibraryId() {
       return this.$store.state.libraries.currentLibraryId


### PR DESCRIPTION
This PR updates both the Library Stats and Your Stats UIs. The 2 main changes are the content div styling, and ensuring both are using h1 headers for the titles

Before:
![image](https://user-images.githubusercontent.com/13617455/174514641-5a993c5f-1b1e-44a1-98f1-bae7f69c6d05.png)
![image](https://user-images.githubusercontent.com/13617455/174514569-08ed728d-7c7f-4aab-a437-7560107dac64.png)


After:
![image](https://user-images.githubusercontent.com/13617455/174514620-a1c6e055-3203-47ef-bbb3-d9036bf6d568.png)
![image](https://user-images.githubusercontent.com/13617455/174514557-4c607252-17ab-4b9a-bf88-15209060c757.png)
