### PR TITLE
Align "Series Name" and "Sequence" inputs on Series Editor modal

### DIFF
--- a/client/components/ui/InputDropdown.vue
+++ b/client/components/ui/InputDropdown.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="w-full">
-    <p class="px-1 text-sm font-semibold" :class="disabled ? 'text-gray-400' : ''">{{ label }}</p>
+    <label class="px-1 text-sm font-semibold" :class="disabled ? 'text-gray-400' : ''">{{ label }}</label>
     <div ref="wrapper" class="relative">
       <form @submit.prevent="submitForm">
         <div ref="inputWrapper" class="input-wrapper flex-wrap relative w-full shadow-sm flex items-center border border-gray-600 rounded px-2 py-2" :class="disabled ? 'pointer-events-none bg-black-300 text-gray-400' : 'bg-primary'">


### PR DESCRIPTION
This PR resolves #1410. We were using a `<p>` instead of a `<label>` on `InputDropdown`. Label makes more sense here, as it's inline with the way you would typically add a label to an input component.

**Before**
![image](https://user-images.githubusercontent.com/13617455/213967514-60e3ae17-1348-4b86-8856-af35119a23c6.png)

**After**
![image](https://user-images.githubusercontent.com/13617455/213967495-83d93cb5-c101-4224-9288-cac11190d258.png)
