### PR TITLE
Don't list book twice in continue series

### DIFF
--- a/server/utils/libraryHelpers.js
+++ b/server/utils/libraryHelpers.js
@@ -672,10 +672,12 @@ module.exports = {
           }
 
           const indexToPut = categoryMap.continueSeries.items.findIndex(i => i.prevBookInProgressLastUpdate < bookForContinueSeries.prevBookInProgressLastUpdate)
-          if (indexToPut >= 0) {
-            categoryMap.continueSeries.items.splice(indexToPut, 0, bookForContinueSeries)
-          } else if (categoryMap.continueSeries.items.length < 10) { // Max 10 books
-            categoryMap.continueSeries.items.push(bookForContinueSeries)
+          if (!categoryMap.continueSeries.items.find(book => book.id === bookForContinueSeries.id)) {
+            if (indexToPut >= 0) {
+              categoryMap.continueSeries.items.splice(indexToPut, 0, bookForContinueSeries)
+            } else if (categoryMap.continueSeries.items.length < 10) { // Max 10 books
+              categoryMap.continueSeries.items.push(bookForContinueSeries)
+            }
           }
         }
       }


### PR DESCRIPTION
Sometimes, a book belongs to more than one series. If you listen to and finish such a book, Audiobookshelf will list the next book in “Continue Series” twice, right next to each other. That is not helpful.

This patch fixes the problem by not adding books to the list if they are already in the list.