### PR TITLE
Fix byte conversion

### DIFF
--- a/server/utils/fileUtils.js
+++ b/server/utils/fileUtils.js
@@ -83,7 +83,7 @@ function bytesPretty(bytes, decimals = 0) {
   if (bytes === 0) {
     return '0 Bytes'
   }
-  const k = 1024
+  const k = 1000
   var dm = decimals < 0 ? 0 : decimals
   const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB']
   const i = Math.floor(Math.log(bytes) / Math.log(k))


### PR DESCRIPTION
Right now ABS converts `206291193b` into `196.73MB`. This is only partially correct, because the bytes are converted using a factor of 1024. The correct amount would be `206.29MB` The are converted to [Mebibyte](https://en.wikipedia.org/wiki/Byte#Multiple-byte_units) not Megabytes. I got confused by it, because if was wondering why my file size did not match with the one I uploaded. Changing the factor to 1000 fixes this. The unit could also be renamed to `MiB` but I think this would only confuse most people.

<img width="682" alt="Bildschirmfoto 2023-07-20 um 00 00 38" src="https://github.com/advplyr/audiobookshelf/assets/49640416/d4d8ae61-c28f-4a01-a93d-9eb5548e6bb3">
<img width="680" alt="Bildschirmfoto 2023-07-20 um 00 00 56" src="https://github.com/advplyr/audiobookshelf/assets/49640416/224e8f3c-dfff-4cc1-a7e8-b8a659897e16">
<img width="877" alt="Bildschirmfoto 2023-07-20 um 00 02 49" src="https://github.com/advplyr/audiobookshelf/assets/49640416/ce5da7cf-8739-4e4e-acb3-a4c43851f799">

<img width="1186" alt="Bildschirmfoto 2023-07-20 um 00 02 11" src="https://github.com/advplyr/audiobookshelf/assets/49640416/1f9c925f-080b-49ac-a5d6-f254e4c5bfc7">

And yes linux used Mebibyte here, but they do it throughout the entire system. My supposed 5TB Hard drive shows up as a 4.5TB one, because it is only technically 5TB large. Actually it has only 4.5TiB of usable space. But I think this is trivial, as most people probably don't use the linux command line to find out what the size of a file is.

<img width="520" alt="Bildschirmfoto 2023-07-20 um 00 11 06" src="https://github.com/advplyr/audiobookshelf/assets/49640416/17828c78-3412-4bd5-8767-d933078a6ab1">
