### PR TITLE
Fix: Resseting time is not taking account codec and mime type resulting in isResetting loop

### DIFF
--- a/server/objects/Stream.js
+++ b/server/objects/Stream.js
@@ -314,7 +314,7 @@ class Stream extends EventEmitter {
       Logger.info('')
       if (this.isResetting) {
         // AAC encode is much slower
-        const clearIsResettingTime = this.transcodeForceAAC ? 3000 : 500
+        const clearIsResettingTime = this.transcodeForceAAC ? 10000 : 500
         setTimeout(() => {
           Logger.info('[STREAM] Clearing isResetting')
           this.isResetting = false

--- a/server/objects/Stream.js
+++ b/server/objects/Stream.js
@@ -121,7 +121,7 @@ class Stream extends EventEmitter {
     return ['mp4', 'm4a', 'm4b'].includes(this.tracksAudioFileType)
   }
   get transcodeForceAAC() {
-    return !!this.transcodeOptions.forceAAC
+    return !!this.transcodeOptions.forceAAC || this.mimeTypesToForceAAC.includes(this.tracksMimeType) || this.codecsToForceAAC.includes(this.tracksCodec)
   }
 
   toJSON() {
@@ -275,7 +275,7 @@ class Stream extends EventEmitter {
     const logLevel = process.env.NODE_ENV === 'production' ? 'error' : 'warning'
 
     let audioCodec = 'copy'
-    if (this.transcodeForceAAC || this.mimeTypesToForceAAC.includes(this.tracksMimeType) || this.codecsToForceAAC.includes(this.tracksCodec)) {
+    if (this.transcodeForceAAC) {
       Logger.debug(`[Stream] Forcing AAC for tracks with mime type ${this.tracksMimeType} and codec ${this.tracksCodec}`)
       audioCodec = 'aac'
     }


### PR DESCRIPTION
The long resetting time is not triggered if transcode is triggered because mimetype or codec. This resulted in a resetting loop, always starting a new transcode.

```
audiobookshelf  | [2023-03-21 06:39:12] INFO: 
audiobookshelf  | [2023-03-21 06:39:13] INFO: [STREAM] Clearing isResetting
audiobookshelf  | [2023-03-21 06:39:13] WARN: File path does not exist /metadata/streams/play_ege9befho8m2xsrhrt/output-289.ts (HlsRouter.js:37)
audiobookshelf  | [2023-03-21 06:39:13] INFO: Segment #289 requested is 287 segments from latest (28:54.0) - Reset Transcode
audiobookshelf  | [2023-03-21 06:39:13] INFO: [FFMPEG] Transcode Killed
audiobookshelf  | [2023-03-21 06:39:14] INFO: Stream Reset New Start Time 28:42.0
audiobookshelf  | [2023-03-21 06:39:14] INFO: [STREAM] START STREAM - Num Segments: 793
audiobookshelf  | [2023-03-21 06:39:14] INFO: [HlsRouter] Resetting Stream - notify client @1734s
audiobookshelf  | [2023-03-21 06:39:14] INFO: [STREAM] Starting Stream at startTime 28:12.0 (User startTime 28:42.0) and Segment #282
audiobookshelf  | [2023-03-21 06:39:14] DEBUG: [Stream] Forcing AAC for tracks with mime type audio/mp4 and codec alac (Stream.js:279)
audiobookshelf  | [2023-03-21 06:39:14] INFO: [INFO] FFMPEG transcoding started with command: ffmpeg -seek_timestamp 1 -f concat -safe 0 -ss 203s -noaccurate_seek -i /metadata/streams/play_ege9befho8m2xsrhrt/files.txt -y -loglevel error -map 0:a -c:a aac -f hls -copyts -avoid_negative_ts make_non_negative -max_delay 5000000 -max_muxing_queue_size 2048 -hls_time 6 -hls_segment_type mpegts -start_number 282 -hls_playlist_type vod -hls_list_size 0 -hls_allow_cache 0 -hls_segment_filename /metadata/streams/play_ege9befho8m2xsrhrt/output-%d.ts /metadata/streams/play_ege9befho8m2xsrhrt/final-output.m3u8
audiobookshelf  | [2023-03-21 06:39:14] INFO: 
audiobookshelf  | [2023-03-21 06:39:14] INFO: [STREAM] Clearing isResetting
audiobookshelf  | [2023-03-21 06:39:15] WARN: File path does not exist /metadata/streams/play_ege9befho8m2xsrhrt/output-289.ts (HlsRouter.js:37)
audiobookshelf  | [2023-03-21 06:39:15] INFO: Segment #289 requested is 287 segments from latest (28:54.0) - Reset Transcode
audiobookshelf  | [2023-03-21 06:39:15] INFO: [FFMPEG] Transcode Killed
audiobookshelf  | [2023-03-21 06:39:16] INFO: Stream Reset New Start Time 28:42.0
audiobookshelf  | [2023-03-21 06:39:16] INFO: [STREAM] START STREAM - Num Segments: 793
audiobookshelf  | [2023-03-21 06:39:16] INFO: [HlsRouter] Resetting Stream - notify client @1734s
audiobookshelf  | [2023-03-21 06:39:16] INFO: [STREAM] Starting Stream at startTime 28:12.0 (User startTime 28:42.0) and Segment #282
audiobookshelf  | [2023-03-21 06:39:16] DEBUG: [Stream] Forcing AAC for tracks with mime type audio/mp4 and codec alac (Stream.js:279)
audiobookshelf  | [2023-03-21 06:39:16] INFO: [INFO] FFMPEG transcoding started with command: ffmpeg -seek_timestamp 1 -f concat -safe 0 -ss 203s -noaccurate_seek -i /metadata/streams/play_ege9befho8m2xsrhrt/files.txt -y -loglevel error -map 0:a -c:a aac -f hls -copyts -avoid_negative_ts make_non_negative -max_delay 5000000 -max_muxing_queue_size 2048 -hls_time 6 -hls_segment_type mpegts -start_number 282 -hls_playlist_type vod -hls_list_size 0 -hls_allow_cache 0 -hls_segment_filename /metadata/streams/play_ege9befho8m2xsrhrt/output-%d.ts /metadata/streams/play_ege9befho8m2xsrhrt/final-output.m3u8
audiobookshelf  | [2023-03-21 06:39:16] INFO: 
audiobookshelf  | [2023-03-21 06:39:16] INFO: [STREAM] Clearing isResetting
audiobookshelf  | [2023-03-21 06:39:17] WARN: File path does not exist /metadata/streams/play_ege9befho8m2xsrhrt/output-289.ts (HlsRouter.js:37)
audiobookshelf  | [2023-03-21 06:39:17] INFO: Segment #289 requested is 287 segments from latest (28:54.0) - Reset Transcode
audiobookshelf  | [2023-03-21 06:39:17] INFO: [FFMPEG] Transcode Killed
audiobookshelf  | [2023-03-21 06:39:18] INFO: Stream Reset New Start Time 28:42.0
audiobookshelf  | [2023-03-21 06:39:18] INFO: [STREAM] START STREAM - Num Segments: 793
audiobookshelf  | [2023-03-21 06:39:18] INFO: [HlsRouter] Resetting Stream - notify client @1734s
audiobookshelf  | [2023-03-21 06:39:18] INFO: [STREAM] Starting Stream at startTime 28:12.0 (User startTime 28:42.0) and Segment #282
audiobookshelf  | [2023-03-21 06:39:18] DEBUG: [Stream] Forcing AAC for tracks with mime type audio/mp4 and codec alac (Stream.js:279)
audiobookshelf  | [2023-03-21 06:39:18] INFO: [INFO] FFMPEG transcoding started with command: ffmpeg -seek_timestamp 1 -f concat -safe 0 -ss 203s -noaccurate_seek -i /metadata/streams/play_ege9befho8m2xsrhrt/files.txt -y -loglevel error -map 0:a -c:a aac -f hls -copyts -avoid_negative_ts make_non_negative -max_delay 5000000 -max_muxing_queue_size 2048 -hls_time 6 -hls_segment_type mpegts -start_number 282 -hls_playlist_type vod -hls_list_size 0 -hls_allow_cache 0 -hls_segment_filename /metadata/streams/play_ege9befho8m2xsrhrt/output-%d.ts /metadata/streams/play_ege9befho8m2xsrhrt/final-output.m3u8

```

`const clearIsResettingTime = this.transcodeForceAAC ? 3000 : 500`might change the `clearIsResettingTime` to 10 seconds. On low powered hardware 3 seconds is to short, and it might falls into the isResetting loop. Maybe the waiting time should be an env var or ui-setting to customize for the device?