### PR TITLE
Improve docker dev container support

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,10 @@
 FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:16
-RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get install ffmpeg gnupg2 -y
+
+COPY --from=sandreas/tone:v0.1.2 /usr/local/bin/tone /usr/local/bin/
+
 ENV NODE_ENV=development
+
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive \
+    apt-get install ffmpeg gnupg curl tzdata -y && \
+    rm -rf /var/lib/apt/lists/*

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,9 +11,9 @@
 		"eamodio.gitlens"
     ],
     "remoteUser": "node",
-    "postStartCommand": {
+    "postCreateCommand": {
         "git": "git config --global --add safe.directory ${containerWorkspaceFolder}",
-        "server": "cd ${containerWorkspaceFolder} && sudo chown $(id -u):$(id -g) node_modules && npm ci",
-        "client": "cd ${containerWorkspaceFolder}/client && sudo chown $(id -u):$(id -g) node_modules && npm ci && npm run generate"
+        "server install": "cd ${containerWorkspaceFolder} && sudo chown $(id -u):$(id -g) node_modules && npm i --from-lockfile",
+        "client install": "cd ${containerWorkspaceFolder}/client && sudo chown $(id -u):$(id -g) node_modules && npm i --from-lockfile && npm run generate"
     }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,7 +11,7 @@
         "eamodio.gitlens"
     ],
     "remoteUser": "node",
-    "postStartCommand": {
+    "postAttachCommand": {
         "git": "git config --global --add safe.directory ${containerWorkspaceFolder}",
         "server": "cd ${containerWorkspaceFolder} && sudo chown $(id -u):$(id -g) node_modules && npm i",
         "client": "cd ${containerWorkspaceFolder}/client && sudo chown $(id -u):$(id -g) node_modules && npm i && npm run generate"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,9 +11,17 @@
 		"eamodio.gitlens"
     ],
     "remoteUser": "node",
-    "postCreateCommand": {
-        "git": "git config --global --add safe.directory ${containerWorkspaceFolder}",
-        "server install": "cd ${containerWorkspaceFolder} && sudo chown $(id -u):$(id -g) node_modules && npm i --from-lockfile",
-        "client install": "cd ${containerWorkspaceFolder}/client && sudo chown $(id -u):$(id -g) node_modules && npm i --from-lockfile && npm run generate"
+    // "postStartCommand": [
+    //     "git",
+    //     "config",
+    //     "--global",
+    //     "--add",
+    //     "safe.directory",
+    //     "${containerWorkspaceFolder}"
+    // ],
+    "postStartCommand": {
+        // "git": "git config --global --add safe.directory ${containerWorkspaceFolder}",
+        "server": "cd ${containerWorkspaceFolder} && sudo chown $(id -u):$(id -g) node_modules && npm i --from-lockfile",
+        "client": "cd ${containerWorkspaceFolder}/client && sudo chown $(id -u):$(id -g) node_modules && npm i --from-lockfile && npm run generate"
     }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,12 +1,19 @@
 {
     "build": { "dockerfile": "Dockerfile" },
     "mounts": [
-        "source=abs-node-node_modules,target=${containerWorkspaceFolder}/node_modules,type=volume"
+        "source=abs-server-node_modules,target=${containerWorkspaceFolder}/node_modules,type=volume",
+        "source=abs-client-node_modules,target=${containerWorkspaceFolder}/client/node_modules,type=volume"
     ],
     "features": {
         "fish": "latest"
 	},
 	"extensions": [
 		"eamodio.gitlens"
-	]
+    ],
+    "remoteUser": "node",
+    "postStartCommand": {
+        "git": "git config --global --add safe.directory ${containerWorkspaceFolder}",
+        "server": "cd ${containerWorkspaceFolder} && sudo chown $(id -u):$(id -g) node_modules && npm ci",
+        "client": "cd ${containerWorkspaceFolder}/client && sudo chown $(id -u):$(id -g) node_modules && npm ci && npm run generate"
+    }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,21 +7,13 @@
     "features": {
         "fish": "latest"
 	},
-	"extensions": [
-		"eamodio.gitlens"
+    "extensions": [
+        "eamodio.gitlens"
     ],
     "remoteUser": "node",
-    // "postStartCommand": [
-    //     "git",
-    //     "config",
-    //     "--global",
-    //     "--add",
-    //     "safe.directory",
-    //     "${containerWorkspaceFolder}"
-    // ],
     "postStartCommand": {
-        // "git": "git config --global --add safe.directory ${containerWorkspaceFolder}",
-        "server": "cd ${containerWorkspaceFolder} && sudo chown $(id -u):$(id -g) node_modules && npm i --from-lockfile",
-        "client": "cd ${containerWorkspaceFolder}/client && sudo chown $(id -u):$(id -g) node_modules && npm i --from-lockfile && npm run generate"
+        "git": "git config --global --add safe.directory ${containerWorkspaceFolder}",
+        "server": "cd ${containerWorkspaceFolder} && sudo chown $(id -u):$(id -g) node_modules && npm i",
+        "client": "cd ${containerWorkspaceFolder}/client && sudo chown $(id -u):$(id -g) node_modules && npm i && npm run generate"
     }
 }

--- a/dev.default.js
+++ b/dev.default.js
@@ -1,0 +1,11 @@
+// DO NOT MODIFY THIS FILE
+// Copy this file to dev.js to make modifications
+
+const Path = require('path')
+module.exports.config = {
+  Port: 3333, // Using port 3333 is important when running the client web app separately
+  ConfigPath: Path.resolve('config'),
+  MetadataPath: Path.resolve('metadata'),
+  FFmpegPath: 'ffmpeg', // On Windows, use 'C:\\<path_to_ffmpeg>\\ffmpeg.exe'
+  FFProbePath: 'ffprobe'
+}

--- a/index.js
+++ b/index.js
@@ -1,9 +1,11 @@
 const server = require('./server/Server')
+const fs = require('fs')
 global.appRoot = __dirname
 
 const isDev = process.env.NODE_ENV !== 'production'
 if (isDev) {
-  const devEnv = require('./dev').config
+  const devFile = fs.existsSync('./dev.js') ? './dev' : './dev.default'
+  const devEnv = require(devFile).config
   process.env.NODE_ENV = 'development'
   process.env.PORT = devEnv.Port
   process.env.CONFIG_PATH = devEnv.ConfigPath


### PR DESCRIPTION
The dev container config was missing a few necessary features. This adds the following features to the dev container:

- Adds tone to the dev container
- moves client/node_modules to a docker volume for performance reasons
- configures git project directory to be trusted, preventing git complaining about ownership
- Automatically install node modules and generate client
- adds dev.default.js. This provides a default config that should work for most linux dev environments. Can be overridden by creating dev.js, so this will not interfere with existing setups. 