### PR TITLE
Activate Dependabot for Server Dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: monthly
+    time: "04:00"


### PR DESCRIPTION
This patch activates Dependabot to automatically submit pull requests updating the server dependencies once per month. This makes it easier to stay up-to-date with potential security problems and library bugs.

This will not touch any client libraries. They are outdated and should get updates as well, but they need manual care first before we can think about a semi-automated update process.


If you choose to accept this, this may also need a change in the repository settings:

![Screenshot from 2023-01-22 13-57-07](https://user-images.githubusercontent.com/1008395/213917204-cfc0c67d-e47f-4a90-a4dd-02ef62b12b37.png)
