### PR TITLE
Encode podcast url when downloading episode

### DIFF
--- a/server/objects/PodcastEpisodeDownload.js
+++ b/server/objects/PodcastEpisodeDownload.js
@@ -50,7 +50,7 @@ class PodcastEpisodeDownload {
   setData(podcastEpisode, libraryItem, isAutoDownload) {
     this.id = getId('epdl')
     this.podcastEpisode = podcastEpisode
-    this.url = podcastEpisode.enclosure.url
+    this.url = encodeURI(podcastEpisode.enclosure.url)
     this.libraryItem = libraryItem
     this.isAutoDownload = isAutoDownload
     this.createdAt = Date.now()


### PR DESCRIPTION
Thanks for all the great work on audiobookshelf! This is a small change to fix a error that I encountered: 

```
ERROR: [PodcastManager] Podcast Episode download failed TypeError [ERR_UNESCAPED_CHARACTERS]: Request path contains unescaped characters
  at new NodeError (node:internal/errors:387:5)
  at new ClientRequest (node:_http_client:182:13)
  at Object.request (node:https:357:10)
  at RedirectableRequest._performRequest (/node_modules/follow-redirects/index.js:284:24)
  at new RedirectableRequest (/node_modules/follow-redirects/index.js:66:8)
  at Object.request (/node_modules/follow-redirects/index.js:523:14)
  at dispatchHttpRequest (/node_modules/axios/lib/adapters/http.js:262:25)
  at new Promise (<anonymous>)
  at httpAdapter (/node_modules/axios/lib/adapters/http.js:49:10)
  at dispatchRequest (/node_modules/axios/lib/core/dispatchRequest.js:58:10) {
  code: 'ERR_UNESCAPED_CHARACTERS'
} (PodcastManager.js:85)
```

Tested the change, this error no longer occurs, and podcast downloads correctly. 
