### PR TITLE
Add total duration info on the podcasts page.

### DIFF
--- a/client/pages/item/_id/index.vue
+++ b/client/pages/item/_id/index.vue
@@ -113,6 +113,14 @@
                   {{ durationPretty }}
                 </div>
               </div>
+              <div v-if="isPodcast" class="flex py-0.5">
+                <div class="w-32">
+                  <span class="text-white text-opacity-60 uppercase text-sm">{{ $strings.LabelDuration }}</span>
+                </div>
+                <div>
+                  {{ (podcastDurationTotal / 3600).toFixed(1) }} (hrs)
+                </div>
+              </div>
               <div class="flex py-0.5">
                 <div class="w-32">
                   <span class="text-white text-opacity-60 uppercase text-sm">{{ $strings.LabelSize }}</span>
@@ -375,6 +383,13 @@ export default {
     },
     podcastAuthor() {
       return this.mediaMetadata.author || ''
+    },
+    podcastDurationTotal() {
+      let totalDuration = 0;
+      this.media.episodes.forEach((ep) => {
+        totalDuration += ep.duration
+      })
+      return totalDuration;
     },
     authors() {
       return this.mediaMetadata.authors || []


### PR DESCRIPTION
For now, the total duration info is not shown for podcasts, just for audio files or audio tracks:

![image](https://user-images.githubusercontent.com/814828/212064669-af36ca05-fa1c-4eaa-953a-17c981e472a1.png)

This pull request adds this information on the podcast page:

![image](https://user-images.githubusercontent.com/814828/212064896-ea900b2f-a1c1-40c1-8c21-d494532c1429.png)

My goal is to have a piece of information about how long is the duration of the podcast, similar to what iTunes does:

<img width="281" alt="image" src="https://user-images.githubusercontent.com/814828/212065565-89f7c859-0644-4898-b347-778c8e1351df.png">

