### PR TITLE
Fix startedAt in progress API

### DIFF
--- a/server/objects/user/MediaProgress.js
+++ b/server/objects/user/MediaProgress.js
@@ -68,7 +68,7 @@ class MediaProgress {
       this.finishedAt = progress.finishedAt || Date.now()
       this.progress = 1
     }
-    this.startedAt = this.finishedAt || Date.now()
+    this.startedAt = progress.startedAt || this.finishedAt || Date.now()
   }
 
   update(payload) {


### PR DESCRIPTION
If no progress had been set before, setting `startedAt` did not work and it would always been set to `finishedAt` or `Date.now()`. Settings this if any progress had already been recorded did work.

This fixes the problem so that setting `startedAt` it properly works in both cases.