### PR TITLE
Persist Volume in Local Storage

### DIFF
--- a/client/components/controls/VolumeControl.vue
+++ b/client/components/controls/VolumeControl.vue
@@ -37,6 +37,11 @@ export default {
         return this.value
       },
       set(val) {
+        try {
+          localStorage.setItem("volume", val);
+        } catch(error) {
+          console.error('Failed to store volume', err)
+        }
         this.$emit('input', val)
       }
     },
@@ -140,6 +145,10 @@ export default {
   mounted() {
     if (this.value === 0) {
       this.isMute = true
+    }
+    const storageVolume = localStorage.getItem("volume")
+    if (storageVolume) {
+      this.volume = parseFloat(storageVolume)
     }
   },
   beforeDestroy() {


### PR DESCRIPTION
I've noticed ABS does not persist the volume in local storage like many other players so refreshing the page sets the volume back to 100%. This commit stores and retrieves the volume from the browser's local storage.