### PR TITLE
Reduce memory usage when scanning large folders

### DIFF
--- a/server/libs/nodeFfprobe/index.js
+++ b/server/libs/nodeFfprobe/index.js
@@ -18,10 +18,7 @@ module.exports = (function () {
       proc.stdout.on('data', function (data) { probeData.push(data) })
       proc.stderr.on('data', function (data) { errData.push(data) })
 
-      proc.on('exit', code => {
-        exitCode = code
-        proc.kill()
-      })
+      proc.on('exit', code => { exitCode = code })
       proc.on('error', err => reject(err))
       proc.on('close', () => {
         try {

--- a/server/libs/nodeFfprobe/index.js
+++ b/server/libs/nodeFfprobe/index.js
@@ -18,7 +18,10 @@ module.exports = (function () {
       proc.stdout.on('data', function (data) { probeData.push(data) })
       proc.stderr.on('data', function (data) { errData.push(data) })
 
-      proc.on('exit', code => { exitCode = code })
+      proc.on('exit', code => {
+        exitCode = code
+        proc.kill()
+      })
       proc.on('error', err => reject(err))
       proc.on('close', () => {
         try {


### PR DESCRIPTION
When audiobookshelf scans a folder with a lot of files, it will take up a lot of memory, because audiobookshelf will start a ffprobe process for each media file at the same time. In order to reduce memory usage, it is necessary to limit the number of ffprobe processes started at the same time.
In addition, after the ffprobe process is executed, it does not exit immediately and becomes a zombie process. It is necessary to call kill() in the exit event to end the process.

Before:
![图片](https://user-images.githubusercontent.com/7497333/217028162-6b6dbb8f-192a-40e0-8203-1b10246b5787.png)

After:
![图片](https://user-images.githubusercontent.com/7497333/217028203-d6ef70d8-a9ec-4e2c-8f2c-f159025d96d3.png)
