### PR TITLE
fix getMediaProgress always returning 404

### DIFF
--- a/server/controllers/MeController.js
+++ b/server/controllers/MeController.js
@@ -33,7 +33,7 @@ class MeController {
 
   // GET: api/me/progress/:id/:episodeId?
   async getMediaProgress(req, res) {
-    const mediaProgress = req.user.getMediaProgress(req.id, req.episodeId || null)
+    const mediaProgress = req.user.getMediaProgress(req.params.id, req.params.episodeId || null)
     if (!mediaProgress) {
       return res.sendStatus(404)
     }


### PR DESCRIPTION
This PR fixes an issue with getMediaProgress always returning an actual value.

Before:
`Not Found`

After:
```
{
  "id": "li_7ldrc1h3c2vn6fmf8v",
  "libraryItemId": "li_7ldrc1h3c2vn6fmf8v",
  "episodeId": null,
  "duration": 198346.729125,
  "progress": 0.1297424974615144,
  "currentTime": 25734,
  "isFinished": false,
  "lastUpdate": 1656618353652,
  "startedAt": 1656516106482,
  "finishedAt": null
}
```