### PR TITLE
No PermissionsStartOnly=true

### DIFF
--- a/build/debian/lib/systemd/system/audiobookshelf.service
+++ b/build/debian/lib/systemd/system/audiobookshelf.service
@@ -11,7 +11,6 @@ ExecReload=/bin/kill -HUP $MAINPID
 Restart=always
 User=audiobookshelf
 Group=audiobookshelf
-PermissionsStartOnly=true
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This patch removes `PermissionsStartOnly=true` from the systemd unit file used for packaging. This shouldn't be necessary for any commands run by the unit.

Note that while I'm pretty sure that this is not necessary, I did not test this.
We should do that before merging this.