### PR TITLE
Update Author Modal on Changes

### DIFF
--- a/client/components/modals/authors/EditModal.vue
+++ b/client/components/modals/authors/EditModal.vue
@@ -136,6 +136,7 @@ export default {
       })
       if (result && result.updated) {
         this.$toast.success(this.$strings.ToastAuthorImageRemoveSuccess)
+        this.$store.commit('globals/showEditAuthorModal', result.author)
       }
       this.processing = false
     },
@@ -157,7 +158,10 @@ export default {
       if (!response) {
         this.$toast.error('Author not found')
       } else if (response.updated) {
-        if (response.author.imagePath) this.$toast.success(this.$strings.ToastAuthorUpdateSuccess)
+        if (response.author.imagePath) {
+          this.$toast.success(this.$strings.ToastAuthorUpdateSuccess)
+          this.$store.commit('globals/showEditAuthorModal', response.author)
+        }
         else this.$toast.success(this.$strings.ToastAuthorUpdateSuccessNoImageFound)
       } else {
         this.$toast.info('No updates were made for Author')


### PR DESCRIPTION
If you are on the home page and open the edit author modal, you can automatically update all data by clicking “Quick Match” or you can remove a set image by clicking 🗑.

Both options will update the actual data, but not the data in the open modal. This means that, for example, a picture is still shown in the modal after deleting it. That's confusing.

This patch fixes the bug and makes sure the modal is updated if the data is updated.