### PR TITLE
Fix keyboard navigation in user settings

### DIFF
--- a/client/components/tables/UsersTable.vue
+++ b/client/components/tables/UsersTable.vue
@@ -35,13 +35,13 @@
             </ui-tooltip>
           </td>
           <td class="py-0">
-            <div class="w-full flex justify-center">
+            <div class="w-full flex justify-left">
               <!-- Dont show edit for non-root users -->
               <div v-if="user.type !== 'root' || userIsRoot" class="h-8 w-8 flex items-center justify-center text-white text-opacity-50 hover:text-opacity-100 cursor-pointer" @click.stop="editUser(user)">
-                <span class="material-icons text-base">edit</span>
+                <button :aria-label="$getString('ButtonUserEdit', [user.username])" class="material-icons text-base">edit</button>
               </div>
               <div v-show="user.type !== 'root'" class="h-8 w-8 flex items-center justify-center text-white text-opacity-50 hover:text-error cursor-pointer" @click.stop="deleteUserClick(user)">
-                <span class="material-icons text-base">delete</span>
+                <button :aria-label="$getString('ButtonUserDelete', [user.username])" class="material-icons text-base">delete</button>
               </div>
             </div>
           </td>

--- a/client/strings/de.json
+++ b/client/strings/de.json
@@ -75,6 +75,8 @@
   "ButtonUploadBackup": "Sicherung hochladen",
   "ButtonUploadCover": "Titelbild hochladen",
   "ButtonUploadOPMLFile": "OPML-Datei hochladen",
+  "ButtonUserEdit": "Benutzer {0} editieren",
+  "ButtonUserDelete": "Benutzer {0} löschen",
   "ButtonViewAll": "Alles anzeigen",
   "ButtonYes": "Ja",
   "HeaderAccount": "Konto",

--- a/client/strings/en-us.json
+++ b/client/strings/en-us.json
@@ -75,6 +75,8 @@
   "ButtonUploadBackup": "Upload Backup",
   "ButtonUploadCover": "Upload Cover",
   "ButtonUploadOPMLFile": "Upload OPML File",
+  "ButtonUserEdit": "Edit user {0}",
+  "ButtonUserDelete": "Delete user {0}",
   "ButtonViewAll": "View All",
   "ButtonYes": "Yes",
   "HeaderAccount": "Account",


### PR DESCRIPTION
This patch makes sure that the option in the user settings are accessible via keyboard navigation and that the labels, if users use a screen reader, actually make sense.

This patch introduces new strings which need to be translated. Although I did already provide a German translation.

As a minor visual details, this patch also aligns the delete and edit icons:

![Screenshot from 2022-12-29 21-03-12](https://user-images.githubusercontent.com/1008395/210008917-720371be-05dc-4885-9b28-16ce474b3237.png)
