### PR TITLE
Add largest item stats

### DIFF
--- a/client/pages/config/library-stats.vue
+++ b/client/pages/config/library-stats.vue
@@ -60,6 +60,25 @@
             </div>
           </template>
         </div>
+        <div class="w-80 my-6 mx-auto">
+          <h1 class="text-2xl mb-4">{{ $strings.HeaderStatsLargestItems }}</h1>
+          <p v-if="!top10LargestItems.length">{{ $strings.MessageNoItems }}</p>
+          <template v-for="(ab, index) in top10LargestItems">
+            <div :key="index" class="w-full py-2">
+              <div class="flex items-center mb-1">
+                <p class="text-sm text-white text-opacity-70 w-44 pr-2 truncate">
+                  {{ index + 1 }}.&nbsp;&nbsp;&nbsp;&nbsp;<nuxt-link :to="`/item/${ab.id}`" class="hover:underline">{{ ab.title }}</nuxt-link>
+                </p>
+                <div class="flex-grow rounded-full h-2.5 bg-primary bg-opacity-0 overflow-hidden">
+                  <div class="bg-yellow-400 h-full rounded-full" :style="{ width: Math.round((100 * ab.size) / largestItemSize) + '%' }" />
+                </div>
+                <div class="w-4 ml-3">
+                  <p class="text-sm font-bold">{{ $bytesPretty(ab.size) }}</p>
+                </div>
+              </div>
+            </div>
+          </template>
+        </div>
       </div>
     </app-settings-content>
   </div>
@@ -104,6 +123,13 @@ export default {
     longestItemDuration() {
       if (!this.top10LongestItems.length) return 0
       return this.top10LongestItems[0].duration
+    },
+    top10LargestItems() {
+      return this.libraryStats ? this.libraryStats.largestItems || [] : []
+    },
+    largestItemSize() {
+      if (!this.top10LargestItems.length) return 0
+      return this.top10LargestItems[0].size
     },
     authorsWithCount() {
       return this.libraryStats ? this.libraryStats.authorsWithCount : []

--- a/client/strings/de.json
+++ b/client/strings/de.json
@@ -138,6 +138,7 @@
   "HeaderSettingsGeneral": "Allgemein",
   "HeaderSettingsScanner": "Scanner",
   "HeaderSleepTimer": "Einschlaf-Timer",
+  "HeaderStatsLargestItems": "Largest Items",
   "HeaderStatsLongestItems": "Längste Einträge (h)",
   "HeaderStatsMinutesListeningChart": "Hörminuten (letzte 7 Tage)",
   "HeaderStatsRecentSessions": "Neueste Ereignisse",

--- a/client/strings/en-us.json
+++ b/client/strings/en-us.json
@@ -138,6 +138,7 @@
   "HeaderSettingsGeneral": "General",
   "HeaderSettingsScanner": "Scanner",
   "HeaderSleepTimer": "Sleep Timer",
+  "HeaderStatsLargestItems": "Largest Items",
   "HeaderStatsLongestItems": "Longest Items (hrs)",
   "HeaderStatsMinutesListeningChart": "Minutes Listening (last 7 days)",
   "HeaderStatsRecentSessions": "Recent Sessions",

--- a/client/strings/es.json
+++ b/client/strings/es.json
@@ -138,6 +138,7 @@
   "HeaderSettingsGeneral": "General",
   "HeaderSettingsScanner": "Scanner",
   "HeaderSleepTimer": "Sleep Timer",
+  "HeaderStatsLargestItems": "Largest Items",
   "HeaderStatsLongestItems": "Longest Items (hrs)",
   "HeaderStatsMinutesListeningChart": "Minutes Listening (last 7 days)",
   "HeaderStatsRecentSessions": "Recent Sessions",

--- a/client/strings/fr.json
+++ b/client/strings/fr.json
@@ -138,6 +138,7 @@
   "HeaderSettingsGeneral": "Général",
   "HeaderSettingsScanner": "Scanneur",
   "HeaderSleepTimer": "Minuterie",
+  "HeaderStatsLargestItems": "Largest Items",
   "HeaderStatsLongestItems": "Articles les plus long (heures)",
   "HeaderStatsMinutesListeningChart": "Minutes d'écoute (7 derniers jours)",
   "HeaderStatsRecentSessions": "Sessions récentes",

--- a/client/strings/hr.json
+++ b/client/strings/hr.json
@@ -138,6 +138,7 @@
   "HeaderSettingsGeneral": "Opčenito",
   "HeaderSettingsScanner": "Scanner",
   "HeaderSleepTimer": "Sleep Timer",
+  "HeaderStatsLargestItems": "Largest Items",
   "HeaderStatsLongestItems": "Najduže stavke (sati)",
   "HeaderStatsMinutesListeningChart": "Minuta odslušanih (posljednjih 7 dana)",
   "HeaderStatsRecentSessions": "Nedavne sesije",

--- a/client/strings/it.json
+++ b/client/strings/it.json
@@ -138,6 +138,7 @@
   "HeaderSettingsGeneral": "Generale",
   "HeaderSettingsScanner": "Scanner",
   "HeaderSleepTimer": "Sveglia",
+  "HeaderStatsLargestItems": "Largest Items",
   "HeaderStatsLongestItems": "libri più lunghi (ore)",
   "HeaderStatsMinutesListeningChart": "Minuti ascoltati (Ultimi 7 Giorni)",
   "HeaderStatsRecentSessions": "Sessioni Recenti",

--- a/client/strings/pl.json
+++ b/client/strings/pl.json
@@ -138,6 +138,7 @@
   "HeaderSettingsGeneral": "Ogólne",
   "HeaderSettingsScanner": "Skanowanie",
   "HeaderSleepTimer": "Wyłącznik czasowy",
+  "HeaderStatsLargestItems": "Largest Items",
   "HeaderStatsLongestItems": "Najdłuższe pozycje (hrs)",
   "HeaderStatsMinutesListeningChart": "Czas słuchania w minutach (ostatnie 7 dni)",
   "HeaderStatsRecentSessions": "Ostatnie sesje",

--- a/client/strings/ru.json
+++ b/client/strings/ru.json
@@ -138,6 +138,7 @@
   "HeaderSettingsGeneral": "Основные",
   "HeaderSettingsScanner": "Сканер",
   "HeaderSleepTimer": "Таймер Сна",
+  "HeaderStatsLargestItems": "Largest Items",
   "HeaderStatsLongestItems": "Самые Длинные Книги (часов)",
   "HeaderStatsMinutesListeningChart": "Минут прослушивания (последние 7 дней)",
   "HeaderStatsRecentSessions": "Последние Сеансы",

--- a/client/strings/zh-cn.json
+++ b/client/strings/zh-cn.json
@@ -138,6 +138,7 @@
   "HeaderSettingsGeneral": "通用",
   "HeaderSettingsScanner": "扫描",
   "HeaderSleepTimer": "睡眠计时",
+  "HeaderStatsLargestItems": "Largest Items",
   "HeaderStatsLongestItems": "项目时长(小时)",
   "HeaderStatsMinutesListeningChart": "收听分钟数(最近7天)",
   "HeaderStatsRecentSessions": "历史会话",

--- a/server/controllers/LibraryController.js
+++ b/server/controllers/LibraryController.js
@@ -637,6 +637,7 @@ class LibraryController {
     var authorsWithCount = libraryHelpers.getAuthorsWithCount(libraryItems)
     var genresWithCount = libraryHelpers.getGenresWithCount(libraryItems)
     var durationStats = libraryHelpers.getItemDurationStats(libraryItems)
+    var sizeStats = libraryHelpers.getItemSizeStats(libraryItems)
     var stats = {
       totalItems: libraryItems.length,
       totalAuthors: Object.keys(authorsWithCount).length,
@@ -645,6 +646,7 @@ class LibraryController {
       longestItems: durationStats.longestItems,
       numAudioTracks: durationStats.numAudioTracks,
       totalSize: libraryHelpers.getLibraryItemsTotalSize(libraryItems),
+      largestItems: sizeStats.largestItems,
       authorsWithCount,
       genresWithCount
     }

--- a/server/utils/libraryHelpers.js
+++ b/server/utils/libraryHelpers.js
@@ -280,6 +280,19 @@ module.exports = {
     }
   },
 
+  getItemSizeStats(libraryItems) {
+    var sorted = sort(libraryItems).desc(li => li.media.size)
+    var top10 = sorted.slice(0, 10).map(li => ({ id: li.id, title: li.media.metadata.title, size: li.media.size })).filter(i => i.size > 0)
+    var totalSize = 0
+    libraryItems.forEach((li) => {
+      totalSize += li.media.size
+    })
+    return {
+      totalSize,
+      largestItems: top10
+    }
+  },
+
   getLibraryItemsTotalSize(libraryItems) {
     var totalSize = 0
     libraryItems.forEach((li) => {


### PR DESCRIPTION
 - Add a new stats item listing the top 10 largest podcasts/books
 - Affects the podcast and book stats page
 - Like the longest items stats that use the total duration for an item (summing all the duration of all media in a podcast/book), on the largest items, I am summing all the sizes of all media within a podcast.

<img width="843" alt="Screenshot 2023-02-19 at 21 40 31" src="https://user-images.githubusercontent.com/814828/219976846-2d2f4024-74e7-439c-82ef-95b20b378050.png">
