### PR TITLE
Skip AUDIOBOOKSHELF_UID/GID if undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,8 +18,8 @@ const PORT = process.env.PORT || 80
 const HOST = process.env.HOST
 const CONFIG_PATH = process.env.CONFIG_PATH || '/config'
 const METADATA_PATH = process.env.METADATA_PATH || '/metadata'
-const UID = process.env.AUDIOBOOKSHELF_UID || 99
-const GID = process.env.AUDIOBOOKSHELF_GID || 100
+const UID = process.env.AUDIOBOOKSHELF_UID
+const GID = process.env.AUDIOBOOKSHELF_GID
 const SOURCE = process.env.SOURCE || 'docker'
 const ROUTER_BASE_PATH = process.env.ROUTER_BASE_PATH || ''
 

--- a/prod.js
+++ b/prod.js
@@ -23,8 +23,8 @@ const PORT = options.port || process.env.PORT || 3333
 const HOST = options.host || process.env.HOST || "0.0.0.0"
 const CONFIG_PATH = inputConfig || process.env.CONFIG_PATH || Path.resolve('config')
 const METADATA_PATH = inputMetadata || process.env.METADATA_PATH || Path.resolve('metadata')
-const UID = 99
-const GID = 100
+const UID = process.env.AUDIOBOOKSHELF_UID
+const GID = process.env.AUDIOBOOKSHELF_GID
 const SOURCE = options.source || 'debian'
 const ROUTER_BASE_PATH = process.env.ROUTER_BASE_PATH || ''
 

--- a/server/Server.js
+++ b/server/Server.js
@@ -43,8 +43,8 @@ class Server {
     this.Host = HOST
     global.Source = SOURCE
     global.isWin = process.platform === 'win32'
-    global.Uid = isNaN(UID) ? 0 : Number(UID)
-    global.Gid = isNaN(GID) ? 0 : Number(GID)
+    global.Uid = isNaN(UID) ? undefined : Number(UID)
+    global.Gid = isNaN(GID) ? undefined : Number(GID)
     global.ConfigPath = fileUtils.filePathToPOSIX(Path.normalize(CONFIG_PATH))
     global.MetadataPath = fileUtils.filePathToPOSIX(Path.normalize(METADATA_PATH))
     global.RouterBasePath = ROUTER_BASE_PATH

--- a/server/utils/filePerms.js
+++ b/server/utils/filePerms.js
@@ -91,7 +91,11 @@ module.exports.setDefault = (path, silent = false) => {
   const uid = global.Uid
   const gid = global.Gid
   return new Promise((resolve) => {
-    if (!silent) Logger.debug(`[FilePerms] Setting permission "${mode}" for uid ${uid} and gid ${gid} | "${path}"`)
+    if (isNaN(uid) || isNaN(gid)) {
+      if (!silent) Logger.debug('Not modifying permissions since no uid/gid is specified')
+      return resolve()
+    }
+    if (!silent) Logger.debug(`Setting permission "${mode}" for uid ${uid} and gid ${gid} | "${path}"`)
     chmodr(path, mode, uid, gid, resolve)
   })
 }
@@ -102,6 +106,10 @@ module.exports.setDefaultDirSync = (path, silent = false) => {
   const mode = 0o744
   const uid = global.Uid
   const gid = global.Gid
+  if (isNaN(uid) || isNaN(gid)) {
+    if (!silent) Logger.debug('Not modifying permissions since no uid/gid is specified')
+    return true
+  }
   if (!silent) Logger.debug(`[FilePerms] Setting dir permission "${mode}" for uid ${uid} and gid ${gid} | "${path}"`)
   try {
     fs.chmodSync(path, mode)


### PR DESCRIPTION
This patch slightly changes the behavior of the `AUDIOBOOKSHELF_UID` and `AUDIOBOOKSHELF_GID` options. Instead of defining a default user and group, trying to modify files and silently failing if the filesystem mode cannot be changed, this patch will just skip the entire process in the first place.

If these options are defined, Audiobookshelf should behave exactly as before. If they are not defined, Audiobookshelf will now cause fewer file modifications (or less failures when trying to modify files).

If this patch gets applied, it should probably be highlighted in the release notes. This usually shouldn't cause problems for migrations since the Docker guides explicitly configure the options and the package installations do not seem to use this at all, but there is still a change that it will and users should be aware of that.

If a problem arises, users can easily fix the problem by either setting the permissions once manually to the audiobookshelf user or by simply defining the `AUDIOBOOKSHELF_UID/GID` options.