### PR TITLE
blur the url input when clicking submit to add info currently in input

### DIFF
--- a/client/components/modals/notification/NotificationEditModal.vue
+++ b/client/components/modals/notification/NotificationEditModal.vue
@@ -10,7 +10,7 @@
         <div class="w-full px-3 py-5 md:p-12">
           <ui-dropdown v-model="newNotification.eventName" :label="$strings.LabelNotificationEvent" :items="eventOptions" class="mb-4" @input="eventOptionUpdated" />
 
-          <ui-multi-select v-model="newNotification.urls" :label="$strings.LabelNotificationAppriseURL" class="mb-2" />
+          <ui-multi-select ref="urlsInput" v-model="newNotification.urls" :label="$strings.LabelNotificationAppriseURL" class="mb-2" />
 
           <ui-text-input-with-label v-model="newNotification.titleTemplate" :label="$strings.LabelNotificationTitleTemplate" class="mb-2" />
 
@@ -103,6 +103,8 @@ export default {
       if (this.$refs.modal) this.$refs.modal.setHide()
     },
     submitForm() {
+      this.$ref.urlsInput.blur()
+      
       if (!this.newNotification.urls.length) {
         this.$toast.error('Must enter an Apprise URL')
         return


### PR DESCRIPTION
Current behavior: if user has entered information in url input box but it hasn't been defocused, an error will be thrown. This blurs the input when the user taps the submit button to add what's in the input as a url