### PR TITLE
One Default Bookshelf View

### DIFF
--- a/server/objects/settings/ServerSettings.js
+++ b/server/objects/settings/ServerSettings.js
@@ -37,7 +37,7 @@ class ServerSettings {
     this.loggerScannerLogsToKeep = 2
 
     // Bookshelf Display
-    this.homeBookshelfView = BookshelfView.STANDARD
+    this.homeBookshelfView = BookshelfView.DETAIL
     this.bookshelfView = BookshelfView.DETAIL
 
     // Podcasts


### PR DESCRIPTION
This patch updates the default value of the home page bookshelf view so that it is identical to the default library view. Having different styles by default seems odd. I picked the non-wooden view as default based on the recent discussion on Matrx/Discord that that one looks more modern.