### PR TITLE
Add library tags variable to podcast notifications

### DIFF
--- a/server/managers/NotificationManager.js
+++ b/server/managers/NotificationManager.js
@@ -24,7 +24,7 @@ class NotificationManager {
       libraryItemId: libraryItem.id,
       libraryId: libraryItem.libraryId,
       libraryName: library ? library.name : 'Unknown',
-      libraryTags: libraryItem.tags,
+      libraryTags: libraryItem.media.tags,
       podcastTitle: libraryItem.media.metadata.title,
       episodeId: episode.id,
       episodeTitle: episode.title

--- a/server/managers/NotificationManager.js
+++ b/server/managers/NotificationManager.js
@@ -24,10 +24,15 @@ class NotificationManager {
       libraryItemId: libraryItem.id,
       libraryId: libraryItem.libraryId,
       libraryName: library ? library.name : 'Unknown',
-      libraryTags: libraryItem.media.tags,
+      mediaTags: (libraryItem.media.tags || []).join(', '),
       podcastTitle: libraryItem.media.metadata.title,
+      podcastAuthor: libraryItem.media.metadata.author || '',
+      podcastDescription: libraryItem.media.metadata.description || '',
+      podcastGenres: (libraryItem.media.metadata.genres || []).join(', '),
       episodeId: episode.id,
-      episodeTitle: episode.title
+      episodeTitle: episode.title,
+      episodeSubtitle: episode.subtitle || '',
+      episodeDescription: episode.description || ''
     }
     this.triggerNotification('onPodcastEpisodeDownloaded', eventData)
   }

--- a/server/managers/NotificationManager.js
+++ b/server/managers/NotificationManager.js
@@ -24,6 +24,7 @@ class NotificationManager {
       libraryItemId: libraryItem.id,
       libraryId: libraryItem.libraryId,
       libraryName: library ? library.name : 'Unknown',
+      libraryTags: libraryItem.tags,
       podcastTitle: libraryItem.media.metadata.title,
       episodeId: episode.id,
       episodeTitle: episode.title

--- a/server/utils/notifications.js
+++ b/server/utils/notifications.js
@@ -7,7 +7,8 @@ module.exports.notificationData = {
       requiresLibrary: true,
       libraryMediaType: 'podcast',
       description: 'Triggered when a podcast episode is auto-downloaded',
-      variables: ['libraryItemId', 'libraryId', 'podcastTitle', 'episodeTitle', 'libraryName', 'episodeId', 'libraryTags'],      defaults: {
+      variables: ['libraryItemId', 'libraryId', 'podcastTitle', 'episodeTitle', 'libraryName', 'episodeId', 'libraryTags'],
+      defaults: {
         title: 'New {{podcastTitle}} Episode!',
         body: '{{episodeTitle}} has been added to {{libraryName}} library.'
       },

--- a/server/utils/notifications.js
+++ b/server/utils/notifications.js
@@ -7,8 +7,7 @@ module.exports.notificationData = {
       requiresLibrary: true,
       libraryMediaType: 'podcast',
       description: 'Triggered when a podcast episode is auto-downloaded',
-      variables: ['libraryItemId', 'libraryId', 'podcastTitle', 'episodeTitle', 'libraryName', 'episodeId'],
-      defaults: {
+      variables: ['libraryItemId', 'libraryId', 'podcastTitle', 'episodeTitle', 'libraryName', 'episodeId', 'libraryTags'],      defaults: {
         title: 'New {{podcastTitle}} Episode!',
         body: '{{episodeTitle}} has been added to {{libraryName}} library.'
       },
@@ -16,6 +15,7 @@ module.exports.notificationData = {
         libraryItemId: 'li_notification_test',
         libraryId: 'lib_test',
         libraryName: 'Podcasts',
+        libraryTags: ['TestTag1', 'TestTag2'],
         podcastTitle: 'Abs Test Podcast',
         episodeId: 'ep_notification_test',
         episodeTitle: 'Successful Test'

--- a/server/utils/notifications.js
+++ b/server/utils/notifications.js
@@ -7,7 +7,7 @@ module.exports.notificationData = {
       requiresLibrary: true,
       libraryMediaType: 'podcast',
       description: 'Triggered when a podcast episode is auto-downloaded',
-      variables: ['libraryItemId', 'libraryId', 'podcastTitle', 'episodeTitle', 'libraryName', 'episodeId', 'libraryTags'],
+      variables: ['libraryItemId', 'libraryId', 'podcastTitle', 'podcastAuthor', 'podcastDescription', 'podcastGenres', 'episodeTitle', 'episodeSubtitle', 'episodeDescription', 'libraryName', 'episodeId', 'mediaTags'],
       defaults: {
         title: 'New {{podcastTitle}} Episode!',
         body: '{{episodeTitle}} has been added to {{libraryName}} library.'
@@ -16,10 +16,15 @@ module.exports.notificationData = {
         libraryItemId: 'li_notification_test',
         libraryId: 'lib_test',
         libraryName: 'Podcasts',
-        libraryTags: ['TestTag1', 'TestTag2'],
+        mediaTags: 'TestTag1, TestTag2',
         podcastTitle: 'Abs Test Podcast',
+        podcastAuthor: 'Audiobookshelf',
+        podcastDescription: 'Description of the Abs Test Podcast belongs here.',
+        podcastGenres: 'TestGenre1, TestGenre2',
         episodeId: 'ep_notification_test',
-        episodeTitle: 'Successful Test'
+        episodeTitle: 'Successful Test Episode',
+        episodeSubtitle: 'Episode Subtitle',
+        episodeDescription: 'Some description of the podcast episode.'
       }
     },
     {


### PR DESCRIPTION
This adds the `libraryTags` variable to the `onPodcastEpisodeDownloaded` notification handler.

This helps in the usecase where multiple users have access only to limited tags.
In this case they can filter the sent out notifications only for the tags that they are interested in and are no longer pinged for every podcast downloaded.

Example:

![image](https://user-images.githubusercontent.com/13933258/218787627-bad448f6-7fd3-48e9-8bcf-2fcb8d67b65f.png)

![image](https://user-images.githubusercontent.com/13933258/218790145-1ee42482-efb9-4a2e-9e4b-917126d12a6c.png)