### PR TITLE
Make User Settings Accessible via Screen Reader

### DIFF
--- a/client/components/app/SettingsContent.vue
+++ b/client/components/app/SettingsContent.vue
@@ -4,7 +4,7 @@
       <h1 class="text-xl">{{ headerText }}</h1>
 
       <div v-if="showAddButton" class="mx-2 w-7 h-7 flex items-center justify-center rounded-full cursor-pointer hover:bg-white hover:bg-opacity-10 text-center" @click="clicked">
-        <span class="material-icons" style="font-size: 1.4rem">add</span>
+        <button class="material-icons" :aria-label="$strings.ButtonAdd + ': ' + headerText" style="font-size: 1.4rem">add</button>
       </div>
     </div>
 

--- a/client/components/modals/AccountModal.vue
+++ b/client/components/modals/AccountModal.vue
@@ -22,8 +22,8 @@
             </div>
             <div class="flex-grow" />
             <div class="flex items-center pt-4 px-2">
-              <p class="px-3 font-semibold" :class="isEditingRoot ? 'text-gray-300' : ''">{{ $strings.LabelEnable }}</p>
-              <ui-toggle-switch v-model="newUser.isActive" :disabled="isEditingRoot" />
+              <p class="px-3 font-semibold" id="user-enabled-toggle" :class="isEditingRoot ? 'text-gray-300' : ''">{{ $strings.LabelEnable }}</p>
+              <ui-toggle-switch labeledBy="user-enabled-toggle" v-model="newUser.isActive" :disabled="isEditingRoot" />
             </div>
           </div>
 
@@ -31,55 +31,55 @@
             <p class="text-lg mb-2 font-semibold">{{ $strings.HeaderPermissions }}</p>
             <div class="flex items-center my-2 max-w-md">
               <div class="w-1/2">
-                <p>{{ $strings.LabelPermissionsDownload }}</p>
+                <p id="download-permissions-toggle">{{ $strings.LabelPermissionsDownload }}</p>
               </div>
               <div class="w-1/2">
-                <ui-toggle-switch v-model="newUser.permissions.download" />
-              </div>
-            </div>
-
-            <div class="flex items-center my-2 max-w-md">
-              <div class="w-1/2">
-                <p>{{ $strings.LabelPermissionsUpdate }}</p>
-              </div>
-              <div class="w-1/2">
-                <ui-toggle-switch v-model="newUser.permissions.update" />
+                <ui-toggle-switch labeledBy="download-permissions-toggle" v-model="newUser.permissions.download" />
               </div>
             </div>
 
             <div class="flex items-center my-2 max-w-md">
               <div class="w-1/2">
-                <p>{{ $strings.LabelPermissionsDelete }}</p>
+                <p id="update-permissions-toggle">{{ $strings.LabelPermissionsUpdate }}</p>
               </div>
               <div class="w-1/2">
-                <ui-toggle-switch v-model="newUser.permissions.delete" />
-              </div>
-            </div>
-
-            <div class="flex items-center my-2 max-w-md">
-              <div class="w-1/2">
-                <p>{{ $strings.LabelPermissionsUpload }}</p>
-              </div>
-              <div class="w-1/2">
-                <ui-toggle-switch v-model="newUser.permissions.upload" />
+                <ui-toggle-switch labeledBy="update-permissions-toggle" v-model="newUser.permissions.update" />
               </div>
             </div>
 
             <div class="flex items-center my-2 max-w-md">
               <div class="w-1/2">
-                <p>{{ $strings.LabelPermissionsAccessExplicitContent }}</p>
+                <p id="delete-permissions-toggle">{{ $strings.LabelPermissionsDelete }}</p>
               </div>
               <div class="w-1/2">
-                <ui-toggle-switch v-model="newUser.permissions.accessExplicitContent" />
+                <ui-toggle-switch labeledBy="delete-permissions-toggle" v-model="newUser.permissions.delete" />
               </div>
             </div>
 
             <div class="flex items-center my-2 max-w-md">
               <div class="w-1/2">
-                <p>{{ $strings.LabelPermissionsAccessAllLibraries }}</p>
+                <p id="upload-permissions-toggle">{{ $strings.LabelPermissionsUpload }}</p>
               </div>
               <div class="w-1/2">
-                <ui-toggle-switch v-model="newUser.permissions.accessAllLibraries" @input="accessAllLibrariesToggled" />
+                <ui-toggle-switch labeledBy="upload-permissions-toggle" v-model="newUser.permissions.upload" />
+              </div>
+            </div>
+
+            <div class="flex items-center my-2 max-w-md">
+              <div class="w-1/2">
+                <p id="explicit-content-permissions-toggle">{{ $strings.LabelPermissionsAccessExplicitContent }}</p>
+              </div>
+              <div class="w-1/2">
+                <ui-toggle-switch labeledBy="explicit-content-permissions-toggle" v-model="newUser.permissions.accessExplicitContent" />
+              </div>
+            </div>
+
+            <div class="flex items-center my-2 max-w-md">
+              <div class="w-1/2">
+                <p id="access-all-libs--permissions-toggle">{{ $strings.LabelPermissionsAccessAllLibraries }}</p>
+              </div>
+              <div class="w-1/2">
+                <ui-toggle-switch labeledBy="access-all-libs--permissions-toggle" v-model="newUser.permissions.accessAllLibraries" @input="accessAllLibrariesToggled" />
               </div>
             </div>
 

--- a/client/components/ui/Dropdown.vue
+++ b/client/components/ui/Dropdown.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="relative w-full" v-click-outside="clickOutsideObj">
     <p class="text-sm font-semibold px-1" :class="disabled ? 'text-gray-300' : ''">{{ label }}</p>
-    <button type="button" :disabled="disabled" class="relative w-full border rounded shadow-sm pl-3 pr-8 py-2 text-left focus:outline-none sm:text-sm" :class="buttonClass" aria-haspopup="listbox" aria-expanded="true" @click.stop.prevent="clickShowMenu">
+    <button type="button" :disabled="disabled" class="relative w-full border rounded shadow-sm pl-3 pr-8 py-2 text-left sm:text-sm" :class="buttonClass" aria-haspopup="listbox" aria-expanded="true" @click.stop.prevent="clickShowMenu">
       <span class="flex items-center">
         <span class="block truncate font-sans" :class="{ 'font-semibold': selectedSubtext, 'text-sm': small }">{{ selectedText }}</span>
         <span v-if="selectedSubtext">:&nbsp;</span>
@@ -13,9 +13,9 @@
     </button>
 
     <transition name="menu">
-      <ul v-show="showMenu" class="absolute z-10 -mt-px w-full bg-primary border border-black-200 shadow-lg max-h-56 rounded-b-md py-1 ring-1 ring-black ring-opacity-5 overflow-auto focus:outline-none sm:text-sm" tabindex="-1" role="listbox">
+      <ul v-show="showMenu" class="absolute z-10 -mt-px w-full bg-primary border border-black-200 shadow-lg max-h-56 rounded-b-md py-1 ring-1 ring-black ring-opacity-5 overflow-auto sm:text-sm" tabindex="-1" role="listbox">
         <template v-for="item in itemsToShow">
-          <li :key="item.value" class="text-gray-100 select-none relative py-2 cursor-pointer hover:bg-black-400" id="listbox-option-0" role="option" @click="clickedOption(item.value)">
+          <li :key="item.value" class="text-gray-100 relative py-2 cursor-pointer hover:bg-black-400" :id="'listbox-option-' + item.value" role="option" tabindex="0" @keyup.enter="clickedOption(item.value)" @click="clickedOption(item.value)">
             <div class="flex items-center">
               <span class="ml-3 block truncate font-sans text-sm" :class="{ 'font-semibold': item.subtext }">{{ item.text }}</span>
               <span v-if="item.subtext">:&nbsp;</span>

--- a/client/components/ui/TextInput.vue
+++ b/client/components/ui/TextInput.vue
@@ -1,6 +1,6 @@
 <template>
   <div ref="wrapper" class="relative">
-    <input ref="input" v-model="inputValue" :type="actualType" :readonly="readonly" :disabled="disabled" :placeholder="placeholder" class="rounded bg-primary text-gray-200 focus:border-gray-300 focus:bg-bg focus:outline-none border border-gray-600 h-full w-full" :class="classList" @keyup="keyup" @change="change" @focus="focused" @blur="blurred" />
+    <input :id="inputId" ref="input" v-model="inputValue" :type="actualType" :readonly="readonly" :disabled="disabled" :placeholder="placeholder" class="rounded bg-primary text-gray-200 focus:border-gray-300 focus:bg-bg focus:outline-none border border-gray-600 h-full w-full" :class="classList" @keyup="keyup" @change="change" @focus="focused" @blur="blurred" />
     <div v-if="clearable && inputValue" class="absolute top-0 right-0 h-full px-2 flex items-center justify-center">
       <span class="material-icons text-gray-300 cursor-pointer" style="font-size: 1.1rem" @click.stop.prevent="clear">close</span>
     </div>
@@ -31,7 +31,8 @@ export default {
     },
     noSpinner: Boolean,
     textCenter: Boolean,
-    clearable: Boolean
+    clearable: Boolean,
+    inputId: String
   },
   data() {
     return {

--- a/client/components/ui/TextInputWithLabel.vue
+++ b/client/components/ui/TextInputWithLabel.vue
@@ -1,11 +1,11 @@
 <template>
   <div class="w-full">
     <slot>
-      <p class="px-1 text-sm font-semibold" :class="{ 'text-gray-400': disabled }">
+      <label :for="identifier" class="px-1 text-sm font-semibold" :class="{ 'text-gray-400': disabled }">
         {{ label }}<em v-if="note" class="font-normal text-xs pl-2">{{ note }}</em>
-      </p>
+      </label>
     </slot>
-    <ui-text-input ref="input" v-model="inputValue" :disabled="disabled" :readonly="readonly" :type="type" class="w-full" :class="inputClass" @blur="inputBlurred" />
+    <ui-text-input :placeholder="label" :inputId="identifier" ref="input" v-model="inputValue" :disabled="disabled" :readonly="readonly" :type="type" class="w-full" :class="inputClass" @blur="inputBlurred" />
   </div>
 </template>
 
@@ -34,6 +34,9 @@ export default {
       set(val) {
         this.$emit('input', val)
       }
+    },
+    identifier() {
+      return Math.random().toString(36).substring(2)
     }
   },
   methods: {

--- a/client/components/ui/TextInputWithLabel.vue
+++ b/client/components/ui/TextInputWithLabel.vue
@@ -1,9 +1,9 @@
 <template>
   <div class="w-full">
     <slot>
-      <label :for="identifier" class="px-1 text-sm font-semibold" :class="{ 'text-gray-400': disabled }">
-        {{ label }}<em v-if="note" class="font-normal text-xs pl-2">{{ note }}</em>
-      </label>
+      <label :for="identifier" class="px-1 text-sm font-semibold" :class="{ 'text-gray-400': disabled }"
+        >{{ label }}<em v-if="note" class="font-normal text-xs pl-2">{{ note }}</em></label
+      >
     </slot>
     <ui-text-input :placeholder="label" :inputId="identifier" ref="input" v-model="inputValue" :disabled="disabled" :readonly="readonly" :type="type" class="w-full" :class="inputClass" @blur="inputBlurred" />
   </div>

--- a/client/components/ui/ToggleSwitch.vue
+++ b/client/components/ui/ToggleSwitch.vue
@@ -1,8 +1,8 @@
 <template>
   <div>
-    <div class="border rounded-full border-black-100 flex items-center cursor-pointer w-10 justify-start" :class="className" @click="clickToggle">
+    <button :aria-labelledby="labeledBy" role="checkbox" class="border rounded-full border-black-100 flex items-center cursor-pointer w-10 justify-start" :aria-checked="toggleValue" :class="className" @click="clickToggle">
       <span class="rounded-full border w-5 h-5 border-black-50 shadow transform transition-transform duration-100" :class="switchClassName"></span>
-    </div>
+    </button>
   </div>
 </template>
 
@@ -18,7 +18,8 @@ export default {
       type: String,
       default: 'primary'
     },
-    disabled: Boolean
+    disabled: Boolean,
+    labeledBy: String
   },
   computed: {
     toggleValue: {


### PR DESCRIPTION
This patch should fix most of the problems for users trying to access the user settings via screen reader. It makes sure user interface elements can be reached via keyboard and provides proper labels, roles and values so you not only can interact with elements but also know what you are actually changing.

While not focused on other views, this should also already fix a number of accessibility issues with other settings pages.