### PR TITLE
Support for scanning semicolon seperated author and narator lists.

### DIFF
--- a/server/utils/parsers/parseNameString.js
+++ b/server/utils/parsers/parseNameString.js
@@ -43,6 +43,8 @@ module.exports.parse = (nameString) => {
   // Example &LF: Friedman, Milton & Friedman, Rose
   if (nameString.includes('&')) {
     nameString.split('&').forEach((asa) => splitNames = splitNames.concat(asa.split(',')))
+  } else if (nameString.includes(';')) {
+    nameString.split(';').forEach((asa) => splitNames = splitNames.concat(asa.split(',')))
   } else {
     splitNames = nameString.split(',')
   }


### PR DESCRIPTION
#793

Duplicate "&" style multi author/narrator support for semicolon. I did consider a loop for handling separators, but it seems like overkill, however happy to be persuaded.