### PR TITLE
Fix:Unescaped characters in description causing issues with m4b merging

### DIFF
--- a/server/managers/AbMergeManager.js
+++ b/server/managers/AbMergeManager.js
@@ -131,7 +131,7 @@ class AbMergeManager {
       }
     }
 
-    const toneMetadataObject = toneHelpers.getToneMetadataObject(libraryItem, chaptersFilePath)
+    const toneMetadataObject = toneHelpers.getEscapedToneMetadataObject(libraryItem, chaptersFilePath)
     toneMetadataObject.TrackNumber = 1
     task.data.toneMetadataObject = toneMetadataObject
 

--- a/server/utils/stringEscaper.js
+++ b/server/utils/stringEscaper.js
@@ -1,0 +1,5 @@
+function escapeString(string) {
+  return string.replace(/[.*"+?^${}()|[\]\\]/g, '\\$&');
+}
+
+module.exports.escapeString = escapeString

--- a/server/utils/toneHelpers.js
+++ b/server/utils/toneHelpers.js
@@ -2,6 +2,7 @@ const tone = require('node-tone')
 const fs = require('../libs/fsExtra')
 const Logger = require('../Logger')
 const { secondsToTimestamp } = require('./index')
+const stringEscaper = require('./stringEscaper')
 
 module.exports.writeToneChaptersFile = (chapters, filePath) => {
   var chaptersTxt = ''
@@ -32,6 +33,67 @@ module.exports.getToneMetadataObject = (libraryItem, chaptersFile) => {
   if (bookMetadata.description) {
     metadataObject['Comment'] = bookMetadata.description
     metadataObject['Description'] = bookMetadata.description
+  }
+  if (bookMetadata.narratorName) {
+    metadataObject['Narrator'] = bookMetadata.narratorName
+    metadataObject['Composer'] = bookMetadata.narratorName
+  }
+  if (bookMetadata.firstSeriesName) {
+    metadataObject['MovementName'] = bookMetadata.firstSeriesName
+  }
+  if (bookMetadata.firstSeriesSequence) {
+    metadataObject['Movement'] = bookMetadata.firstSeriesSequence
+  }
+  if (bookMetadata.genres.length) {
+    metadataObject['Genre'] = bookMetadata.genres.join('/')
+  }
+  if (bookMetadata.publisher) {
+    metadataObject['Publisher'] = bookMetadata.publisher
+  }
+  if (bookMetadata.asin) {
+    additionalFields.push(`ASIN=${bookMetadata.asin}`)
+  }
+  if (bookMetadata.isbn) {
+    additionalFields.push(`ISBN=${bookMetadata.isbn}`)
+  }
+  if (coverPath) {
+    metadataObject['CoverFile'] = coverPath
+  }
+  if (parsePublishedYear(bookMetadata.publishedYear)) {
+    metadataObject['PublishingDate'] = parsePublishedYear(bookMetadata.publishedYear)
+  }
+  if (chaptersFile) {
+    metadataObject['ChaptersFile'] = chaptersFile
+  }
+
+  if (additionalFields.length) {
+    metadataObject['AdditionalFields'] = additionalFields
+  }
+
+  return metadataObject
+}
+
+module.exports.getEscapedToneMetadataObject = (libraryItem, chaptersFile) => {
+  const coverPath = libraryItem.media.coverPath
+  const bookMetadata = libraryItem.media.metadata
+
+  const metadataObject = {
+    'Title': bookMetadata.title || '',
+    'Album': bookMetadata.title || '',
+    'TrackTotal': libraryItem.media.tracks.length
+  }
+  const additionalFields = []
+
+  if (bookMetadata.subtitle) {
+    metadataObject['Subtitle'] = bookMetadata.subtitle
+  }
+  if (bookMetadata.authorName) {
+    metadataObject['Artist'] = bookMetadata.authorName
+    metadataObject['AlbumArtist'] = bookMetadata.authorName
+  }
+  if (bookMetadata.description) {
+    metadataObject['Comment'] = stringEscaper.escapeString(bookMetadata.description)
+    metadataObject['Description'] = stringEscaper.escapeString(bookMetadata.description)
   }
   if (bookMetadata.narratorName) {
     metadataObject['Narrator'] = bookMetadata.narratorName


### PR DESCRIPTION
When the merge tags the merged file, and the metadata contains an unescaped double quote (or potentially only when it is the first character), it causes the merge to fail, and potentially other issues if the tagging action happens to succeed anyway.

Here's a nice error where the description after the initial quoted text gets added to the filepath:
![image](https://user-images.githubusercontent.com/9056681/196329481-c2e5aac2-63ec-4856-bf42-70a7a8c6660f.png)

This happened with a few other merges that completed "succesfully":
![image](https://user-images.githubusercontent.com/9056681/196329531-fc91d4df-0c4a-47bd-95bf-5be09f3518ca.png)

Escaping the characters may have stopped this Missing Parts problem happening as well, though I'm not certain as it doesn't consistently happen when they're unescaped.

My fix is a bit of a lazy one in that I just duplicated the getToneMetadataObject function, as escaping by default meant that the descriptions in the library were full of backslashes and I didn't fancy rewriting the frontend to render escaped characters normally 😇 