### PR TITLE
Fix undefined string assignment

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,11 +5,11 @@ const isDev = process.env.NODE_ENV !== 'production'
 if (isDev) {
   const devEnv = require('./dev').config
   process.env.NODE_ENV = 'development'
-  process.env.PORT = devEnv.Port
-  process.env.CONFIG_PATH = devEnv.ConfigPath
-  process.env.METADATA_PATH = devEnv.MetadataPath
-  process.env.FFMPEG_PATH = devEnv.FFmpegPath
-  process.env.FFPROBE_PATH = devEnv.FFProbePath
+  if (devEnv.Port) process.env.PORT = devEnv.Port
+  if (devEnv.ConfigPath) process.env.CONFIG_PATH = devEnv.ConfigPath
+  if (devEnv.MetadataPath) process.env.METADATA_PATH = devEnv.MetadataPath
+  if (devEnv.FFmpegPath) process.env.FFMPEG_PATH = devEnv.FFmpegPath
+  if (devEnv.FFProbePath) process.env.FFPROBE_PATH = devEnv.FFProbePath
   process.env.SOURCE = 'local'
   process.env.ROUTER_BASE_PATH = devEnv.RouterBasePath || ''
 }


### PR DESCRIPTION
Assigning something to `process.env.profile`, Node stringifies the value. This means that assigning `undefined` to an environment variable in Node will result in it holding the string `undefined`.

This means, for example, that `module.exports.FFPROBE_PATH || 'ffprobe'` in `server/libs/nodeFfprobe/index.js` will actually result in the string `undefined`.

This patch fixes several such assignments in the `index.js`, potentially causing problems in the development mode.