### PR TITLE
Adding podcast type, season and episode info to the feed

### DIFF
--- a/client/components/modals/podcast/NewModal.vue
+++ b/client/components/modals/podcast/NewModal.vue
@@ -33,6 +33,11 @@
         </div>
         <div class="flex flex-wrap">
           <div class="w-full md:w-1/2 p-2">
+            <ui-dropdown :label="$strings.LabelPodcastType" v-model="podcast.type" :items="podcastTypes" small />
+          </div>
+        </div>
+        <div class="flex flex-wrap">
+          <div class="w-full md:w-1/2 p-2">
             <ui-dropdown v-model="selectedFolderId" :items="folderItems" :disabled="processing" :label="$strings.LabelFolder" @input="folderUpdated" />
           </div>
           <div class="w-full md:w-1/2 p-2">
@@ -82,7 +87,8 @@ export default {
         itunesPageUrl: '',
         itunesId: '',
         itunesArtistId: '',
-        autoDownloadEpisodes: false
+        autoDownloadEpisodes: false,
+        type: ''
       }
     }
   },
@@ -140,6 +146,9 @@ export default {
     selectedFolderPath() {
       if (!this.selectedFolder) return ''
       return this.selectedFolder.fullPath
+    },
+    podcastTypes() {
+      return this.$store.state.globals.podcastTypes || []
     }
   },
   methods: {
@@ -170,7 +179,8 @@ export default {
             itunesPageUrl: this.podcast.itunesPageUrl,
             itunesId: this.podcast.itunesId,
             itunesArtistId: this.podcast.itunesArtistId,
-            language: this.podcast.language
+            language: this.podcast.language,
+            type: this.podcast.type
           },
           autoDownloadEpisodes: this.podcast.autoDownloadEpisodes
         }
@@ -207,6 +217,7 @@ export default {
       this.podcast.itunesArtistId = this._podcastData.artistId || ''
       this.podcast.language = this._podcastData.language || ''
       this.podcast.autoDownloadEpisodes = false
+      this.podcast.type = this._podcastData.type || this.feedMetadata.type || 'episodic'
 
       if (this.folderItems[0]) {
         this.selectedFolderId = this.folderItems[0].value

--- a/client/components/modals/podcast/NewModal.vue
+++ b/client/components/modals/podcast/NewModal.vue
@@ -29,20 +29,18 @@
           </div>
         </div>
         <div class="flex flex-wrap">
-          <div class="w-full md:w-1/2 p-2">
+          <div class="md:w-1/4 p-2">
+            <ui-dropdown :label="$strings.LabelPodcastType" v-model="podcast.type" :items="podcastTypes" small />
+          </div>
+          <div class="md:w-1/4 p-2">
             <ui-text-input-with-label v-model="podcast.language" :label="$strings.LabelLanguage" />
           </div>
-          <div class="flex-grow px-1 pt-6">
+          <div class="md:w-1/4 px-2 pt-7">
             <ui-checkbox v-model="podcast.explicit" :label="$strings.LabelExplicit" checkbox-bg="primary" border-color="gray-600" label-class="pl-2 text-base font-semibold" />
           </div>
         </div>
         <div class="p-2 w-full">
           <ui-textarea-with-label v-model="podcast.description" :label="$strings.LabelDescription" :rows="3" />
-        </div>
-        <div class="flex flex-wrap">
-          <div class="w-full md:w-1/2 p-2">
-            <ui-dropdown :label="$strings.LabelPodcastType" v-model="podcast.type" :items="podcastTypes" small />
-          </div>
         </div>
         <div class="flex flex-wrap">
           <div class="w-full md:w-1/2 p-2">

--- a/client/components/modals/podcast/tabs/EpisodeDetails.vue
+++ b/client/components/modals/podcast/tabs/EpisodeDetails.vue
@@ -8,7 +8,7 @@
         <ui-text-input-with-label v-model="newEpisode.episode" :label="$strings.LabelEpisode" />
       </div>
       <div class="w-1/5 p-1">
-        <ui-text-input-with-label v-model="newEpisode.episodeType" :label="$strings.LabelEpisodeType" />
+        <ui-dropdown v-model="newEpisode.episodeType" :label="$strings.LabelEpisodeType" :items="episodeTypes" small />
       </div>
       <div class="w-2/5 p-1">
         <ui-text-input-with-label v-model="pubDateInput" @input="updatePubDate" type="datetime-local" :label="$strings.LabelPubDate" />
@@ -89,6 +89,9 @@ export default {
     },
     enclosureUrl() {
       return this.enclosure.url
+    },
+    episodeTypes() {
+      return this.$store.state.globals.episodeTypes || []
     }
   },
   methods: {

--- a/client/components/widgets/PodcastDetailsEdit.vue
+++ b/client/components/widgets/PodcastDetailsEdit.vue
@@ -39,6 +39,11 @@
           </div>
         </div>
       </div>
+      <div class="flex mt-2 -mx-1">
+        <div class="w-1/4 px-1">
+          <ui-dropdown :label="$strings.LabelPodcastType" v-model="details.type" :items="podcastTypes" small class="max-w-52" />
+        </div>
+      </div>
     </form>
   </div>
 </template>
@@ -65,7 +70,8 @@ export default {
         itunesId: null,
         itunesArtistId: null,
         explicit: false,
-        language: null
+        language: null,
+        type: null
       },
       newTags: []
     }
@@ -93,7 +99,10 @@ export default {
     },
     filterData() {
       return this.$store.state.libraries.filterData || {}
-    }
+    },
+    podcastTypes() {
+      return this.$store.state.globals.podcastTypes || []
+    },
   },
   methods: {
     getDetails() {
@@ -219,6 +228,7 @@ export default {
       this.details.itunesArtistId = this.mediaMetadata.itunesArtistId || ''
       this.details.language = this.mediaMetadata.language || ''
       this.details.explicit = !!this.mediaMetadata.explicit
+      this.details.type = this.mediaMetadata.type || 'episodic'
 
       this.newTags = [...(this.media.tags || [])]
     },

--- a/client/components/widgets/PodcastDetailsEdit.vue
+++ b/client/components/widgets/PodcastDetailsEdit.vue
@@ -102,7 +102,7 @@ export default {
     },
     podcastTypes() {
       return this.$store.state.globals.podcastTypes || []
-    },
+    }
   },
   methods: {
     getDetails() {

--- a/client/store/globals.js
+++ b/client/store/globals.js
@@ -37,6 +37,15 @@ export const state = () => ({
       value: 'yyyy-MM-dd'
     }
   ],
+  podcastTypes: [
+    { text: 'Episodic', value: 'episodic' },
+    { text: 'Serial', value: 'serial' }
+  ],
+  episodeTypes: [
+    { text: 'Full', value: 'full' },
+    { text: 'Trailer', value: 'trailer' },
+    { text: 'Bonus', value: 'bonus' }
+  ],
   libraryIcons: ['database', 'audiobookshelf', 'books-1', 'books-2', 'book-1', 'microphone-1', 'microphone-3', 'radio', 'podcast', 'rss', 'headphones', 'music', 'file-picture', 'rocket', 'power', 'star', 'heart']
 })
 

--- a/client/strings/de.json
+++ b/client/strings/de.json
@@ -301,6 +301,7 @@
   "LabelPlayMethod": "Abspielmethode",
   "LabelPodcast": "Podcast",
   "LabelPodcasts": "Podcasts",
+  "LabelPodcastType": "Podcast Type",
   "LabelPrefixesToIgnore": "Zu ignorierende(s) Vorwort(e) (Groß- und Kleinschreibung wird nicht berücksichtigt)",
   "LabelProgress": "Fortschritt",
   "LabelProvider": "Anbieter",

--- a/client/strings/en-us.json
+++ b/client/strings/en-us.json
@@ -301,6 +301,7 @@
   "LabelPlayMethod": "Play Method",
   "LabelPodcast": "Podcast",
   "LabelPodcasts": "Podcasts",
+  "LabelPodcastType": "Podcast Type",
   "LabelPrefixesToIgnore": "Prefixes to Ignore (case insensitive)",
   "LabelProgress": "Progress",
   "LabelProvider": "Provider",

--- a/client/strings/es.json
+++ b/client/strings/es.json
@@ -301,6 +301,7 @@
   "LabelPlayMethod": "Play Method",
   "LabelPodcast": "Podcast",
   "LabelPodcasts": "Podcasts",
+  "LabelPodcastType": "Podcast Type",
   "LabelPrefixesToIgnore": "Prefixes to Ignore (case insensitive)",
   "LabelProgress": "Progress",
   "LabelProvider": "Provider",

--- a/client/strings/fr.json
+++ b/client/strings/fr.json
@@ -301,6 +301,7 @@
   "LabelPlayMethod": "Méthode d'écoute",
   "LabelPodcast": "Podcast",
   "LabelPodcasts": "Podcasts",
+  "LabelPodcastType": "Podcast Type",
   "LabelPrefixesToIgnore": "Préfixes à Ignorer (Insensible à la Casse)",
   "LabelProgress": "Progression",
   "LabelProvider": "Fournisseur",

--- a/client/strings/hr.json
+++ b/client/strings/hr.json
@@ -301,6 +301,7 @@
   "LabelPlayMethod": "Vrsta reprodukcije",
   "LabelPodcast": "Podcast",
   "LabelPodcasts": "Podcasts",
+  "LabelPodcastType": "Podcast Type",
   "LabelPrefixesToIgnore": "Prefiksi za ignorirati (mala i velika slova nisu bitna)",
   "LabelProgress": "Napredak",
   "LabelProvider": "Dobavljač",

--- a/client/strings/it.json
+++ b/client/strings/it.json
@@ -301,6 +301,7 @@
   "LabelPlayMethod": "Metodo di riproduzione",
   "LabelPodcast": "Podcast",
   "LabelPodcasts": "Podcasts",
+  "LabelPodcastType": "Podcast Type",
   "LabelPrefixesToIgnore": "Suffissi da ignorare (specificando maiuscole e minuscole)",
   "LabelProgress": "Cominciati",
   "LabelProvider": "Provider",

--- a/client/strings/pl.json
+++ b/client/strings/pl.json
@@ -301,6 +301,7 @@
   "LabelPlayMethod": "Metoda odtwarzania",
   "LabelPodcast": "Podcast",
   "LabelPodcasts": "Podcasty",
+  "LabelPodcastType": "Podcast Type",
   "LabelPrefixesToIgnore": "Ignorowane prefiksy (wielkość liter nie ma znaczenia)",
   "LabelProgress": "Postęp",
   "LabelProvider": "Dostawca",

--- a/client/strings/ru.json
+++ b/client/strings/ru.json
@@ -301,6 +301,7 @@
   "LabelPlayMethod": "Метод Воспроизведения",
   "LabelPodcast": "Подкаст",
   "LabelPodcasts": "Подкасты",
+  "LabelPodcastType": "Podcast Type",
   "LabelPrefixesToIgnore": "Игнорируемые Префиксы (без учета регистра)",
   "LabelProgress": "Прогресс",
   "LabelProvider": "Провайдер",

--- a/client/strings/zh-cn.json
+++ b/client/strings/zh-cn.json
@@ -301,6 +301,7 @@
   "LabelPlayMethod": "播放方法",
   "LabelPodcast": "播客",
   "LabelPodcasts": "播客",
+  "LabelPodcastType": "Podcast Type",
   "LabelPrefixesToIgnore": "忽略的前缀 (不区分大小写)",
   "LabelProgress": "进度",
   "LabelProvider": "供应商",

--- a/server/objects/Feed.js
+++ b/server/objects/Feed.js
@@ -107,6 +107,7 @@ class Feed {
     this.meta.link = `${serverAddress}/item/${libraryItem.id}`
     this.meta.explicit = !!mediaMetadata.explicit
     this.meta.type = mediaMetadata.type
+    this.meta.language = mediaMetadata.language
 
     this.episodes = []
     if (isPodcast) { // PODCAST EPISODES
@@ -144,6 +145,7 @@ class Feed {
     this.meta.imageUrl = media.coverPath ? `${this.serverAddress}/feed/${this.slug}/cover` : `${this.serverAddress}/Logo.png`
     this.meta.explicit = !!mediaMetadata.explicit
     this.meta.type = mediaMetadata.type
+    this.meta.language = mediaMetadata.language
 
     this.episodes = []
     if (isPodcast) { // PODCAST EPISODES

--- a/server/objects/Feed.js
+++ b/server/objects/Feed.js
@@ -106,6 +106,7 @@ class Feed {
     this.meta.feedUrl = feedUrl
     this.meta.link = `${serverAddress}/item/${libraryItem.id}`
     this.meta.explicit = !!mediaMetadata.explicit
+    this.meta.type = mediaMetadata.type
 
     this.episodes = []
     if (isPodcast) { // PODCAST EPISODES
@@ -142,6 +143,7 @@ class Feed {
     this.meta.author = author
     this.meta.imageUrl = media.coverPath ? `${this.serverAddress}/feed/${this.slug}/cover` : `${this.serverAddress}/Logo.png`
     this.meta.explicit = !!mediaMetadata.explicit
+    this.meta.type = mediaMetadata.type
 
     this.episodes = []
     if (isPodcast) { // PODCAST EPISODES

--- a/server/objects/FeedEpisode.js
+++ b/server/objects/FeedEpisode.js
@@ -14,6 +14,9 @@ class FeedEpisode {
     this.author = null
     this.explicit = null
     this.duration = null
+    this.season = null
+    this.episode = null
+    this.episodeType = null
 
     this.libraryItemId = null
     this.episodeId = null
@@ -35,6 +38,9 @@ class FeedEpisode {
     this.author = episode.author
     this.explicit = episode.explicit
     this.duration = episode.duration
+    this.season = episode.season
+    this.episode = episode.episode
+    this.episodeType = episode.episodeType
     this.libraryItemId = episode.libraryItemId
     this.episodeId = episode.episodeId || null
     this.trackIndex = episode.trackIndex || 0
@@ -52,6 +58,9 @@ class FeedEpisode {
       author: this.author,
       explicit: this.explicit,
       duration: this.duration,
+      season: this.season,
+      episode: this.episode,
+      episodeType: this.episodeType,
       libraryItemId: this.libraryItemId,
       episodeId: this.episodeId,
       trackIndex: this.trackIndex,
@@ -77,6 +86,9 @@ class FeedEpisode {
     this.author = meta.author
     this.explicit = mediaMetadata.explicit
     this.duration = episode.duration
+    this.season = episode.season
+    this.episode = episode.episode
+    this.episodeType = episode.episodeType
     this.libraryItemId = libraryItem.id
     this.episodeId = episode.id
     this.trackIndex = 0
@@ -144,7 +156,10 @@ class FeedEpisode {
         { 'itunes:summary': this.description || '' },
         {
           "itunes:explicit": !!this.explicit
-        }
+        },
+        {"itunes:episodeType": this.episodeType},
+        {"itunes:season": this.season},
+        {"itunes:episode": this.episode}
       ]
     }
   }

--- a/server/objects/FeedMeta.js
+++ b/server/objects/FeedMeta.js
@@ -7,6 +7,7 @@ class FeedMeta {
     this.feedUrl = null
     this.link = null
     this.explicit = null
+    this.type = null
 
     if (meta) {
       this.construct(meta)
@@ -21,6 +22,7 @@ class FeedMeta {
     this.feedUrl = meta.feedUrl
     this.link = meta.link
     this.explicit = meta.explicit
+    this.type = meta.type
   }
 
   toJSON() {
@@ -31,7 +33,8 @@ class FeedMeta {
       imageUrl: this.imageUrl,
       feedUrl: this.feedUrl,
       link: this.link,
-      explicit: this.explicit
+      explicit: this.explicit,
+      type: this.type
     }
   }
 
@@ -53,6 +56,7 @@ class FeedMeta {
         { 'author': this.author || 'advplyr' },
         { 'itunes:author': this.author || 'advplyr' },
         { 'itunes:summary': this.description || '' },
+        { 'itunes:type': this.type },
         {
           'itunes:image': {
             _attr: {

--- a/server/objects/FeedMeta.js
+++ b/server/objects/FeedMeta.js
@@ -8,6 +8,7 @@ class FeedMeta {
     this.link = null
     this.explicit = null
     this.type = null
+    this.language = null
 
     if (meta) {
       this.construct(meta)
@@ -23,6 +24,7 @@ class FeedMeta {
     this.link = meta.link
     this.explicit = meta.explicit
     this.type = meta.type
+    this.language = meta.language
   }
 
   toJSON() {
@@ -34,7 +36,8 @@ class FeedMeta {
       feedUrl: this.feedUrl,
       link: this.link,
       explicit: this.explicit,
-      type: this.type
+      type: this.type,
+      language: this.language
     }
   }
 
@@ -46,13 +49,13 @@ class FeedMeta {
       feed_url: this.feedUrl,
       site_url: this.link,
       image_url: this.imageUrl,
-      language: 'en',
       custom_namespaces: {
         'itunes': 'http://www.itunes.com/dtds/podcast-1.0.dtd',
         'psc': 'http://podlove.org/simple-chapters',
         'podcast': 'https://podcastindex.org/namespace/1.0'
       },
       custom_elements: [
+        { 'language': this.language || 'en' },
         { 'author': this.author || 'advplyr' },
         { 'itunes:author': this.author || 'advplyr' },
         { 'itunes:summary': this.description || '' },

--- a/server/objects/entities/PodcastEpisode.js
+++ b/server/objects/entities/PodcastEpisode.js
@@ -117,7 +117,7 @@ class PodcastEpisode {
     this.enclosure = data.enclosure ? { ...data.enclosure } : null
     this.season = data.season || ''
     this.episode = data.episode || ''
-    this.episodeType = data.episodeType || ''
+    this.episodeType = data.episodeType || 'full'
     this.publishedAt = data.publishedAt || 0
     this.addedAt = Date.now()
     this.updatedAt = Date.now()

--- a/server/objects/metadata/PodcastMetadata.js
+++ b/server/objects/metadata/PodcastMetadata.js
@@ -15,6 +15,7 @@ class PodcastMetadata {
     this.itunesArtistId = null
     this.explicit = false
     this.language = null
+    this.type = null
 
     if (metadata) {
       this.construct(metadata)
@@ -34,6 +35,7 @@ class PodcastMetadata {
     this.itunesArtistId = metadata.itunesArtistId
     this.explicit = metadata.explicit
     this.language = metadata.language || null
+    this.type = metadata.type || 'episodic'
   }
 
   toJSON() {
@@ -49,7 +51,8 @@ class PodcastMetadata {
       itunesId: this.itunesId,
       itunesArtistId: this.itunesArtistId,
       explicit: this.explicit,
-      language: this.language
+      language: this.language,
+      type: this.type
     }
   }
 
@@ -67,7 +70,8 @@ class PodcastMetadata {
       itunesId: this.itunesId,
       itunesArtistId: this.itunesArtistId,
       explicit: this.explicit,
-      language: this.language
+      language: this.language,
+      type: this.type
     }
   }
 
@@ -112,6 +116,7 @@ class PodcastMetadata {
     this.itunesArtistId = mediaMetadata.itunesArtistId || null
     this.explicit = !!mediaMetadata.explicit
     this.language = mediaMetadata.language || null
+    this.type = mediaMetadata.type || null
     if (mediaMetadata.genres && mediaMetadata.genres.length) {
       this.genres = [...mediaMetadata.genres]
     }

--- a/server/scanner/Scanner.js
+++ b/server/scanner/Scanner.js
@@ -899,7 +899,7 @@ class Scanner {
       description: episodeToMatch.description || '',
       enclosure: episodeToMatch.enclosure || null,
       episode: episodeToMatch.episode || '',
-      episodeType: episodeToMatch.episodeType || '',
+      episodeType: episodeToMatch.episodeType || 'full',
       season: episodeToMatch.season || '',
       pubDate: episodeToMatch.pubDate || '',
       publishedAt: episodeToMatch.publishedAt

--- a/server/utils/podcastUtils.js
+++ b/server/utils/podcastUtils.js
@@ -46,7 +46,8 @@ function extractPodcastMetadata(channel) {
     categories: extractCategories(channel),
     feedUrl: null,
     description: null,
-    descriptionPlain: null
+    descriptionPlain: null,
+    type: null
   }
 
   if (channel['itunes:new-feed-url']) {
@@ -61,7 +62,7 @@ function extractPodcastMetadata(channel) {
     metadata.descriptionPlain = htmlSanitizer.stripAllTags(rawDescription)
   }
 
-  var arrayFields = ['title', 'language', 'itunes:explicit', 'itunes:author', 'pubDate', 'link']
+  var arrayFields = ['title', 'language', 'itunes:explicit', 'itunes:author', 'pubDate', 'link', 'itunes:type']
   arrayFields.forEach((key) => {
     var cleanKey = key.split(':').pop()
     metadata[cleanKey] = extractFirstArrayItem(channel, key)


### PR DESCRIPTION
To make the RSS Feed more compliant with the RSS Feed standards, I created this pull request to add:
 - Add a podcast type field <_itunes:type_> - Episodic (default) or Serial
 - Add a dropdown with the episode types <_itunes:episodeType_> - Full, Trailer, Bonus
 - Add Season, Episode number, Episode Type and Podcast Type on the Feed - <_itunes:season_>, <_itunes:episode_>, <_itunes:episodeType_> and <_itunes:type_>
 - Use language information from the Item for the language tag. If the item doesn't have language information use "_en_" as default. - <_language_>

----
**Context:**
I researched to identify the Podcast Types and Episodes Types patterns used by iTunes Podcast, Google Podcast, and other providers. All open services use the same pattern informed by [Apple - A Podcaster’s Guide to RSS](https://help.apple.com/itc/podcasts_connect/#/itcb54353390).
W3C Feed validator also recommends the same types: [Episode Type](https://validator.w3.org/feed/docs/error/InvalidItunesEpisodeType.html) and [Channel Type ](https://validator.w3.org/feed/docs/error/InvalidItunesChannelType.html)

These are the types used:
 - Podcast Types:
   - **Episodic** (default). Specify episodic when episodes are intended to be consumed without any specific order. Apple Podcasts will present newest episodes first and display the publish date (required) of each episode. If organized into [seasons](https://help.apple.com/itc/podcasts_connect/#/itc77382b700), the newest season will be presented first - otherwise, episodes will be grouped by year published, newest first.
   - **Serial**. Specify serial when episodes are intended to be consumed in sequential order. Apple Podcasts will present the oldest episodes first and display the episode numbers (required) of each episode. If organized into seasons, the newest season will be presented first and <_itunes:episode_> numbers must be given for each episode.
 - Episode Types:
   - **Full** (default). Specify full when you are submitting the complete content of your [show](https://help.apple.com/itc/podcasts_connect/#/itca5dea085b).
   - **Trailer**. Specify trailer when you are submitting a short, promotional piece of content that represents a preview of your current show.
   - **Bonus**. Specify bonus when you are submitting extra content for your show (for example, behind the scenes information or interviews with the cast) or cross-promotional content for another show.
---

### Editing podcast type on an existing podcast
<img width="827" alt="Screenshot 2023-02-22 at 18 58 55" src="https://user-images.githubusercontent.com/814828/220736040-6bab0433-697b-484d-9878-85a14a13f298.png">

### Adding a podcast from the search and importing the podcast type
<img width="1118" alt="Screenshot 2023-02-22 at 19 15 44" src="https://user-images.githubusercontent.com/814828/220736110-86469ef3-41e4-46c3-b939-0ba222b9c61c.png">

### Screenshot demonstrating the podcasts app loading the Podcast Type, Season and Episode number from the RSS.

<img width="517" alt="Screenshot 2023-02-22 at 19 27 55" src="https://user-images.githubusercontent.com/814828/220738684-41a5ae8a-7eef-4ad2-a9df-02c1444b75b6.png">
