### PR TITLE
Fixed explicit/language info import and added Explicit indicator

### DIFF
--- a/client/components/cards/BookMatchCard.vue
+++ b/client/components/cards/BookMatchCard.vue
@@ -28,7 +28,7 @@
         </div>
       </div>
       <div v-else class="px-4 flex-grow">
-        <h1>{{ book.title }}</h1>
+        <h1>{{ book.title }}<widgets-explicit-indicator :explicit="book.explicit" /></h1>
         <p class="text-base text-gray-300 whitespace-nowrap truncate">by {{ book.author }}</p>
         <p v-if="book.genres" class="text-xs text-gray-400 leading-5">{{ book.genres.join(', ') }}</p>
         <p class="text-xs text-gray-400 leading-5">{{ book.trackCount }} Episodes</p>

--- a/client/components/cards/LazyBookCard.vue
+++ b/client/components/cards/LazyBookCard.vue
@@ -8,7 +8,7 @@
     <!-- Alternative bookshelf title/author/sort -->
     <div v-if="isAlternativeBookshelfView || isAuthorBookshelfView" class="absolute left-0 z-50 w-full" :style="{ bottom: `-${titleDisplayBottomOffset}rem` }">
       <p class="truncate" :style="{ fontSize: 0.9 * sizeMultiplier + 'rem' }">
-        {{ displayTitle }}
+        {{ displayTitle }}<widgets-explicit-indicator :explicit="isExplicit" />
       </p>
       <p class="truncate text-gray-400" :style="{ fontSize: 0.8 * sizeMultiplier + 'rem' }">{{ displayLineTwo || '&nbsp;' }}</p>
       <p v-if="displaySortLine" class="truncate text-gray-400" :style="{ fontSize: 0.8 * sizeMultiplier + 'rem' }">{{ displaySortLine }}</p>
@@ -192,6 +192,9 @@ export default {
     },
     isMusic() {
       return this.mediaType === 'music'
+    },
+    isExplicit() {
+      return this.mediaMetadata.explicit || false
     },
     placeholderUrl() {
       const config = this.$config || this.$nuxt.$config

--- a/client/components/modals/item/tabs/Match.vue
+++ b/client/components/modals/item/tabs/Match.vue
@@ -164,6 +164,13 @@
             <p v-if="mediaMetadata.releaseDate" class="text-xs ml-1 text-white text-opacity-60">{{ $strings.LabelCurrently }} {{ mediaMetadata.releaseDate || '' }}</p>
           </div>
         </div>
+        <div v-if="selectedMatchOrig.explicit != null" class="flex items-center py-2">
+          <ui-checkbox v-model="selectedMatchUsage.explicit" checkbox-bg="bg" @input="checkboxToggled" />
+          <div class="flex-grow ml-4">
+            <ui-checkbox v-model="selectedMatch.explicit" :label="$strings.LabelExplicit" checkbox-bg="primary" border-color="gray-600" label-class="pl-2 text-base font-semibold" />
+            <p v-if="mediaMetadata.explicit != null" class="text-xs ml-1 text-white text-opacity-60">{{ $strings.LabelCurrently }} {{ mediaMetadata.explicit ? 'Explicit (checked)' : 'Not Explicit (unchecked)' }}</p>
+          </div>
+        </div>
 
         <div class="flex items-center justify-end py-2">
           <ui-btn color="success" type="submit">{{ $strings.ButtonSubmit }}</ui-btn>
@@ -327,6 +334,7 @@ export default {
           res.itunesPageUrl = res.pageUrl || null
           res.itunesId = res.id || null
           res.author = res.artistName || null
+          res.explicit = res.explicit || false
           return res
         })
       }

--- a/client/components/modals/podcast/NewModal.vue
+++ b/client/components/modals/podcast/NewModal.vue
@@ -28,6 +28,14 @@
             <ui-multi-select v-model="podcast.genres" :items="podcast.genres" :label="$strings.LabelGenres" />
           </div>
         </div>
+        <div class="flex flex-wrap">
+          <div class="w-full md:w-1/2 p-2">
+            <ui-text-input-with-label v-model="podcast.language" :label="$strings.LabelLanguage" />
+          </div>
+          <div class="flex-grow px-1 pt-6">
+            <ui-checkbox v-model="podcast.explicit" :label="$strings.LabelExplicit" checkbox-bg="primary" border-color="gray-600" label-class="pl-2 text-base font-semibold" />
+          </div>
+        </div>
         <div class="p-2 w-full">
           <ui-textarea-with-label v-model="podcast.description" :label="$strings.LabelDescription" :rows="3" />
         </div>
@@ -82,7 +90,9 @@ export default {
         itunesPageUrl: '',
         itunesId: '',
         itunesArtistId: '',
-        autoDownloadEpisodes: false
+        autoDownloadEpisodes: false,
+        language: '',
+        explicit: false
       }
     }
   },
@@ -170,7 +180,8 @@ export default {
             itunesPageUrl: this.podcast.itunesPageUrl,
             itunesId: this.podcast.itunesId,
             itunesArtistId: this.podcast.itunesArtistId,
-            language: this.podcast.language
+            language: this.podcast.language,
+            explicit: this.podcast.explicit
           },
           autoDownloadEpisodes: this.podcast.autoDownloadEpisodes
         }
@@ -205,8 +216,12 @@ export default {
       this.podcast.itunesPageUrl = this._podcastData.pageUrl || ''
       this.podcast.itunesId = this._podcastData.id || ''
       this.podcast.itunesArtistId = this._podcastData.artistId || ''
-      this.podcast.language = this._podcastData.language || ''
+      this.podcast.language = this._podcastData.language || this.feedMetadata.language || ''
       this.podcast.autoDownloadEpisodes = false
+
+      if (this._podcastData.explicit === 'yes' || this._podcastData.explicit == 'true' || this.feedMetadata.explicit === 'yes' || this.feedMetadata.explicit == 'true') {
+        this.podcast.explicit = true
+      } else this.podcast.explicit = false
 
       if (this.folderItems[0]) {
         this.selectedFolderId = this.folderItems[0].value

--- a/client/components/modals/podcast/NewModal.vue
+++ b/client/components/modals/podcast/NewModal.vue
@@ -219,10 +219,7 @@ export default {
       this.podcast.language = this._podcastData.language || this.feedMetadata.language || ''
       this.podcast.autoDownloadEpisodes = false
 
-      if (this._podcastData.explicit === 'yes' || this._podcastData.explicit == 'true' || this.feedMetadata.explicit === 'yes' || this.feedMetadata.explicit == 'true') {
-        this.podcast.explicit = true
-      } else this.podcast.explicit = false
-
+      this.podcast.explicit = this._podcastData.explicit || this.feedMetadata.explicit === 'yes' || this.feedMetadata.explicit == 'true'
       if (this.folderItems[0]) {
         this.selectedFolderId = this.folderItems[0].value
         this.folderUpdated()

--- a/client/components/widgets/ExplicitIndicator.vue
+++ b/client/components/widgets/ExplicitIndicator.vue
@@ -1,0 +1,17 @@
+<template>
+  <span v-if="explicit" class="material-icons ml-1" style="font-size: 0.8rem">explicit</span>
+</template>
+
+<script>
+export default {
+  props: {
+    explicit: Boolean
+  },
+  data() {
+    return {}
+  },
+  computed: {},
+  methods: {},
+  mounted() {}
+}
+</script>

--- a/client/pages/item/_id/index.vue
+++ b/client/pages/item/_id/index.vue
@@ -25,7 +25,7 @@
           <div class="flex justify-center">
             <div class="mb-4">
               <h1 class="text-2xl md:text-3xl font-semibold">
-                {{ title }}
+                {{ title }}<widgets-explicit-indicator :explicit="isExplicit" />
               </h1>
 
               <p v-if="bookSubtitle" class="text-gray-200 text-xl md:text-2xl">{{ bookSubtitle }}</p>
@@ -314,6 +314,9 @@ export default {
     },
     isInvalid() {
       return this.libraryItem.isInvalid
+    },
+    isExplicit() {
+      return this.mediaMetadata.explicit || false;
     },
     invalidAudioFiles() {
       if (!this.isBook) return []

--- a/client/pages/library/_library/podcast/latest.vue
+++ b/client/pages/library/_library/podcast/latest.vue
@@ -14,14 +14,14 @@
               <div class="flex md:hidden mb-2">
                 <covers-preview-cover :src="$store.getters['globals/getLibraryItemCoverSrcById'](episode.libraryItemId)" :width="48" :book-cover-aspect-ratio="bookCoverAspectRatio" :show-resolution="false" class="md:hidden" />
                 <div class="flex-grow px-2">
-                  <nuxt-link :to="`/item/${episode.libraryItemId}`" class="text-sm text-gray-200 hover:underline">{{ episode.podcast.metadata.title }}</nuxt-link>
+                  <nuxt-link :to="`/item/${episode.libraryItemId}`" class="text-sm text-gray-200 hover:underline">{{ episode.podcast.metadata.title }}</nuxt-link><widgets-explicit-indicator :explicit="episode.podcast.metadata.explicit" />
 
                   <p class="text-xs text-gray-300 mb-1">{{ $dateDistanceFromNow(episode.publishedAt) }}</p>
                 </div>
               </div>
               <!-- desktop -->
               <div class="hidden md:block">
-                <nuxt-link :to="`/item/${episode.libraryItemId}`" class="text-sm text-gray-200 hover:underline">{{ episode.podcast.metadata.title }}</nuxt-link>
+                <nuxt-link :to="`/item/${episode.libraryItemId}`" class="text-sm text-gray-200 hover:underline">{{ episode.podcast.metadata.title }}</nuxt-link><widgets-explicit-indicator :explicit="episode.podcast.metadata.explicit" />
 
                 <p class="text-xs text-gray-300 mb-1">{{ $dateDistanceFromNow(episode.publishedAt) }}</p>
               </div>

--- a/client/pages/library/_library/podcast/search.vue
+++ b/client/pages/library/_library/podcast/search.vue
@@ -20,7 +20,7 @@
               <img v-if="podcast.cover" :src="podcast.cover" class="h-full w-full" />
             </div>
             <div class="flex-grow pl-4 max-w-2xl">
-              <a :href="podcast.pageUrl" class="text-base md:text-lg text-gray-200 hover:underline" target="_blank" @click.stop>{{ podcast.title }}</a>
+              <a :href="podcast.pageUrl" class="text-base md:text-lg text-gray-200 hover:underline" target="_blank" @click.stop>{{ podcast.title }}</a><widgets-explicit-indicator :explicit="podcast.explicit" />
               <p class="text-sm md:text-base text-gray-300 whitespace-nowrap truncate">by {{ podcast.artistName }}</p>
               <p class="text-xs text-gray-400 leading-5">{{ podcast.genres.join(', ') }}</p>
               <p class="text-xs text-gray-400 leading-5">{{ podcast.trackCount }} {{ $strings.HeaderEpisodes }}</p>

--- a/server/providers/iTunes.js
+++ b/server/providers/iTunes.js
@@ -95,7 +95,8 @@ class iTunes {
       cover: this.getCoverArtwork(data),
       trackCount: data.trackCount,
       feedUrl: data.feedUrl,
-      pageUrl: data.collectionViewUrl
+      pageUrl: data.collectionViewUrl,
+      explicit: data.trackExplicitness === 'explicit'
     }
   }
 


### PR DESCRIPTION
The language and explicit information aren't imported when you search for a podcast and add it to the library.
This pull request fixes this and adds an explicit indicator when a podcast/book has the explicit field checked (similar to what Apple Podcasts does).
A component (widget) was created to use the same explicit indicator style.


**Importing Explicit and Language Info**
<img width="969" alt="Screenshot 2023-02-22 at 12 55 49" src="https://user-images.githubusercontent.com/814828/220626616-8ab63e4e-9aec-48e9-91ea-cb894ee2f8ca.png">

**Add explicit info when matching an existent item**
<img width="969" alt="Screenshot 2023-02-22 at 12 56 23" src="https://user-images.githubusercontent.com/814828/220626622-1aade5e0-c43b-45fa-8a51-6b9ef47920a8.png">

**Apple Podcasts explicit label**
<img width="784" alt="Screenshot 2023-02-22 at 13 04 38" src="https://user-images.githubusercontent.com/814828/220627815-cad790a9-1435-4367-8780-22f5cbcaaf90.png">

**Explicit label on the contents**
<img width="884" alt="Screenshot 2023-02-22 at 12 56 53" src="https://user-images.githubusercontent.com/814828/220626626-75e7c84d-4f30-4038-ae60-ecd9585cf9d0.png">

<img width="969" alt="Screenshot 2023-02-22 at 12 56 16" src="https://user-images.githubusercontent.com/814828/220626619-71009f52-ca3b-41db-8bf2-432bf557cc67.png">

<img width="883" alt="Screenshot 2023-02-22 at 12 53 52" src="https://user-images.githubusercontent.com/814828/220626599-47c5cd5f-67c2-4c17-b82f-c86276c57ed9.png">

<img width="864" alt="Screenshot 2023-02-22 at 13 12 20" src="https://user-images.githubusercontent.com/814828/220629972-7553f027-1a39-40f9-a337-444bbb906ba8.png">

**Works for books as well**
<img width="629" alt="Screenshot 2023-02-22 at 13 12 44" src="https://user-images.githubusercontent.com/814828/220630014-95635f8e-517e-476e-8939-8cf64265fb32.png">


