### PR TITLE
Added podcasts volume to docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       - 13378:80
     volumes:
       - ./audiobooks:/audiobooks
+      - ./podcasts:/podcasts
       - ./metadata:/metadata
       - ./config:/config
     restart: unless-stopped


### PR DESCRIPTION
The example docker compose file in github does not have the podcasts volume in it, unlike on [the official website](https://www.audiobookshelf.org/docs#docker-compose-install).