### PR TITLE
Update readme.md - Expand required Apache modules for reverse proxy and detail how to handle acme challenges

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -117,9 +117,11 @@ Add this to the site config file on your Apache server after you have changed th
 
 For this to work you must enable at least the following mods using `a2enmod`:
   - `ssl`
-  - `proxy_module`
-  - `proxy_wstunnel_module`
-  - `rewrite_module`
+  - `proxy`
+  - `proxy_http`
+  - `proxy_balancer`
+  - `proxy_wstunnel`
+  - `rewrite`
 
 ```bash
 <IfModule mod_ssl.c>
@@ -142,6 +144,26 @@ For this to work you must enable at least the following mods using `a2enmod`:
     SSLCertificateKeyFile /path/to/key/file
 </VirtualHost>
 </IfModule>
+```
+
+Some SSL certificates like those signed by Let's Encrypt require ACME validation. To allow Let's Encrypt to write and confirm 
+the ACME challenge, edit your VirtualHost definition to prevent proxying traffic that queries `/.well-known` and instead
+serve that directly:
+```bash
+<VirtualHost *:443>
+    # ...
+
+    # create the directory structure  /.well-known/acme-challenges
+    # within DocumentRoot and give the HTTP user recursive write
+    # access to it.
+    DocumentRoot /path/to/local/directory
+    
+    ProxyPreserveHost On
+    ProxyPass /.well-known !
+    ProxyPass / http://localhost:<audiobookshelf_port>/
+    
+    # ...
+</VirtualHost>    
 ```
 
 


### PR DESCRIPTION
After setting up the reverse proxy for Apache per the current instructions, I received the error:

> AH01144: No protocol handler was valid for the URL / (scheme 'http')

Installing `proxy_http` and `proxy_balancer` modules in addition to those listed (as recommended [here](https://stackoverflow.com/a/26045183)) fixed this issue.

`a2enmod` command does not include the redundant `_module` suffix.

Let's Encrypt was not able to validate certificates either automatically or manually as ABS does not respond to ACME challenges directly. Editing the virtual environment configuration to not reverse-proxy `/.well-known`, and serving that directly from Apache allowed LE to validate the challenge.