### PR TITLE
fix: disable workbox to prevent failure with service worker

### DIFF
--- a/client/nuxt.config.js
+++ b/client/nuxt.config.js
@@ -120,6 +120,9 @@ module.exports = {
           sizes: "512x512"
         }
       ]
+    },
+    workbox: {
+      enabled: false,
     }
   },
 


### PR DESCRIPTION
This fixes a variety of lockups and failures to play on both chrome and firefox. Previously, rapidly clickiing through the application with workbox enabled (the default in nuxt production environments) would cause chrome to practically lock up, and firefox would fail to play files until the entire m4b had downloaded. 

In theory, this may cause issues with offline caching and playback. I'm not sure what level of offline functionality the audiobookshelf app is supposed to support. This is probably worth a fairly thorough test.

The change makes the service significantly more robust in my short time testing with the change. 