### PR TITLE
Fixed schedule info when using Prev/Next button

### DIFF
--- a/client/components/modals/item/tabs/Schedule.vue
+++ b/client/components/modals/item/tabs/Schedule.vue
@@ -59,6 +59,14 @@ export default {
       newMaxNewEpisodesToDownload: 0
     }
   },
+  watch: {
+    libraryItem: {
+      immediate: true,
+      handler(newVal) {
+        if (newVal) this.init()
+      }
+    }
+  },
   computed: {
     isProcessing: {
       get() {

--- a/client/components/widgets/CronExpressionBuilder.vue
+++ b/client/components/widgets/CronExpressionBuilder.vue
@@ -279,10 +279,10 @@ export default {
         })
     },
     init() {
-      this.selectedInterval = 'custom';
-      this.selectedHour = 0;
-      this.selectedMinute = 0;
-      this.selectedWeekdays = [];
+      this.selectedInterval = 'custom'
+      this.selectedHour = 0
+      this.selectedMinute = 0
+      this.selectedWeekdays = []
 
       if (!this.value) return
       const pieces = this.value.split(' ')

--- a/client/components/widgets/CronExpressionBuilder.vue
+++ b/client/components/widgets/CronExpressionBuilder.vue
@@ -63,6 +63,14 @@ export default {
       isValid: true
     }
   },
+  watch: {
+    value: {
+      immediate: true,
+      handler(newVal) {
+        this.init()
+      }
+    }
+  },
   computed: {
     minuteIsValid() {
       return !(isNaN(this.selectedMinute) || this.selectedMinute === '' || this.selectedMinute < 0 || this.selectedMinute > 59)
@@ -271,6 +279,11 @@ export default {
         })
     },
     init() {
+      this.selectedInterval = 'custom';
+      this.selectedHour = 0;
+      this.selectedMinute = 0;
+      this.selectedWeekdays = [];
+
       if (!this.value) return
       const pieces = this.value.split(' ')
       if (pieces.length !== 5) {


### PR DESCRIPTION
Today if you set up a schedule for each podcast, you can see the configuration if you access each podcast individually.
But if you try to use the prev/next button to navigate between each podcast schedule, the configuration is not refreshed, and the modal freeze on the first podcast configuration.

This pull request fixes the configuration loading when you use the prev/next button to navigate on the schedule modal.


### Bug 
efore I access each podcast schedule configuration individually after I try to use the Prev/Next button.

https://user-images.githubusercontent.com/814828/220464863-657b1977-43ed-4c4a-b8ba-b2c1fcc71625.mov



### After fix

https://user-images.githubusercontent.com/814828/220464908-c4a5be5d-3323-42d7-8552-661f326ce3ee.mov

