### PR TITLE
Reduce Fingerprinting

### DIFF
--- a/server/Server.js
+++ b/server/Server.js
@@ -142,6 +142,7 @@ class Server {
     const app = express()
     const router = express.Router()
     app.use(global.RouterBasePath, router)
+    app.disable('x-powered-by')
 
     this.server = http.createServer(app)
 


### PR DESCRIPTION
As DieselTech#6997 pointed out in Matrix, it is a good idea to reduce fingerprinting by removing the `X-Powered-By` response header as pointed out by the Express security best practices:

See http://expressjs.com/en/advanced/best-practice-security.html#reduce-fingerprinting