### PR TITLE
Localized stats page

### DIFF
--- a/client/components/stats/DailyListeningChart.vue
+++ b/client/components/stats/DailyListeningChart.vue
@@ -27,7 +27,7 @@
       <div class="absolute -bottom-2 left-0 flex ml-6">
         <template v-for="dayObj in last7Days">
           <div :key="dayObj.date" :style="{ width: daySpacing + daySpacing / 14 + 'px' }">
-            <p class="text-sm font-book">{{ dayObj.dayOfWeek.slice(0, 3) }}</p>
+            <p class="text-sm font-book">{{ dayObj.dayOfWeekAbbr }}</p>
           </div>
         </template>
       </div>
@@ -108,6 +108,7 @@ export default {
         var _date = this.$addDaysToToday(i * -1)
         days.push({
           dayOfWeek: this.$formatJsDate(_date, 'EEEE'),
+          dayOfWeekAbbr: this.$strings[`Weekday${this.$formatJsDate(_date, 'EEE')}`],
           date: this.$formatJsDate(_date, 'yyyy-MM-dd')
         })
       }

--- a/client/components/stats/Heatmap.vue
+++ b/client/components/stats/Heatmap.vue
@@ -208,7 +208,7 @@ export default {
         const date = i === 0 ? this.firstWeekStart : this.$addDaysToDate(this.firstWeekStart, i)
         const dateString = this.$formatJsDate(date, 'yyyy-MM-dd')
         const datePretty = this.$formatJsDate(date, 'MMM d, yyyy')
-        const monthString = this.$formatJsDate(date, 'MMM')
+        const monthString = this.$strings[`Month${this.$formatJsDate(date, 'MMM')}`]
         const value = this.daysListening[dateString] || 0
         const x = col * 13
         const y = row * 13

--- a/client/strings/de.json
+++ b/client/strings/de.json
@@ -630,9 +630,13 @@
   "WeekdayFriday": "Freitag",
   "WeekdayMon": "Mon",
   "WeekdayMonday": "Montag",
+  "WeekdaySat": "Sat",
   "WeekdaySaturday": "Samstag",
+  "WeekdaySun": "Sun",
   "WeekdaySunday": "Sonntag",
+  "WeekdayThu": "Thu",
   "WeekdayThursday": "Donnerstag",
+  "WeekdayTue": "Tue",
   "WeekdayTuesday": "Dienstag",
   "WeekdayWed": "Wed",
   "WeekdayWednesday": "Mittwoch"

--- a/client/strings/en-us.json
+++ b/client/strings/en-us.json
@@ -630,9 +630,13 @@
   "WeekdayFriday": "Friday",
   "WeekdayMon": "Mon",
   "WeekdayMonday": "Monday",
+  "WeekdaySat": "Sat",
   "WeekdaySaturday": "Saturday",
+  "WeekdaySun": "Sun",
   "WeekdaySunday": "Sunday",
+  "WeekdayThu": "Thu",
   "WeekdayThursday": "Thursday",
+  "WeekdayTue": "Tue",
   "WeekdayTuesday": "Tuesday",
   "WeekdayWed": "Wed",
   "WeekdayWednesday": "Wednesday"

--- a/client/strings/es.json
+++ b/client/strings/es.json
@@ -630,9 +630,13 @@
   "WeekdayFriday": "Friday",
   "WeekdayMon": "Mon",
   "WeekdayMonday": "Monday",
+  "WeekdaySat": "Sat",
   "WeekdaySaturday": "Saturday",
+  "WeekdaySun": "Sun",
   "WeekdaySunday": "Sunday",
+  "WeekdayThu": "Thu",
   "WeekdayThursday": "Thursday",
+  "WeekdayTue": "Tue",
   "WeekdayTuesday": "Tuesday",
   "WeekdayWed": "Wed",
   "WeekdayWednesday": "Wednesday"

--- a/client/strings/fr.json
+++ b/client/strings/fr.json
@@ -630,9 +630,13 @@
   "WeekdayFriday": "Vendredi",
   "WeekdayMon": "Lun",
   "WeekdayMonday": "Lundi",
+  "WeekdaySat": "Sam",
   "WeekdaySaturday": "Samedi",
+  "WeekdaySun": "Dim",
   "WeekdaySunday": "Dimanche",
+  "WeekdayThu": "Jeu",
   "WeekdayThursday": "Jeudi",
+  "WeekdayTue": "Mar",
   "WeekdayTuesday": "Mardi",
   "WeekdayWed": "Mer",
   "WeekdayWednesday": "Mercredi"

--- a/client/strings/hr.json
+++ b/client/strings/hr.json
@@ -630,9 +630,13 @@
   "WeekdayFriday": "Petak",
   "WeekdayMon": "Mon",
   "WeekdayMonday": "Ponedjeljak",
+  "WeekdaySat": "Sat",
   "WeekdaySaturday": "Subota",
+  "WeekdaySun": "Sun",
   "WeekdaySunday": "Nedjelja",
+  "WeekdayThu": "Thu",
   "WeekdayThursday": "Četvrtak",
+  "WeekdayTue": "Tue",
   "WeekdayTuesday": "Utorak",
   "WeekdayWed": "Wed",
   "WeekdayWednesday": "Srijeda"

--- a/client/strings/it.json
+++ b/client/strings/it.json
@@ -630,9 +630,13 @@
   "WeekdayFriday": "Venerdì",
   "WeekdayMon": "Lun",
   "WeekdayMonday": "Lunedì",
+  "WeekdaySat": "Sat",
   "WeekdaySaturday": "Sabato",
+  "WeekdaySun": "Sun",
   "WeekdaySunday": "Domenica",
+  "WeekdayThu": "Thu",
   "WeekdayThursday": "Giovedì",
+  "WeekdayTue": "Tue",
   "WeekdayTuesday": "Martedì",
   "WeekdayWed": "Mer",
   "WeekdayWednesday": "Mercoledì"

--- a/client/strings/pl.json
+++ b/client/strings/pl.json
@@ -630,9 +630,13 @@
   "WeekdayFriday": "Piątek",
   "WeekdayMon": "Mon",
   "WeekdayMonday": "Poniedziałek",
+  "WeekdaySat": "Sat",
   "WeekdaySaturday": "Sobota",
+  "WeekdaySun": "Sun",
   "WeekdaySunday": "Niedziela",
+  "WeekdayThu": "Thu",
   "WeekdayThursday": "Czwartek",
+  "WeekdayTue": "Tue",
   "WeekdayTuesday": "Wtorek",
   "WeekdayWed": "Wed",
   "WeekdayWednesday": "Środa"

--- a/client/strings/zh-cn.json
+++ b/client/strings/zh-cn.json
@@ -630,9 +630,13 @@
   "WeekdayFriday": "星期五",
   "WeekdayMon": "Mon",
   "WeekdayMonday": "星期一",
+  "WeekdaySat": "Sat",
   "WeekdaySaturday": "星期六",
+  "WeekdaySun": "Sun",
   "WeekdaySunday": "星期日",
+  "WeekdayThu": "Thu",
   "WeekdayThursday": "星期四",
+  "WeekdayTue": "Tue",
   "WeekdayTuesday": "星期二",
   "WeekdayWed": "Wed",
   "WeekdayWednesday": "星期三"


### PR DESCRIPTION
I modified the page a bit to accept the translated strings for abbreviated Month and Days

I have not changed the non translated elapsed string in the Recent Session Pane because it is an output of lib date-fns formatDistance function and I need to dig a bit into it to see how to do local with date-fns