### PR TITLE
Fix Sub-path Detection

### DIFF
--- a/server/scanner/Scanner.js
+++ b/server/scanner/Scanner.js
@@ -614,7 +614,7 @@ class Scanner {
       }
 
       // Check if a library item is a subdirectory of this dir
-      var childItem = this.db.libraryItems.find(li => li.path.startsWith(fullPath))
+      var childItem = this.db.libraryItems.find(li => (li.path + '/').startsWith(fullPath + '/'))
       if (childItem) {
         Logger.warn(`[Scanner] Files were modified in a parent directory of a library item "${childItem.media.metadata.title}" - ignoring`)
         itemGroupingResults[itemDir] = ScanResult.NOTHING


### PR DESCRIPTION
If the scanner detects new files with a path containing part of the name of an already existing library item, the new item will incorrectly be detected as being a parent directory of the already existing item and the import will be aborted.

You can follow these steps to reproduce the issue:

```
❯ mkdir audiobooks/author/

❯ mv title\ 10 audiobooks/author
[2022-12-18 22:14:12] DEBUG: [Watcher] File Added /home/lars/dev/audiobookshelf/audiobooks/author/title 10/dictaphone.mp3
[2022-12-18 22:14:16] DEBUG: [DB] Library Items inserted 1

❯ mv title\ 1 audiobooks/author
[2022-12-18 22:15:03] DEBUG: [Watcher] File Added /home/lars/dev/audiobookshelf/audiobooks/author/title 1/dictaphone.mp3
[2022-12-18 22:15:07]  WARN: [Scanner] Files were modified in a parent directory of a library item "title 10" - ignoring
```

Since `'title 10'.startsWith('title 1')` is `true`, the current code makes this false assumption.

This patch fixes the issue by requiring a path separator to be part of the matching path. This should ensure that only true parent directories are detected.

This patch requires audiobookshelf to always use Unix file separators. But that shouldn't be a problem since audiobookshelf always seems to use these kinds of separators. Even on Windows.