### PR TITLE
Add restart and fix volumes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     ports:
       - 13378:80
     volumes:
-      - /audiobooks:/audiobooks
-      - /metadata:/metadata
-      - /config:/config
+      - ./audiobooks:/audiobooks
+      - ./metadata:/metadata
+      - ./config:/config
+    restart: unless-stopped


### PR DESCRIPTION
Added `restart: unless-stopped`
Adjust volumes - probably shouldn't be scattering the volumes around the root dir? Could also do this to put them in the home dir instead of relative to the .yml file location:
```
      - ~/abs/audiobooks:/audiobooks
      - ~/abs/metadata:/metadata
      - ~/abs/config:/config
```
https://docs.docker.com/compose/compose-file/compose-file-v3/#short-syntax-3