### PR TITLE
Fixing range generation in series labels

### DIFF
--- a/server/controllers/LibraryController.js
+++ b/server/controllers/LibraryController.js
@@ -285,7 +285,7 @@ class LibraryController {
                   lastRange.end = currentSequence
                 }
                 else {
-                  ranges.push({ start: currentSequence, end: currentSequence, isNumber: isNaN(currentSequence) })
+                  ranges.push({ start: currentSequence, end: currentSequence, isNumber: isNumber })
                 }
 
                 return ranges


### PR DESCRIPTION
I realized I made a mistake and broke range collapsing for series tags. This fixes that.