### PR TITLE
Add AudiobookCovers.com metadata provider

### DIFF
--- a/client/components/modals/item/tabs/Cover.vue
+++ b/client/components/modals/item/tabs/Cover.vue
@@ -49,7 +49,7 @@
     </div>
     <form @submit.prevent="submitSearchForm">
       <div class="flex items-center justify-start -mx-1 h-20">
-        <div class="w-45 px-1">
+        <div class="w-48 px-1">
           <ui-dropdown v-model="provider" :items="providers" :label="$strings.LabelProvider" small />
         </div>
         <div class="w-72 px-1">

--- a/client/components/modals/item/tabs/Cover.vue
+++ b/client/components/modals/item/tabs/Cover.vue
@@ -49,13 +49,13 @@
     </div>
     <form @submit.prevent="submitSearchForm">
       <div class="flex items-center justify-start -mx-1 h-20">
-        <div class="w-40 px-1">
+        <div class="w-45 px-1">
           <ui-dropdown v-model="provider" :items="providers" :label="$strings.LabelProvider" small />
         </div>
         <div class="w-72 px-1">
           <ui-text-input-with-label v-model="searchTitle" :label="searchTitleLabel" :placeholder="$strings.PlaceholderSearch" />
         </div>
-        <div v-show="provider != 'itunes'" class="w-72 px-1">
+        <div v-show="provider != 'itunes' && provider != 'audiobookcovers'" class="w-72 px-1">
           <ui-text-input-with-label v-model="searchAuthor" :label="$strings.LabelAuthor" />
         </div>
         <ui-btn class="mt-5 ml-1" type="submit">{{ $strings.ButtonSearch }}</ui-btn>
@@ -128,7 +128,7 @@ export default {
     },
     providers() {
       if (this.isPodcast) return this.$store.state.scanners.podcastProviders
-      return this.$store.state.scanners.providers
+      return [...this.$store.state.scanners.providers, ...this.$store.state.scanners.coverOnlyProviders]
     },
     searchTitleLabel() {
       if (this.provider.startsWith('audible')) return this.$strings.LabelSearchTitleOrASIN

--- a/client/store/scanners.js
+++ b/client/store/scanners.js
@@ -63,6 +63,12 @@ export const state = () => ({
       text: 'iTunes',
       value: 'itunes'
     }
+  ],
+  coverOnlyProviders: [
+    {
+      text: 'AudiobookCovers.com',
+      value: 'audiobookcovers'
+    }
   ]
 })
 

--- a/server/finders/BookFinder.js
+++ b/server/finders/BookFinder.js
@@ -4,6 +4,7 @@ const Audible = require('../providers/Audible')
 const iTunes = require('../providers/iTunes')
 const Audnexus = require('../providers/Audnexus')
 const FantLab = require('../providers/FantLab')
+const AudiobookCovers = require('../providers/AudiobookCovers')
 const Logger = require('../Logger')
 const { levenshteinDistance } = require('../utils/index')
 
@@ -15,6 +16,7 @@ class BookFinder {
     this.iTunesApi = new iTunes()
     this.audnexus = new Audnexus()
     this.fantLab = new FantLab()
+    this.audiobookCovers = new AudiobookCovers()
 
     this.verbose = false
   }
@@ -159,6 +161,16 @@ class BookFinder {
     return books
   }
 
+  async getAudiobookCoversResults(search) {
+    const covers = await this.audiobookCovers.search(search)
+    if (this.verbose) Logger.debug(`AudiobookCovers Book Search Results: ${books.length || 0}`)
+    if (covers.errorCode) {
+      Logger.error(`AusiobookCovers Search Error ${books.errorCode}`)
+      return []
+    }
+    return covers
+  }
+
   async getiTunesAudiobooksResults(title, author) {
     return this.iTunesApi.searchAudiobooks(title)
   }
@@ -187,10 +199,14 @@ class BookFinder {
       books = await this.getOpenLibResults(title, author, maxTitleDistance, maxAuthorDistance)
     } else if (provider === 'fantlab') {
       books = await this.getFantLabResults(title, author)
+    } else if (provider === 'audiobookcovers') {
+      books = await this.getAudiobookCoversResults(title)
     }
     else {
       books = await this.getGoogleBooksResults(title, author)
     }
+
+    console.log(books)
 
     if (!books.length && !options.currentlyTryingCleaned) {
       var cleanedTitle = this.cleanTitleForCompares(title)

--- a/server/finders/BookFinder.js
+++ b/server/finders/BookFinder.js
@@ -163,12 +163,8 @@ class BookFinder {
 
   async getAudiobookCoversResults(search) {
     const covers = await this.audiobookCovers.search(search)
-    if (this.verbose) Logger.debug(`AudiobookCovers Book Search Results: ${books.length || 0}`)
-    if (covers.errorCode) {
-      Logger.error(`AusiobookCovers Search Error ${books.errorCode}`)
-      return []
-    }
-    return covers
+    if (this.verbose) Logger.debug(`AudiobookCovers Search Results: ${covers.length || 0}`)
+    return covers || []
   }
 
   async getiTunesAudiobooksResults(title, author) {
@@ -206,8 +202,6 @@ class BookFinder {
       books = await this.getGoogleBooksResults(title, author)
     }
 
-    console.log(books)
-
     if (!books.length && !options.currentlyTryingCleaned) {
       var cleanedTitle = this.cleanTitleForCompares(title)
       var cleanedAuthor = this.cleanAuthorForCompares(author)
@@ -218,11 +212,13 @@ class BookFinder {
       return this.search(provider, cleanedTitle, cleanedAuthor, isbn, asin, options)
     }
 
-    if (["google", "audible", "itunes", 'fantlab'].includes(provider)) return books
+    if (provider === 'openlibrary') {
+      books.sort((a, b) => {
+        return a.totalDistance - b.totalDistance
+      })
+    }
 
-    return books.sort((a, b) => {
-      return a.totalDistance - b.totalDistance
-    })
+    return books
   }
 
   async findCovers(provider, title, author, options = {}) {

--- a/server/providers/AudiobookCovers.js
+++ b/server/providers/AudiobookCovers.js
@@ -14,9 +14,6 @@ class AudiobookCovers {
       Logger.error('[AudiobookCovers] Cover search error', error)
       return []
     })
-    // console.log(items)
-    // return items as an array of objects, each object contains:
-    // cover: item.filename
     return items.map(item => { return { cover: item.filename } })
   }
 }

--- a/server/providers/AudiobookCovers.js
+++ b/server/providers/AudiobookCovers.js
@@ -14,7 +14,7 @@ class AudiobookCovers {
       Logger.error('[AudiobookCovers] Cover search error', error)
       return []
     })
-    return items.map(item => { return { cover: item.filename } })
+    return items.map(item => ({ cover: item.filename }))
   }
 }
 

--- a/server/providers/AudiobookCovers.js
+++ b/server/providers/AudiobookCovers.js
@@ -1,0 +1,26 @@
+const axios = require('axios')
+const Logger = require('../Logger')
+
+class AudiobookCovers {
+  constructor() { }
+
+  async search(search) {
+    const url = `https://api.audiobookcovers.com/cover/bytext/`
+    const params = new URLSearchParams([['q', search]])
+    const items = await axios.get(url, { params }).then((res) => {
+      if (!res || !res.data) return []
+      return res.data
+    }).catch(error => {
+      Logger.error('[AudiobookCovers] Cover search error', error)
+      return []
+    })
+    // console.log(items)
+    // return items as an array of objects, each object contains:
+    // cover: item.filename
+    return items.map(item => { return { cover: item.filename } })
+  }
+}
+
+
+
+module.exports = AudiobookCovers


### PR DESCRIPTION
I recently launched [AudiobookCovers.com](audiobookcovers.com). [Source code and documentation](https://github.com/Weldawadyathink/Audiobook-Covers). The goal of the project is to archive all the audiobook covers posted to [/r/audiobookcovers](reddit.com/r/audiobookcovers), and make them searchable using google vision optical character recognition. 

This pull request adds support for AudiobookCovers.com as a metadata provider. Unlike other metadata providers, it only provides cover images. Therefore, this PR also allows providers to be listed only in the covers modal, so the new provider will not be listed under match or the library config screens. 