### PR TITLE
Fix listening sessions count bug

### DIFF
--- a/client/pages/config/users/_id/index.vue
+++ b/client/pages/config/users/_id/index.vue
@@ -24,7 +24,7 @@
       <div class="py-2">
         <h1 class="text-lg mb-2 text-white text-opacity-90 px-2 sm:px-0">{{ $strings.HeaderListeningStats }}</h1>
         <div class="flex items-center">
-          <p class="text-sm text-gray-300">{{ this.listeningSessions.total }} {{ $strings.HeaderListeningSessions }}</p>
+          <p class="text-sm text-gray-300">{{ listeningSessions.total }} {{ $strings.HeaderListeningSessions }}</p>
           <ui-btn :to="`/config/users/${user.id}/sessions`" class="text-xs mx-2" :padding-x="1.5" :padding-y="1">{{ $strings.ButtonViewAll }}</ui-btn>
         </div>
         <p class="text-sm text-gray-300">
@@ -110,8 +110,7 @@ export default {
   },
   data() {
     return {
-      listeningSessions: [],
-      totalSessions: 0,
+      listeningSessions: {},
       listeningStats: {},
       purgingMediaProgress: false
     }

--- a/client/pages/config/users/_id/index.vue
+++ b/client/pages/config/users/_id/index.vue
@@ -24,7 +24,7 @@
       <div class="py-2">
         <h1 class="text-lg mb-2 text-white text-opacity-90 px-2 sm:px-0">{{ $strings.HeaderListeningStats }}</h1>
         <div class="flex items-center">
-          <p class="text-sm text-gray-300">{{ listeningSessions.length }} {{ $strings.HeaderListeningSessions }}</p>
+          <p class="text-sm text-gray-300">{{ this.listeningSessions.total }} {{ $strings.HeaderListeningSessions }}</p>
           <ui-btn :to="`/config/users/${user.id}/sessions`" class="text-xs mx-2" :padding-x="1.5" :padding-y="1">{{ $strings.ButtonViewAll }}</ui-btn>
         </div>
         <p class="text-sm text-gray-300">
@@ -111,6 +111,7 @@ export default {
   data() {
     return {
       listeningSessions: [],
+      totalSessions: 0,
       listeningStats: {},
       purgingMediaProgress: false
     }
@@ -147,8 +148,8 @@ export default {
       return this.listeningStats.today || 0
     },
     latestSession() {
-      if (!this.listeningSessions.length) return null
-      return this.listeningSessions[0]
+      if (!this.listeningSessions.sessions.length) return null
+      return this.listeningSessions.sessions[0]
     }
   },
   methods: {
@@ -159,11 +160,11 @@ export default {
       this.listeningSessions = await this.$axios
         .$get(`/api/users/${this.user.id}/listening-sessions?page=0&itemsPerPage=10`)
         .then((data) => {
-          return data.sessions || []
+          return data || {}
         })
         .catch((err) => {
           console.error('Failed to load listening sesions', err)
-          return []
+          return {}
         })
       this.listeningStats = await this.$axios.$get(`/api/users/${this.user.id}/listening-stats`).catch((err) => {
         console.error('Failed to load listening sesions', err)

--- a/client/pages/config/users/_id/index.vue
+++ b/client/pages/config/users/_id/index.vue
@@ -147,7 +147,7 @@ export default {
       return this.listeningStats.today || 0
     },
     latestSession() {
-      if (!this.listeningSessions.sessions.length) return null
+      if (!this.listeningSessions.sessions || !this.listeningSessions.sessions.length) return null
       return this.listeningSessions.sessions[0]
     }
   },


### PR DESCRIPTION
Fixes the bug reported [here](https://github.com/advplyr/audiobookshelf/issues/1142) where listening sessions weren't being reported properly on the user details page.

Rather than adding a new field to `listening-stats` as discussed in the issue, I opted to utilize the `total` field already given by `listening-sessions`, necessitating a very minor refactor of how we get the `latestSession` 