### PR TITLE
Fix transcoded streams fail to continue listening

### DIFF
--- a/client/players/LocalAudioPlayer.js
+++ b/client/players/LocalAudioPlayer.js
@@ -149,7 +149,7 @@ export default class LocalAudioPlayer extends EventEmitter {
 
     this.hlsInstance.attachMedia(this.player)
     this.hlsInstance.on(Hls.Events.MEDIA_ATTACHED, () => {
-      this.hlsInstance.loadSource(m3u8Url)
+      this.hlsInstance.loadSource(this.currentTrack.relativeContentUrl)
 
       this.hlsInstance.on(Hls.Events.MANIFEST_PARSED, () => {
         console.log('[HLS] Manifest Parsed')


### PR DESCRIPTION
For example alac did not continue at the saved point. This was due an error in the Web UI choosing a non existent m3u8 Url. Also tested on iOS because there a fallback is used.