### PR TITLE
No feed log level

### DIFF
--- a/server/managers/RssFeedManager.js
+++ b/server/managers/RssFeedManager.js
@@ -33,7 +33,7 @@ class RssFeedManager {
   async getFeed(req, res) {
     var feed = this.feeds[req.params.id]
     if (!feed) {
-      Logger.error(`[RssFeedManager] Feed not found ${req.params.id}`)
+      Logger.debug(`[RssFeedManager] Feed not found ${req.params.id}`)
       res.sendStatus(404)
       return
     }

--- a/server/managers/RssFeedManager.js
+++ b/server/managers/RssFeedManager.js
@@ -55,7 +55,7 @@ class RssFeedManager {
   getFeedItem(req, res) {
     var feed = this.feeds[req.params.id]
     if (!feed) {
-      Logger.error(`[RssFeedManager] Feed not found ${req.params.id}`)
+      Logger.debug(`[RssFeedManager] Feed not found ${req.params.id}`)
       res.sendStatus(404)
       return
     }
@@ -71,7 +71,7 @@ class RssFeedManager {
   getFeedCover(req, res) {
     var feed = this.feeds[req.params.id]
     if (!feed) {
-      Logger.error(`[RssFeedManager] Feed not found ${req.params.id}`)
+      Logger.debug(`[RssFeedManager] Feed not found ${req.params.id}`)
       res.sendStatus(404)
       return
     }


### PR DESCRIPTION
This patch drops the log level for logging requests to non-existing feeds from error to debug. The reasoning behind this is that this is a client error and a client error is returned and can be handled by the client.

Otherwise anyone can easily spam the logs with error messages by just requesting non-existing feeds.