### PR TITLE
Allow specifying start and end of progress via API

### DIFF
--- a/server/objects/user/MediaProgress.js
+++ b/server/objects/user/MediaProgress.js
@@ -63,12 +63,12 @@ class MediaProgress {
     this.isFinished = !!progress.isFinished || this.progress == 1
     this.hideFromContinueListening = !!progress.hideFromContinueListening
     this.lastUpdate = Date.now()
-    this.startedAt = Date.now()
     this.finishedAt = null
     if (this.isFinished) {
-      this.finishedAt = Date.now()
+      this.finishedAt = progress.finishedAt || Date.now()
       this.progress = 1
     }
+    this.startedAt = this.finishedAt || Date.now()
   }
 
   update(payload) {
@@ -95,7 +95,7 @@ class MediaProgress {
     // If time remaining is less than 5 seconds then mark as finished
     if ((this.progress >= 1 || (this.duration && !isNaN(timeRemaining) && timeRemaining < 5))) {
       this.isFinished = true
-      this.finishedAt = Date.now()
+      this.finishedAt = payload.finishedAt || Date.now()
       this.progress = 1
     } else if (this.progress < 1 && this.isFinished) {
       this.isFinished = false
@@ -103,7 +103,7 @@ class MediaProgress {
     }
 
     if (!this.startedAt) {
-      this.startedAt = Date.now()
+      this.startedAt = this.finishedAt || Date.now()
     }
     if (hasUpdates) {
       if (payload.hideFromContinueListening === undefined) {


### PR DESCRIPTION
This patch is a minor extension to the update progress and batch update progress API and allows you to specify `finishedAt` and `startedAt` when updating a progress.

If not specified, both values are still automatically set to the current time. If just `finishedAt` is specified, `startedAt` is set to the same value.

Example API request:

```
❯ curl -i -X PATCH \
  'http://127.0.0.1:3333/api/me/progress/li_ywupqxw5d22adcadpa' \
  -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOiJyb290IiwidXNlcm5hbWUiOiJyb290IiwiaWF0IjoxNjY4OTYxNjAxfQ._NbilCoFy_hfoqy7uvbV4E_0X6qgLYapQ_MoRptP0oI' \
  -H 'Content-Type: application/json' \
  --data-raw '{"isFinished":true, "finishedAt": 1668556852000, "startedAt": 1668056852000}'
```