### PR TITLE
Respond with bad request to unvalid request data

### DIFF
--- a/server/controllers/MeController.js
+++ b/server/controllers/MeController.js
@@ -91,7 +91,7 @@ class MeController {
   async batchUpdateMediaProgress(req, res) {
     var itemProgressPayloads = req.body
     if (!itemProgressPayloads || !itemProgressPayloads.length) {
-      return res.sendStatus(500)
+      return res.status(400).send('Missing request payload')
     }
 
     var shouldUpdate = false


### PR DESCRIPTION
This patch updates the batch progress update endpoint to respond with a `400 Bad Request` instead of a `500 Internal Server Error` if a user sends an invalid request with no body. This is a user error after all.

```
❯ curl -i -X PATCH \
  'http://127.0.0.1:3333/api/me/progress/batch/update' \
  -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5Q_MoRptP0oI' \
  -H 'Content-Type: application/json'
HTTP/1.1 400 Bad Request
…

Missing request payload
```