### PR TITLE
fix: use chapter duration when seeking on track bar

### DIFF
--- a/client/components/player/PlayerTrackBar.vue
+++ b/client/components/player/PlayerTrackBar.vue
@@ -83,8 +83,9 @@ export default {
 
       var offsetX = e.offsetX
       var perc = offsetX / this.trackWidth
-      const duration = this.useChapterTrack ? this.currentChapterDuration : this.duration
-      var time = perc * duration
+      const baseTime = this.useChapterTrack ? this.currentChapterStart : 0;
+      const duration = this.useChapterTrack ? this.currentChapterDuration : this.duration;
+      var time = baseTime + (perc * duration);
       if (isNaN(time) || time === null) {
         console.error('Invalid time', perc, time)
         return

--- a/client/components/player/PlayerTrackBar.vue
+++ b/client/components/player/PlayerTrackBar.vue
@@ -83,7 +83,8 @@ export default {
 
       var offsetX = e.offsetX
       var perc = offsetX / this.trackWidth
-      var time = perc * this.duration
+      const duration = this.useChapterTrack ? this.currentChapterDuration : this.duration
+      var time = perc * duration
       if (isNaN(time) || time === null) {
         console.error('Invalid time', perc, time)
         return


### PR DESCRIPTION
Fixes an issue where seeking by clicking the track bar acts as if the whole book's duration is being seeked.