### PR TITLE
Multi select quick match

### DIFF
--- a/client/components/app/Appbar.vue
+++ b/client/components/app/Appbar.vue
@@ -49,6 +49,9 @@
       <div v-show="numLibraryItemsSelected" class="absolute top-0 left-0 w-full h-full px-4 bg-primary flex items-center">
         <h1 class="text-2xl px-4">{{ numLibraryItemsSelected }} Selected</h1>
         <div class="flex-grow" />
+        <ui-tooltip v-if="userIsAdminOrUp && !isPodcastLibrary" text="Quick Match Selected" direction="bottom">
+          <ui-icon-btn :disabled="processingBatch" icon="auto_awesome" @click="batchAutoMatchClick" class="mx-1.5" />
+        </ui-tooltip>
         <ui-tooltip v-if="!isPodcastLibrary" :text="`Mark as ${selectedIsFinished ? 'Not Finished' : 'Finished'}`" direction="bottom">
           <ui-read-icon-btn :disabled="processingBatch" :is-read="selectedIsFinished" @click="toggleBatchRead" class="mx-1.5" />
         </ui-tooltip>
@@ -210,7 +213,10 @@ export default {
     },
     setBookshelfTotalEntities(totalEntities) {
       this.totalEntities = totalEntities
-    }
+    },
+    batchAutoMatchClick() {
+      this.$store.commit('globals/setShowBatchQuickMatchModal', true)
+    },
   },
   mounted() {
     this.$eventBus.$on('bookshelf-total-entities', this.setBookshelfTotalEntities)

--- a/client/components/modals/BatchQuickMatchModel.vue
+++ b/client/components/modals/BatchQuickMatchModel.vue
@@ -1,0 +1,70 @@
+<template>
+  <modals-modal v-model="show" name="batchQuickMatch" :processing="processing" :width="500" :height="'unset'">
+    <template #outer>
+      <div class="absolute top-0 left-0 p-5 w-2/3 overflow-hidden">
+        <p class="font-book text-3xl text-white truncate">{{ title }}</p>
+      </div>
+    </template>
+
+    <div ref="container" class="w-full rounded-lg bg-primary box-shadow-md overflow-y-auto overflow-x-hidden" style="max-height: 80vh">
+      <div v-if="show" class="w-full h-full">
+        <div class="py-4 px-4">
+          <h1 class="text-2xl">Quick Match {{ selectedBookIds.length }} Books</h1>
+        </div>
+      </div>
+    </div>
+  </modals-modal>
+</template>
+
+<script>
+export default {
+  data() {
+    return {
+      processing: false
+    }
+  },
+  computed: {
+    show: {
+      get() {
+		  console.log("Getter")
+        return this.$store.state.globals.showBatchQuickMatchModal
+      },
+      set(val) {
+		  console.log("Setter")
+        this.$store.commit('globals/setShowBatchQuickMatchModal', val)
+      }
+    },
+    title() {
+      return `${this.selectedBookIds.length} Items Selected`
+    },
+    showBatchQuickMatchModal() {
+      return this.$store.state.globals.showBatchQuickMatchModal
+    },
+    selectedBookIds() {
+      return this.$store.state.selectedLibraryItems || []
+    },
+    currentLibraryId() {
+      return this.$store.state.libraries.currentLibraryId
+    }
+  },
+  methods: {
+  },
+  mounted() {}
+}
+</script>
+
+<style>
+.list-complete-item {
+  transition: all 0.8s ease;
+}
+
+.list-complete-enter-from,
+.list-complete-leave-to {
+  opacity: 0;
+  transform: translateY(30px);
+}
+
+.list-complete-leave-active {
+  position: absolute;
+}
+</style>

--- a/client/components/modals/BatchQuickMatchModel.vue
+++ b/client/components/modals/BatchQuickMatchModel.vue
@@ -36,7 +36,7 @@
               </p>
             </ui-tooltip>
           </div>
-          <div class="mt-4 py-4 border-b border-white border-opacity-10 text-white text-opacity-80" :class="isScrollable ? 'box-shadow-md-up' : 'border-t border-white border-opacity-5'">
+          <div class="mt-4 py-4 border-b border-white border-opacity-10 text-white text-opacity-80 border-t border-white border-opacity-5">
             <div class="flex items-center px-4">
               <ui-btn type="button" @click="show = false">Cancel</ui-btn>
               <div class="flex-grow" />

--- a/client/components/modals/BatchQuickMatchModel.vue
+++ b/client/components/modals/BatchQuickMatchModel.vue
@@ -124,8 +124,17 @@ export default {
           options: this.options,
           libraryItemIds: this.selectedBookIds
         })
-        .then(() => {
-          this.$toast.success('Batch quick match success!')
+        .then((result) => {
+		  var success = result.success || false
+		  var toast = 'Batch quick match complete!\n' + result.updates + ' Updated'
+		  if (result.unmatched && (result.unmatched > 0)) {
+			toast += '\n' + result.unmatched + ' with no matches'
+		  }
+		  if (success) {
+			this.$toast.success(toast)
+		  } else {
+		    this.$toast.info(toast)
+		  }
           this.processing = false
           this.$store.commit('setProcessingBatch', false)
           this.show = false

--- a/client/components/modals/BatchQuickMatchModel.vue
+++ b/client/components/modals/BatchQuickMatchModel.vue
@@ -109,7 +109,7 @@ export default {
       // the selected provider to the current library default provider
       if (!this.options.provider || (this.options.lastUsedLibrary != this.currentLibraryId)) {
         this.options.lastUsedLibrary = this.currentLibraryId
-        this.options.provider = this.libraryProvider;
+        this.options.provider = this.libraryProvider
       }
     },
     doBatchQuickMatch() {

--- a/client/components/modals/BatchQuickMatchModel.vue
+++ b/client/components/modals/BatchQuickMatchModel.vue
@@ -101,7 +101,7 @@ export default {
     },
     libraryProvider() {
       return this.$store.getters['libraries/getLibraryProvider'](this.currentLibraryId) || 'google'
-    },
+    }
   },
   methods: {
     init() {

--- a/client/components/modals/BatchQuickMatchModel.vue
+++ b/client/components/modals/BatchQuickMatchModel.vue
@@ -54,7 +54,6 @@ export default {
   data() {
     return {
       processing: false,
-      isScrollable: false,
       lastUsedLibrary: undefined,
       options: {
         provider: undefined,

--- a/client/components/modals/BatchQuickMatchModel.vue
+++ b/client/components/modals/BatchQuickMatchModel.vue
@@ -17,6 +17,7 @@
 		    <p class="pr-4">Provider</p>
 			<ui-dropdown v-model="options.provider" :items="providers" small />
 	      </div>
+		  <p class="text-base px-8 py-2">Quick Match will attempt to add missing covers and metadata for the selected books.  Enable the options below to allow Quick Match to overwrite existing covers and/or metadata.</p>
           <div class="flex px-8 items-end py-2">
             <ui-toggle-switch v-model="options.overrideCover"/>
             <ui-tooltip :text="tooltips.updateCovers">
@@ -56,11 +57,12 @@ export default {
 	  options: {
 		provider: 'google',
 		overrideDetails: true,
-		overrideCover: true
+		overrideCover: true,
+		overrideDefaults: true
 	  },
 	  tooltips: {
-		  updateCovers: 'Update the selected book covers when a match is located.',
-		  updateDetails: 'Update the selected book details when a match is located.'
+		  updateCovers: 'Allow overwriting of existing covers for the selected books when a match is located.',
+		  updateDetails: 'Allow overwriting of existing details for the selected books when a match is located.'
 	  }
     }
   },

--- a/client/components/modals/BatchQuickMatchModel.vue
+++ b/client/components/modals/BatchQuickMatchModel.vue
@@ -124,17 +124,8 @@ export default {
           options: this.options,
           libraryItemIds: this.selectedBookIds
         })
-        .then((result) => {
-		  var success = result.success || false
-		  var toast = 'Batch quick match complete!\n' + result.updates + ' Updated'
-		  if (result.unmatched && (result.unmatched > 0)) {
-			toast += '\n' + result.unmatched + ' with no matches'
-		  }
-		  if (success) {
-			this.$toast.success(toast)
-		  } else {
-		    this.$toast.info(toast)
-		  }
+        .then(() => {
+          this.$toast.info('Batch quick match of ' + this.selectedBookIds.length + ' books started!')
           this.processing = false
           this.$store.commit('setProcessingBatch', false)
           this.show = false

--- a/client/components/modals/BatchQuickMatchModel.vue
+++ b/client/components/modals/BatchQuickMatchModel.vue
@@ -17,7 +17,7 @@
             <p class="pr-4">Provider</p>
             <ui-dropdown v-model="options.provider" :items="providers" small />
           </div>
-          <p class="text-base px-8 py-2">Quick Match will attempt to add missing covers and metadata for the selected books.  Enable the options below to allow Quick Match to overwrite existing covers and/or metadata.</p>
+          <p class="text-base px-8 py-2">Quick Match will attempt to add missing covers and metadata for the selected books. Enable the options below to allow Quick Match to overwrite existing covers and/or metadata.</p>
           <div class="flex px-8 items-end py-2">
             <ui-toggle-switch v-model="options.overrideCover"/>
             <ui-tooltip :text="tooltips.updateCovers">

--- a/client/components/modals/BatchQuickMatchModel.vue
+++ b/client/components/modals/BatchQuickMatchModel.vue
@@ -62,8 +62,8 @@ export default {
         overrideDefaults: true
       },
       tooltips: {
-          updateCovers: 'Allow overwriting of existing covers for the selected books when a match is located.',
-          updateDetails: 'Allow overwriting of existing details for the selected books when a match is located.'
+        updateCovers: 'Allow overwriting of existing covers for the selected books when a match is located.',
+        updateDetails: 'Allow overwriting of existing details for the selected books when a match is located.'
       }
     }
   },

--- a/client/components/modals/BatchQuickMatchModel.vue
+++ b/client/components/modals/BatchQuickMatchModel.vue
@@ -125,13 +125,10 @@ export default {
         })
         .then(() => {
           this.$toast.info('Batch quick match of ' + this.selectedBookIds.length + ' books started!')
-          this.processing = false
-          this.$store.commit('setProcessingBatch', false)
-          this.show = false
-        })
-        .catch((error) => {
+        }).catch((error) => {
           this.$toast.error('Batch quick match failed')
           console.error('Failed to batch quick match', error)
+        }).finally(() => {
           this.processing = false
           this.$store.commit('setProcessingBatch', false)
           this.show = false

--- a/client/components/modals/BatchQuickMatchModel.vue
+++ b/client/components/modals/BatchQuickMatchModel.vue
@@ -10,19 +10,19 @@
       <div v-if="show" class="w-full h-full">
         <div class="py-4 px-4">
           <h1 class="text-2xl">Quick Match {{ selectedBookIds.length }} Books</h1>
-		</div>
-		
-		<div class="w-full overflow-y-auto overflow-x-hidden max-h-96">
+        </div>
+        
+        <div class="w-full overflow-y-auto overflow-x-hidden max-h-96">
           <div class="flex px-8 items-center py-2">
-		    <p class="pr-4">Provider</p>
-			<ui-dropdown v-model="options.provider" :items="providers" small />
-	      </div>
-		  <p class="text-base px-8 py-2">Quick Match will attempt to add missing covers and metadata for the selected books.  Enable the options below to allow Quick Match to overwrite existing covers and/or metadata.</p>
+            <p class="pr-4">Provider</p>
+            <ui-dropdown v-model="options.provider" :items="providers" small />
+          </div>
+          <p class="text-base px-8 py-2">Quick Match will attempt to add missing covers and metadata for the selected books.  Enable the options below to allow Quick Match to overwrite existing covers and/or metadata.</p>
           <div class="flex px-8 items-end py-2">
             <ui-toggle-switch v-model="options.overrideCover"/>
             <ui-tooltip :text="tooltips.updateCovers">
               <p class="pl-4">
-			    Update Covers
+                Update Covers
                 <span class="material-icons icon-text text-sm">info_outlined</span>
               </p>
             </ui-tooltip>
@@ -43,7 +43,7 @@
               <ui-btn color="success" @click="doBatchQuickMatch">Continue</ui-btn>
             </div>
           </div>
-		</div>
+        </div>
       </div>
     </div>
   </modals-modal>
@@ -54,26 +54,24 @@ export default {
   data() {
     return {
       processing: false,
-	  options: {
-		provider: 'google',
-		overrideDetails: true,
-		overrideCover: true,
-		overrideDefaults: true
-	  },
-	  tooltips: {
-		  updateCovers: 'Allow overwriting of existing covers for the selected books when a match is located.',
-		  updateDetails: 'Allow overwriting of existing details for the selected books when a match is located.'
-	  }
+      options: {
+        provider: 'google',
+        overrideDetails: true,
+        overrideCover: true,
+        overrideDefaults: true
+      },
+      tooltips: {
+          updateCovers: 'Allow overwriting of existing covers for the selected books when a match is located.',
+          updateDetails: 'Allow overwriting of existing details for the selected books when a match is located.'
+      }
     }
   },
   computed: {
     show: {
       get() {
-		  console.log("Getter")
         return this.$store.state.globals.showBatchQuickMatchModal
       },
       set(val) {
-		  console.log("Setter")
         this.$store.commit('globals/setShowBatchQuickMatchModal', val)
       }
     },
@@ -95,31 +93,31 @@ export default {
     }
   },
   methods: {
-	  doBatchQuickMatch() {
-		  if (!this.selectedBookIds.length) return
-		  if (this.processing) return
-		  
-		  this.processing = true
-		  this.$store.commit('setProcessingBatch', true)
-		  this.$axios
+      doBatchQuickMatch() {
+          if (!this.selectedBookIds.length) return
+          if (this.processing) return
+          
+          this.processing = true
+          this.$store.commit('setProcessingBatch', true)
+          this.$axios
             .$post(`/api/items/batch/quickmatch`, {
-			  options: this.options,
+              options: this.options,
               libraryItemIds: this.selectedBookIds
             })
             .then(() => {
               this.$toast.success('Batch quick match success!')
               this.processing = false
               this.$store.commit('setProcessingBatch', false)
-			  this.show = false
+              this.show = false
             })
             .catch((error) => {
               this.$toast.error('Batch quick match failed')
               console.error('Failed to batch quick match', error)
               this.processing = false
               this.$store.commit('setProcessingBatch', false)
-			  this.show = false
+              this.show = false
             })
-	  }
+      }
   },
   mounted() {}
 }

--- a/client/layouts/default.vue
+++ b/client/layouts/default.vue
@@ -359,6 +359,18 @@ export default {
       // Force refresh
       location.reload()
     },
+    batchQuickMatchComplete(result) {
+      var success = result.success || false
+      var toast = 'Batch quick match complete!\n' + result.updates + ' Updated'
+      if (result.unmatched && (result.unmatched > 0)) {
+        toast += '\n' + result.unmatched + ' with no matches'
+      }
+      if (success) {
+        this.$toast.success(toast)
+      } else {
+        this.$toast.info(toast)
+      }
+    },
     initializeSocket() {
       this.socket = this.$nuxtSocket({
         name: process.env.NODE_ENV === 'development' ? 'dev' : 'prod',
@@ -430,6 +442,8 @@ export default {
       this.socket.on('rss_feed_closed', this.rssFeedClosed)
 
       this.socket.on('backup_applied', this.backupApplied)
+      
+      this.socket.on('batch_quickmatch_complete', this.batchQuickMatchComplete)
     },
     showUpdateToast(versionData) {
       var ignoreVersion = localStorage.getItem('ignoreVersion')

--- a/client/layouts/default.vue
+++ b/client/layouts/default.vue
@@ -15,7 +15,7 @@
     <modals-podcast-edit-episode />
     <modals-podcast-view-episode />
     <modals-authors-edit-modal />
-	<modals-batch-quick-match-model />
+    <modals-batch-quick-match-model />
     <prompt-confirm />
     <readers-reader />
   </div>

--- a/client/layouts/default.vue
+++ b/client/layouts/default.vue
@@ -15,6 +15,7 @@
     <modals-podcast-edit-episode />
     <modals-podcast-view-episode />
     <modals-authors-edit-modal />
+	<modals-batch-quick-match-model />
     <prompt-confirm />
     <readers-reader />
   </div>

--- a/client/store/globals.js
+++ b/client/store/globals.js
@@ -14,6 +14,7 @@ export const state = () => ({
   selectedAuthor: null,
   isCasting: false, // Actively casting
   isChromecastInitialized: false, // Script loaded
+  showBatchQuickMatchModal: false,
   dateFormats: [
     {
       text: 'MM/DD/YYYY',
@@ -108,5 +109,9 @@ export const mutations = {
   },
   setCasting(state, val) {
     state.isCasting = val
+  },
+  setShowBatchQuickMatchModal(state, val) {
+	  console.log("setShowBatchQuickMatchModal: " + val)
+    state.showBatchQuickMatchModal = val
   }
 }

--- a/client/store/globals.js
+++ b/client/store/globals.js
@@ -111,7 +111,6 @@ export const mutations = {
     state.isCasting = val
   },
   setShowBatchQuickMatchModal(state, val) {
-	  console.log("setShowBatchQuickMatchModal: " + val)
     state.showBatchQuickMatchModal = val
   }
 }

--- a/server/controllers/LibraryItemController.js
+++ b/server/controllers/LibraryItemController.js
@@ -321,7 +321,7 @@ class LibraryItemController {
     if (!items || !items.length) {
       return res.sendStatus(500)
     }
-    res.sendStatus(200);
+    res.sendStatus(200)
     
     for (let i = 0; i < items.length; i++) {
         var libraryItem = this.db.libraryItems.find(_li => _li.id === items[i])

--- a/server/controllers/LibraryItemController.js
+++ b/server/controllers/LibraryItemController.js
@@ -311,9 +311,9 @@ class LibraryItemController {
       Logger.warn('User other than admin attempted to batch quick match library items', req.user)
       return res.sendStatus(403)
     }
-	  
+      
     var itemsUpdated = 0
-	var itemsUnmatched = 0
+    var itemsUnmatched = 0
 
     var matchData = req.body
     var options = matchData.options || {}
@@ -321,7 +321,7 @@ class LibraryItemController {
     if (!items || !items.length) {
       return res.sendStatus(500)
     }
-	res.sendStatus(200);
+    res.sendStatus(200);
     
     for (let i = 0; i < items.length; i++) {
         var libraryItem = this.db.libraryItems.find(_li => _li.id === items[i])
@@ -329,16 +329,16 @@ class LibraryItemController {
         if (matchResult.updated) {
             itemsUpdated++
         } else if (matchResult.warning) {
-			itemsUnmatched++
-		}
+            itemsUnmatched++
+        }
     }
     
-	var result = {
+    var result = {
       success: itemsUpdated > 0,
       updates: itemsUpdated,
       unmatched: itemsUnmatched
     };
-	this.clientEmitter(req.user.id, 'batch_quickmatch_complete', result)
+    this.clientEmitter(req.user.id, 'batch_quickmatch_complete', result)
   }
 
   // DELETE: api/items/all

--- a/server/controllers/LibraryItemController.js
+++ b/server/controllers/LibraryItemController.js
@@ -307,26 +307,26 @@ class LibraryItemController {
 
   // POST: api/items/batch/quickmatch
   async batchQuickMatch(req, res) {
-	var itemsUpdated = 0
+    var itemsUpdated = 0
 
-	var matchData = req.body
-	var options = matchData.options || {}
-	var items = matchData.libraryItemIds
+    var matchData = req.body
+    var options = matchData.options || {}
+    var items = matchData.libraryItemIds
     if (!items || !items.length) {
       return res.sendStatus(500)
     }
-	
+    
     for (let i = 0; i < items.length; i++) {
-		var libraryItem = this.db.libraryItems.find(_li => _li.id === items[i])
-		var matchResult = await this.scanner.quickMatchLibraryItem(libraryItem, options)
-		if (matchResult.updated) {
-			itemsUpdated++
-		}
-	}
-	
-	res.json({
-	  success: itemsUpdated > 0,
-	  updates: itemsUpdated
+        var libraryItem = this.db.libraryItems.find(_li => _li.id === items[i])
+        var matchResult = await this.scanner.quickMatchLibraryItem(libraryItem, options)
+        if (matchResult.updated) {
+            itemsUpdated++
+        }
+    }
+    
+    res.json({
+      success: itemsUpdated > 0,
+      updates: itemsUpdated
     })
   }
 

--- a/server/controllers/LibraryItemController.js
+++ b/server/controllers/LibraryItemController.js
@@ -305,6 +305,31 @@ class LibraryItemController {
     res.json(libraryItems)
   }
 
+  // POST: api/items/batch/quickmatch
+  async batchQuickMatch(req, res) {
+	var itemsUpdated = 0
+
+	var matchData = req.body
+	var options = matchData.options || {}
+	var items = matchData.libraryItemIds
+    if (!items || !items.length) {
+      return res.sendStatus(500)
+    }
+	
+    for (let i = 0; i < items.length; i++) {
+		var libraryItem = this.db.libraryItems.find(_li => _li.id === items[i])
+		var matchResult = await this.scanner.quickMatchLibraryItem(libraryItem, options)
+		if (matchResult.updated) {
+			itemsUpdated++
+		}
+	}
+	
+	res.json({
+	  success: itemsUpdated > 0,
+	  updates: itemsUpdated
+    })
+  }
+
   // DELETE: api/items/all
   async deleteAll(req, res) {
     if (!req.user.isAdminOrUp) {

--- a/server/controllers/LibraryItemController.js
+++ b/server/controllers/LibraryItemController.js
@@ -308,6 +308,7 @@ class LibraryItemController {
   // POST: api/items/batch/quickmatch
   async batchQuickMatch(req, res) {
     var itemsUpdated = 0
+	var itemsUnmatched = 0
 
     var matchData = req.body
     var options = matchData.options || {}
@@ -321,12 +322,15 @@ class LibraryItemController {
         var matchResult = await this.scanner.quickMatchLibraryItem(libraryItem, options)
         if (matchResult.updated) {
             itemsUpdated++
-        }
+        } else if (matchResult.warning) {
+			itemsUnmatched++
+		}
     }
     
     res.json({
       success: itemsUpdated > 0,
-      updates: itemsUpdated
+      updates: itemsUpdated,
+	  unmatched: itemsUnmatched
     })
   }
 

--- a/server/controllers/LibraryItemController.js
+++ b/server/controllers/LibraryItemController.js
@@ -307,6 +307,11 @@ class LibraryItemController {
 
   // POST: api/items/batch/quickmatch
   async batchQuickMatch(req, res) {
+    if (!req.user.isAdminOrUp) {
+      Logger.warn('User other than admin attempted to batch quick match library items', req.user)
+      return res.sendStatus(403)
+    }
+	  
     var itemsUpdated = 0
 	var itemsUnmatched = 0
 
@@ -316,6 +321,7 @@ class LibraryItemController {
     if (!items || !items.length) {
       return res.sendStatus(500)
     }
+	res.sendStatus(200);
     
     for (let i = 0; i < items.length; i++) {
         var libraryItem = this.db.libraryItems.find(_li => _li.id === items[i])
@@ -327,11 +333,12 @@ class LibraryItemController {
 		}
     }
     
-    res.json({
+	var result = {
       success: itemsUpdated > 0,
       updates: itemsUpdated,
-	  unmatched: itemsUnmatched
-    })
+      unmatched: itemsUnmatched
+    };
+	this.clientEmitter(req.user.id, 'batch_quickmatch_complete', result)
   }
 
   // DELETE: api/items/all

--- a/server/controllers/LibraryItemController.js
+++ b/server/controllers/LibraryItemController.js
@@ -337,7 +337,7 @@ class LibraryItemController {
       success: itemsUpdated > 0,
       updates: itemsUpdated,
       unmatched: itemsUnmatched
-    };
+    }
     this.clientEmitter(req.user.id, 'batch_quickmatch_complete', result)
   }
 

--- a/server/routers/ApiRouter.js
+++ b/server/routers/ApiRouter.js
@@ -101,6 +101,7 @@ class ApiRouter {
     this.router.post('/items/batch/delete', LibraryItemController.batchDelete.bind(this))
     this.router.post('/items/batch/update', LibraryItemController.batchUpdate.bind(this))
     this.router.post('/items/batch/get', LibraryItemController.batchGet.bind(this))
+	this.router.post('/items/batch/quickmatch', LibraryItemController.batchQuickMatch.bind(this))
 
     //
     // User Routes

--- a/server/routers/ApiRouter.js
+++ b/server/routers/ApiRouter.js
@@ -101,7 +101,7 @@ class ApiRouter {
     this.router.post('/items/batch/delete', LibraryItemController.batchDelete.bind(this))
     this.router.post('/items/batch/update', LibraryItemController.batchUpdate.bind(this))
     this.router.post('/items/batch/get', LibraryItemController.batchGet.bind(this))
-	this.router.post('/items/batch/quickmatch', LibraryItemController.batchQuickMatch.bind(this))
+    this.router.post('/items/batch/quickmatch', LibraryItemController.batchQuickMatch.bind(this))
 
     //
     // User Routes

--- a/server/scanner/Scanner.js
+++ b/server/scanner/Scanner.js
@@ -675,10 +675,10 @@ class Scanner {
     var provider = options.provider || 'google'
     var searchTitle = options.title || libraryItem.media.metadata.title
     var searchAuthor = options.author || libraryItem.media.metadata.authorName
-	var overrideDefaults = options.overrideDefaults || false
+    var overrideDefaults = options.overrideDefaults || false
 
     // Set to override existing metadata if scannerPreferMatchedMetadata setting is true and 
-	// the overrideDefaults option is not set or set to false.
+    // the overrideDefaults option is not set or set to false.
     if ((overrideDefaults == false) && (this.db.serverSettings.scannerPreferMatchedMetadata)) {
       options.overrideCover = true
       options.overrideDetails = true

--- a/server/scanner/Scanner.js
+++ b/server/scanner/Scanner.js
@@ -675,9 +675,11 @@ class Scanner {
     var provider = options.provider || 'google'
     var searchTitle = options.title || libraryItem.media.metadata.title
     var searchAuthor = options.author || libraryItem.media.metadata.authorName
+	var overrideDefaults = options.overrideDefaults || false
 
-    // Set to override existing metadata if scannerPreferMatchedMetadata setting is true
-    if (this.db.serverSettings.scannerPreferMatchedMetadata) {
+    // Set to override existing metadata if scannerPreferMatchedMetadata setting is true and 
+	// the overrideDefaults option is not set or set to false.
+    if ((overrideDefaults == false) && (this.db.serverSettings.scannerPreferMatchedMetadata)) {
       options.overrideCover = true
       options.overrideDetails = true
     }


### PR DESCRIPTION
Adds a feature to allow the user to batch Quick Match the selected audiobooks.

A button is added to the Appbar when one or more audiobooks are selected using the multi-select option (left most button on the below image).

![button](https://user-images.githubusercontent.com/1608488/192035499-423e79f7-e97b-4b58-9993-4adc8bb14438.png)

Once clicked, a dialog is shown allowing the user to select the metadata provider and to select whether exiting covers or metadata should be overwritten.

![dialog](https://user-images.githubusercontent.com/1608488/192035708-e34de784-ebc6-4588-a833-114f6437eff2.png)

When "Continue" is selected, a quick match is run against each selected audiobook, updating metadata and covers as required.
