### PR TITLE
Fix HTTP links not working in podcast show notes.

### DIFF
--- a/server/utils/htmlSanitizer.js
+++ b/server/utils/htmlSanitizer.js
@@ -10,7 +10,7 @@ function sanitize(html) {
     allowedAttributes: {
       a: ['href', 'name', 'target']
     },
-    allowedSchemes: ['http', 'https'],
+    allowedSchemes: ['http', 'https', 'mailto'],
     allowProtocolRelative: false
   }
 

--- a/server/utils/htmlSanitizer.js
+++ b/server/utils/htmlSanitizer.js
@@ -10,7 +10,7 @@ function sanitize(html) {
     allowedAttributes: {
       a: ['href', 'name', 'target']
     },
-    allowedSchemes: ['https'],
+    allowedSchemes: ['http', 'https'],
     allowProtocolRelative: false
   }
 


### PR DESCRIPTION
Fixes #1418. HTTP links in show notes didn't work because `sanitize` in `server/utils/htmlSanitizer.js` removes them, as only `https` was set in `allowedSchemes`. This commit adds `http`.

`htmlSanitizer/sanitize` is only used for podcast and episode descriptions (in `server/utils/podcastUtils.js` and `server/providers/iTunes.js`) , so I don't think there's any reason to disallow HTTP.