### PR TITLE
Don't sync progress for finished content

### DIFF
--- a/client/components/app/StreamContainer.vue
+++ b/client/components/app/StreamContainer.vue
@@ -41,6 +41,7 @@
       :sleep-timer-set="sleepTimerSet"
       :sleep-timer-remaining="sleepTimerRemaining"
       :is-podcast="isPodcast"
+      :is-finished="isFinished"
       @playPause="playPause"
       @jumpForward="jumpForward"
       @jumpBackward="jumpBackward"
@@ -82,7 +83,8 @@ export default {
       sleepTimer: null,
       displayTitle: null,
       currentPlaybackRate: 1,
-      syncFailedToast: null
+      syncFailedToast: null,
+      isFinished: false
     }
   },
   computed: {
@@ -203,6 +205,7 @@ export default {
     },
     setPlaying(isPlaying) {
       this.isPlaying = isPlaying
+      this.isFinished = !this.playerHandler.syncProgress
       this.$store.commit('setIsPlaying', isPlaying)
       this.updateMediaSessionPlaybackState()
     },

--- a/client/components/player/PlayerTrackBar.vue
+++ b/client/components/player/PlayerTrackBar.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="relative">
     <!-- Track -->
-    <div ref="track" class="w-full h-2 bg-gray-700 relative cursor-pointer transform duration-100 hover:scale-y-125 overflow-hidden" @mousemove="mousemoveTrack" @mouseleave="mouseleaveTrack" @click.stop="clickTrack">
+    <div ref="track" :class="isFinished ? 'bg-yellow-400' : 'bg-gray-700'" class="w-full h-2 relative cursor-pointer transform duration-100 hover:scale-y-125 overflow-hidden" @mousemove="mousemoveTrack" @mouseleave="mouseleaveTrack" @click.stop="clickTrack">
       <div ref="readyTrack" class="h-full bg-gray-600 absolute top-0 left-0 pointer-events-none" />
       <div ref="bufferTrack" class="h-full bg-gray-500 absolute top-0 left-0 pointer-events-none" />
       <div ref="playedTrack" class="h-full bg-gray-200 absolute top-0 left-0 pointer-events-none" />
@@ -39,7 +39,8 @@ export default {
       type: Object,
       default: () => {}
     },
-    playbackRate: Number
+    playbackRate: Number,
+    isFinished: Boolean
   },
   data() {
     return {

--- a/client/components/player/PlayerUi.vue
+++ b/client/components/player/PlayerUi.vue
@@ -46,7 +46,7 @@
       <player-playback-controls :loading="loading" :seek-loading="seekLoading" :playback-rate.sync="playbackRate" :paused="paused" :has-next-chapter="hasNextChapter" @prevChapter="prevChapter" @nextChapter="nextChapter" @jumpForward="jumpForward" @jumpBackward="jumpBackward" @setPlaybackRate="setPlaybackRate" @playPause="playPause" />
     </div>
 
-    <player-track-bar ref="trackbar" :loading="loading" :chapters="chapters" :duration="duration" :current-chapter="currentChapter" :playback-rate="playbackRate" @seek="seek" />
+    <player-track-bar ref="trackbar" :loading="loading" :chapters="chapters" :duration="duration" :current-chapter="currentChapter" :playback-rate="playbackRate" :is-finished="isFinished" @seek="seek" />
 
     <div class="flex">
       <p ref="currentTimestamp" class="font-mono text-xxs sm:text-sm text-gray-100 pointer-events-auto">00:00:00</p>
@@ -78,7 +78,8 @@ export default {
     },
     sleepTimerSet: Boolean,
     sleepTimerRemaining: Number,
-    isPodcast: Boolean
+    isPodcast: Boolean,
+    isFinished: Boolean
   },
   data() {
     return {

--- a/client/players/PlayerHandler.js
+++ b/client/players/PlayerHandler.js
@@ -27,6 +27,7 @@ export default class PlayerHandler {
     this.listeningTimeSinceSync = 0
 
     this.playInterval = null
+    this.syncProgress = true
   }
 
   get isCasting() {
@@ -218,6 +219,7 @@ export default class PlayerHandler {
   prepareSession(session) {
     this.failedProgressSyncs = 0
     this.startTime = this.startTimeOverride !== undefined ? this.startTimeOverride : session.currentTime
+    this.syncProgress = !session.isFinished
     this.currentSessionId = session.id
     this.displayTitle = session.displayTitle
     this.displayAuthor = session.displayAuthor
@@ -300,7 +302,7 @@ export default class PlayerHandler {
     if (this.player) {
       const listeningTimeToAdd = Math.max(0, Math.floor(this.listeningTimeSinceSync))
       // When opening player and quickly closing dont save progress
-      if (listeningTimeToAdd > 20 || this.lastSyncTime > 0) {
+      if (this.syncProgress && (listeningTimeToAdd > 20 || this.lastSyncTime > 0)) {
         syncData = {
           timeListened: listeningTimeToAdd,
           duration: this.getDuration(),
@@ -316,7 +318,7 @@ export default class PlayerHandler {
   }
 
   sendProgressSync(currentTime) {
-    if (this.isMusic) return
+    if (this.isMusic || !this.syncProgress) return
 
     const diffSinceLastSync = Math.abs(this.lastSyncTime - currentTime)
     if (diffSinceLastSync < 1) return

--- a/server/managers/PlaybackSessionManager.js
+++ b/server/managers/PlaybackSessionManager.js
@@ -173,7 +173,7 @@ class PlaybackSessionManager {
       }
     }
     const newPlaybackSession = new PlaybackSession()
-    newPlaybackSession.setData(libraryItem, user, mediaPlayer, deviceInfo, userStartTime, episodeId)
+    newPlaybackSession.setData(libraryItem, user, mediaPlayer, deviceInfo, userStartTime, userProgress.isFinished, episodeId)
 
     if (libraryItem.mediaType === 'video') {
       if (shouldDirectPlay) {

--- a/server/objects/PlaybackSession.js
+++ b/server/objects/PlaybackSession.js
@@ -32,6 +32,7 @@ class PlaybackSession {
     this.timeListening = null
     this.startTime = null // media current time at start of playback
     this.currentTime = 0 // Last current time set
+    this.isFinished = null
 
     this.startedAt = null
     this.updatedAt = null
@@ -69,6 +70,7 @@ class PlaybackSession {
       timeListening: this.timeListening,
       startTime: this.startTime,
       currentTime: this.currentTime,
+      isFinished: this.isFinished,
       startedAt: this.startedAt,
       updatedAt: this.updatedAt
     }
@@ -96,6 +98,7 @@ class PlaybackSession {
       timeListening: this.timeListening,
       startTime: this.startTime,
       currentTime: this.currentTime,
+      isFinished: this.isFinished,
       startedAt: this.startedAt,
       updatedAt: this.updatedAt,
       audioTracks: this.audioTracks.map(at => at.toJSON()),
@@ -136,6 +139,7 @@ class PlaybackSession {
     this.timeListening = session.timeListening || null
     this.startTime = session.startTime || 0
     this.currentTime = session.currentTime || 0
+    this.currentTime = session.isFinished || null
 
     this.startedAt = session.startedAt
     this.updatedAt = session.updatedAt || null
@@ -169,7 +173,7 @@ class PlaybackSession {
     }
   }
 
-  setData(libraryItem, user, mediaPlayer, deviceInfo, startTime, episodeId = null) {
+  setData(libraryItem, user, mediaPlayer, deviceInfo, startTime, isFinished, episodeId = null) {
     this.id = getId('play')
     this.userId = user.id
     this.libraryId = libraryItem.libraryId
@@ -194,6 +198,7 @@ class PlaybackSession {
     this.timeListening = 0
     this.startTime = startTime
     this.currentTime = startTime
+    this.isFinished = isFinished
 
     this.date = date.format(new Date(), 'YYYY-MM-DD')
     this.dayOfWeek = date.format(new Date(), 'dddd')


### PR DESCRIPTION
This is just a drafted idea for the moment, but the goal is essentially to allow finished content to be re-visited without (necessarily) updating progress or listening stats.

This relates to a few topics currently being discussed, but most pertinently [Let me use bookmarks without losing reading stats](https://github.com/advplyr/audiobookshelf/issues/1766#top). It explores [a comment](https://github.com/advplyr/audiobookshelf/issues/1766#issuecomment-1544529902) on that issue which proposed the idea of a sort of preview player (one that won't track progress), but instead of being activated by a button, here it is enabled or disabled depending on finished status. That issue has now been marked as a duplicate of https://github.com/advplyr/audiobookshelf/issues/1653, so I'll add any further comments there (even if it doesn't quite feel like the same thing).

In terms of implementation, I think ultimately it might be better to have this as a setting rather than default behavior. When set, it would still of course be possible to mark the item as unfinished again to re-enable progress tracking. I created a distinction between `isFinished` at the session/progress level, and `syncProgress` at the player level, mostly because `syncProgress` need not necessarily only be deactivated for finished content going forward, even if that's the current proposition.

Some things which remain to be addressed:

* Since the behavior of the player depends on finished status, changing the finished status should probably close or better yet update the player state accordingly.
* Should a listening session be opened at all for finished content? I believe right now a listening session is required in order to get the media details, so I've left it like this for now to keep things simple.

Again, this is just an idea to see whether it's something potentially workable. I'm fine with throwing it away of course, but it turned out to be surprisingly easy to put together so I figured I'd share it all the same.