### PR TITLE
feat: add PUID PGID UMASK settings to image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,19 +14,24 @@ RUN apk update && \
     apk add --no-cache --update \
     curl \
     tzdata \
-    ffmpeg
+    ffmpeg \
+    bash \
+    jq \
+    shadow \
+    su-exec \
+    dumb-init && \
+    usermod --shell /bin/bash node && \
+    rm -rf /var/cache/apk/*
 
 COPY --from=tone /usr/local/bin/tone /usr/local/bin/
 COPY --from=build /client/dist /client/dist
 COPY index.js package* /
 COPY server server
+COPY --chmod=755 entrypoint.sh /entrypoint.sh
 
 RUN npm ci --only=production
 
-EXPOSE 80
-HEALTHCHECK \
-    --interval=30s \
-    --timeout=3s \
-    --start-period=10s \
-    CMD curl -f http://127.0.0.1/healthcheck || exit 1
+ENTRYPOINT [ "/entrypoint.sh" ]
 CMD ["node", "index.js"]
+
+EXPOSE 80

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -27,6 +27,11 @@ groupmod -o -g ${PGID} node
 usermod -o -u ${PUID} node
 
 chown -R node:node \
+    /client \
+    /index.js \
+    /package* \
+    /server
+chown -R node:node \
     /config \
     /metadata
 chown node:node \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+UMASK=${UMASK:-022}
+PUID=${PUID:-1000}
+PGID=${PGID:-1000}
+
+umask ${UMASK}
+
+if [ ! -d /config ]; then
+    mkdir /config
+fi
+if [ ! -d /metadata ]; then
+    mkdir /metadata
+fi
+if [ ! -d /audiobooks ]; then
+    mkdir /audiobooks
+fi
+if [ ! -d /podcasts ]; then
+    mkdir /podcasts
+fi
+
+echo "Change owner to user AudioBookShelf..."
+echo "PUID=${PUID}"
+echo "PGID=${PGID}"
+
+groupmod -o -g ${PGID} node
+usermod -o -u ${PUID} node
+
+chown -R node:node \
+    /config \
+    /metadata
+chown node:node \
+    /audiobooks \
+    /podcasts
+
+exec su-exec node:node dumb-init $*


### PR DESCRIPTION
## Changes
- Add `UMASK` environment variable setting. The usefulness of `UMASK` setting can be seen in the explanation of linuxserver: https://github.com/linuxserver/docker-radarr#umask-for-running-applications
- Add `PUID` `PGID` environment variable setting (Use this setting to replace the previous `AUDIOBOOKSHELF_UID/GID` setting). The usefulness of `PUID` `PGID` settings can be seen in the explanation of linuxserver: https://github.com/linuxserver/docker-radarr#user--group-identifiers
- Remove the HEALTHCHECK specified in the Dockerfile. Use the following method to set HEALTHCHECK:
```bash
docker pull ghcr.io/advplyr/audiobookshelf

docker run -d \
  -p 13378:80 \
  -v </path/to/config>:/config \
  -v </path/to/metadata>:/metadata \
  -v </path/to/audiobooks>:/audiobooks \
  -v </path/to/podcasts>:/podcasts \
  --health-cmd="curl -f http://127.0.0.1/healthcheck || exit 1" \
  --health-interval=30s \
  --health-timeout=3s \
  --health-start-period=10s \
  --name audiobookshelf \
  --rm ghcr.io/advplyr/audiobookshelf
```
```yaml
version: "3.7"
services:
  audiobookshelf:
    image: ghcr.io/advplyr/audiobookshelf:latest
    ports:
      - 13378:80
    volumes:
      - </path/to/audiobooks>:/audiobooks
      - </path/to/podcasts>:/podcasts
      - </path/to/config>:/config
      - </path/to/metadata>:/metadata
    healthcheck:
      test: ["CMD", "curl", "-f", "http://127.0.0.1/healthcheck"]
      interval: 30s
      timeout: 3s
      start_period: 10s
```
Because HEALTHCHECK will take up a certain amount of performance, it is more reasonable to make user-defined settings
## Explain
The node base image comes with a `node` user. The container gets the uid and gid from the PUID PGID environment variable set by the user and changes the uid of the node user and the gid of the node user group. this unifies the user and user group for file permissions inside and outside the container