### PR TITLE
Slightly increase width of left navigation bar

### DIFF
--- a/client/components/app/SideRail.vue
+++ b/client/components/app/SideRail.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="w-20 bg-bg h-full fixed left-0 box-shadow-side z-50" style="min-width: 80px" :style="{ top: offsetTop + 'px' }">
+  <div class="w-20 bg-bg h-full fixed left-0 box-shadow-side z-50" style="min-width: 90px" :style="{ top: offsetTop + 'px' }">
     <!-- ugly little workaround to cover up the shadow overlapping the bookshelf toolbar -->
     <div v-if="isShowingBookshelfToolbar" class="absolute top-0 -right-4 w-4 bg-bg h-10 pointer-events-none" />
 


### PR DESCRIPTION
This patch slightly increases the width of the left navigation bar to allow for a little bit of padding on the “Collections” link which looked odd pressed right to the edge of the navigation.

<img width="200px" src="https://user-images.githubusercontent.com/1008395/210897725-b73fab34-c2e1-4aec-b2ea-ce8eceb51d3d.png" />