### PR TITLE
Makes it so the when sorting and ignoring prefixes, prefixes are actually ignored

### DIFF
--- a/server/controllers/LibraryController.js
+++ b/server/controllers/LibraryController.js
@@ -288,7 +288,7 @@ class LibraryController {
           } else if (payload.sortBy === 'addedAt') {
             return se.addedAt
           } else { // sort by name
-            return this.db.serverSettings.sortingIgnorePrefix ? se.nameIgnorePrefix : se.name
+            return this.db.serverSettings.sortingIgnorePrefix ? se.nameIgnorePrefixSort : se.name
           }
         }
       }

--- a/server/objects/metadata/BookMetadata.js
+++ b/server/objects/metadata/BookMetadata.js
@@ -1,5 +1,5 @@
 const Logger = require('../../Logger')
-const { areEquivalent, copyValue, cleanStringForSearch, getTitleIgnorePrefix } = require('../../utils/index')
+const { areEquivalent, copyValue, cleanStringForSearch, getTitleIgnorePrefix, getTitlePrefixAtEnd } = require('../../utils/index')
 const parseNameString = require('../../utils/parsers/parseNameString')
 class BookMetadata {
   constructor(metadata) {
@@ -62,7 +62,7 @@ class BookMetadata {
   toJSONMinified() {
     return {
       title: this.title,
-      titleIgnorePrefix: this.titleIgnorePrefix,
+      titleIgnorePrefix: this.titlePrefixAtEnd,
       subtitle: this.subtitle,
       authorName: this.authorName,
       authorNameLF: this.authorNameLF,
@@ -83,7 +83,7 @@ class BookMetadata {
   toJSONExpanded() {
     return {
       title: this.title,
-      titleIgnorePrefix: this.titleIgnorePrefix,
+      titleIgnorePrefix: this.titlePrefixAtEnd,
       subtitle: this.subtitle,
       authors: this.authors.map(a => ({ ...a })), // Author JSONMinimal with name and id
       narrators: [...this.narrators],
@@ -111,6 +111,9 @@ class BookMetadata {
   get titleIgnorePrefix() {
     return getTitleIgnorePrefix(this.title)
   }
+  get titlePrefixAtEnd() {
+    return getTitlePrefixAtEnd(this.title)
+  }
   get authorName() {
     if (!this.authors.length) return ''
     return this.authors.map(au => au.name).join(', ')
@@ -131,6 +134,13 @@ class BookMetadata {
     return this.series.map(se => {
       if (!se.sequence) return getTitleIgnorePrefix(se.name)
       return `${getTitleIgnorePrefix(se.name)} #${se.sequence}`
+    }).join(', ')
+  }
+  get seriesNamePrefixAtEnd() {
+    if (!this.series.length) return ''
+    return this.series.map(se => {
+      if (!se.sequence) return getTitlePrefixAtEnd(se.name)
+      return `${getTitlePrefixAtEnd(se.name)} #${se.sequence}`
     }).join(', ')
   }
   get firstSeriesName() {

--- a/server/objects/metadata/PodcastMetadata.js
+++ b/server/objects/metadata/PodcastMetadata.js
@@ -1,5 +1,5 @@
 const Logger = require('../../Logger')
-const { areEquivalent, copyValue, cleanStringForSearch } = require('../../utils/index')
+const { areEquivalent, copyValue, cleanStringForSearch, getTitleIgnorePrefix, getTitlePrefixAtEnd } = require('../../utils/index')
 
 class PodcastMetadata {
   constructor(metadata) {
@@ -56,7 +56,7 @@ class PodcastMetadata {
   toJSONMinified() {
     return {
       title: this.title,
-      titleIgnorePrefix: this.titleIgnorePrefix,
+      titleIgnorePrefix: this.titlePrefixAtEnd,
       author: this.author,
       description: this.description,
       releaseDate: this.releaseDate,
@@ -80,15 +80,11 @@ class PodcastMetadata {
   }
 
   get titleIgnorePrefix() {
-    if (!this.title) return ''
-    var prefixesToIgnore = global.ServerSettings.sortingPrefixes || []
-    for (const prefix of prefixesToIgnore) {
-      // e.g. for prefix "the". If title is "The Book Title" return "Book Title, The"
-      if (this.title.toLowerCase().startsWith(`${prefix} `)) {
-        return this.title.substr(prefix.length + 1) + `, ${prefix.substr(0, 1).toUpperCase() + prefix.substr(1)}`
-      }
-    }
-    return this.title
+    return getTitleIgnorePrefix(this.title)
+  }
+
+  get titlePrefixAtEnd() {
+    return getTitlePrefixAtEnd(this.title)
   }
 
   searchQuery(query) { // Returns key if match is found

--- a/server/objects/metadata/VideoMetadata.js
+++ b/server/objects/metadata/VideoMetadata.js
@@ -1,5 +1,5 @@
 const Logger = require('../../Logger')
-const { areEquivalent, copyValue } = require('../../utils/index')
+const { areEquivalent, copyValue, getTitleIgnorePrefix, getTitlePrefixAtEnd } = require('../../utils/index')
 
 class VideoMetadata {
   constructor(metadata) {
@@ -32,7 +32,7 @@ class VideoMetadata {
   toJSONMinified() {
     return {
       title: this.title,
-      titleIgnorePrefix: this.titleIgnorePrefix,
+      titleIgnorePrefix: this.titlePrefixAtEnd,
       description: this.description,
       explicit: this.explicit,
       language: this.language
@@ -48,15 +48,11 @@ class VideoMetadata {
   }
 
   get titleIgnorePrefix() {
-    if (!this.title) return ''
-    var prefixesToIgnore = global.ServerSettings.sortingPrefixes || []
-    for (const prefix of prefixesToIgnore) {
-      // e.g. for prefix "the". If title is "The Book Title" return "Book Title, The"
-      if (this.title.toLowerCase().startsWith(`${prefix} `)) {
-        return this.title.substr(prefix.length + 1) + `, ${prefix.substr(0, 1).toUpperCase() + prefix.substr(1)}`
-      }
-    }
-    return this.title
+    return getTitleIgnorePrefix(this.title)
+  }
+
+  get titlePrefixAtEnd() {
+    return getTitlePrefixAtEnd(this.title)
   }
 
   searchQuery(query) { // Returns key if match is found

--- a/server/utils/index.js
+++ b/server/utils/index.js
@@ -140,14 +140,24 @@ module.exports.cleanStringForSearch = (str) => {
   return str.toLowerCase().replace(/[\'\.\`\",]/g, '').trim()
 }
 
-module.exports.getTitleIgnorePrefix = (title) => {
-  if (!title) return ''
+const getTitleParts = (title) => {
+  if (!title) return ['', null]
   var prefixesToIgnore = global.ServerSettings.sortingPrefixes || []
+  prefixes = []
   for (const prefix of prefixesToIgnore) {
     // e.g. for prefix "the". If title is "The Book" return "Book, The"
     if (title.toLowerCase().startsWith(`${prefix} `)) {
-      return title.substr(prefix.length + 1) + `, ${prefix.substr(0, 1).toUpperCase() + prefix.substr(1)}`
+      return [title.substr(prefix.length + 1), `${prefix.substr(0, 1).toUpperCase() + prefix.substr(1)}`]
     }
   }
-  return title
+  return [title, null]
+}
+
+module.exports.getTitleIgnorePrefix = (title) => {
+  return getTitleParts(title)[0]
+}
+
+module.exports.getTitlePrefixAtEnd = (title) => {
+  let [sort, prefix] = getTitleParts(title)
+  return prefix ? `${sort}, ${prefix}` : title
 }

--- a/server/utils/libraryHelpers.js
+++ b/server/utils/libraryHelpers.js
@@ -1,5 +1,5 @@
 const { sort, createNewSortInstance } = require('../libs/fastSort')
-const { getTitleIgnorePrefix, isNullOrNaN } = require('../utils/index')
+const { getTitlePrefixAtEnd, isNullOrNaN, getTitleIgnorePrefix } = require('../utils/index')
 const naturalSort = createNewSortInstance({
   comparer: new Intl.Collator(undefined, { numeric: true, sensitivity: 'base' }).compare
 })
@@ -183,7 +183,8 @@ module.exports = {
           _series[bookSeriesObj.id] = {
             id: bookSeriesObj.id,
             name: bookSeriesObj.name,
-            nameIgnorePrefix: getTitleIgnorePrefix(bookSeriesObj.name),
+            nameIgnorePrefix: getTitlePrefixAtEnd(bookSeriesObj.name),
+            nameIgnorePrefixSort: getTitleIgnorePrefix(bookSeriesObj.name),
             type: 'series',
             books: [abJson],
             addedAt: series ? series.addedAt : 0,


### PR DESCRIPTION
I noticed that when sorting with ignore prefix on, items were not actually sorted correctly. For example, imagine having three items:

"The A"
"The A B"
"The A C"

This sorted to
"A B, The"
"A C, The"
"A, The"

This happens because the ", The" is part of the sort operation. I've modified the code so that is no longer the case. I chose to leave the Vue side of things alone, so the true sort value is only available to the server.