### PR TITLE
Use HTTPS for Google Books Images

### DIFF
--- a/server/providers/GoogleBooks.js
+++ b/server/providers/GoogleBooks.js
@@ -20,7 +20,8 @@ class GoogleBooks {
     let cover = null
     // Selects the largest cover assuming the largest is the last key in the object
     if (imageLinks && Object.keys(imageLinks).length) {
-      cover = imageLinks[Object.keys(imageLinks).pop()] || null
+      cover = imageLinks[Object.keys(imageLinks).pop()]
+      cover = cover?.replace(/^http:/, 'https:') || null
     }
 
     return {


### PR DESCRIPTION
The API for Google Books will return HTTP image URLs when matiching any books using it as a search provider. In a secure environment, this causes browser warnings.

![Screenshot from 2022-12-18 00-05-36](https://user-images.githubusercontent.com/1008395/208269585-fe3529f6-df1a-4736-87ba-6cd91a77be3a.png)

![Screenshot from 2022-12-18 00-02-08](https://user-images.githubusercontent.com/1008395/208269591-1a59ad67-4e23-4b85-9b3c-48d9a132ea44.png)


All Google image links support HTTPS and we can safely switch to HTTOS to avoid these warnings.