### PR TITLE
Update notification settings UI to match other pages

### DIFF
--- a/client/pages/config/notifications.vue
+++ b/client/pages/config/notifications.vue
@@ -1,7 +1,9 @@
 <template>
   <div>
-    <div class="bg-bg rounded-md shadow-lg border border-white border-opacity-5 p-3 md:p-8 mb-2 max-w-3xl mx-auto">
-      <h2 class="text-xl font-semibold mb-4">{{ $strings.HeaderAppriseNotificationSettings }}</h2>
+    <div class="bg-bg rounded-md shadow-lg border border-white border-opacity-5 p-4 mb-8">
+      <div class="flex items-center mb-2">
+        <h1 class="text-xl">{{ $strings.HeaderAppriseNotificationSettings }}</h1>
+      </div>
       <p id="appriseDescription" class="mb-6 text-gray-200" v-html="$strings.MessageAppriseDescription" />
 
       <form @submit.prevent="submitForm">


### PR DESCRIPTION
The settings pages were all unified in #755 #757 #758 and #759. This PR unifies the new notifications settings page as well to be consistent with the others

**Before**
![Screen Shot 2022-11-25 at 11 07 05](https://user-images.githubusercontent.com/13617455/204043066-31b79a03-210a-4ba7-ade4-4deeb7b7a374.png)

**After**
![Screen Shot 2022-11-25 at 11 06 47](https://user-images.githubusercontent.com/13617455/204043044-eca4b4fd-6cb8-4d67-970c-84f94beb77cc.png)
