### PR TITLE
Fuzzy Matching V1

### DIFF
--- a/server/finders/BookFinder.js
+++ b/server/finders/BookFinder.js
@@ -214,7 +214,7 @@ class BookFinder {
     var books = []
     const maxTitleDistance = !isNaN(options.titleDistance) ? Number(options.titleDistance) : 4
     const maxAuthorDistance = !isNaN(options.authorDistance) ? Number(options.authorDistance) : 4
-    const maxFuzzySearches = 5
+    const maxFuzzySearches = !isNaN(options.maxFuzzySearches) ? Number(options.maxFuzzySearches) : 5
     var numFuzzySearches = 0
 
     if (!title)

--- a/server/finders/BookFinder.js
+++ b/server/finders/BookFinder.js
@@ -52,21 +52,19 @@ class BookFinder {
   cleanTitleForCompares(title) {
     if (!title) return ''
     // Remove subtitle if there (i.e. "Cool Book: Coolest Ever" becomes "Cool Book")
-    var stripped = this.stripSubtitle(title)
+    let stripped = this.stripSubtitle(title)
 
     // Remove text in paranthesis (i.e. "Ender's Game (Ender's Saga)" becomes "Ender's Game")
-    var cleaned = stripped.replace(/ *\([^)]*\) */g, "")
+    let cleaned = stripped.replace(/ *\([^)]*\) */g, "")
 
     // Remove single quotes (i.e. "Ender's Game" becomes "Enders Game")
     cleaned = cleaned.replace(/'/g, '')
-    cleaned = this.replaceAccentedChars(cleaned)
-    return cleaned
+    return this.replaceAccentedChars(cleaned)
   }
 
   cleanAuthorForCompares(author) {
     if (!author) return ''
-    var cleaned = this.replaceAccentedChars(author)
-    return cleaned
+    return this.replaceAccentedChars(author)
   }
 
   filterSearchResults(books, title, author, maxTitleDistance, maxAuthorDistance) {
@@ -210,12 +208,23 @@ class BookFinder {
       candidates.add(candidate)
   }
 
+  /**
+   * Search for books including fuzzy searches
+   * 
+   * @param {string} provider 
+   * @param {string} title 
+   * @param {string} author 
+   * @param {string} isbn 
+   * @param {string} asin 
+   * @param {{titleDistance:number, authorDistance:number, maxFuzzySearches:number}} options 
+   * @returns {Promise<Object[]>}
+   */
   async search(provider, title, author, isbn, asin, options = {}) {
-    var books = []
+    let books = []
     const maxTitleDistance = !isNaN(options.titleDistance) ? Number(options.titleDistance) : 4
     const maxAuthorDistance = !isNaN(options.authorDistance) ? Number(options.authorDistance) : 4
     const maxFuzzySearches = !isNaN(options.maxFuzzySearches) ? Number(options.maxFuzzySearches) : 5
-    var numFuzzySearches = 0
+    let numFuzzySearches = 0
 
     if (!title)
       return books
@@ -228,8 +237,8 @@ class BookFinder {
       author = author.trim().toLowerCase()
 
       // Now run up to maxFuzzySearches fuzzy searches
-      var candidates = new Set()
-      var cleanedAuthor = this.cleanAuthorForCompares(author)
+      let candidates = new Set()
+      let cleanedAuthor = this.cleanAuthorForCompares(author)
       this.addTitleCandidate(title, candidates)
 
       // remove parentheses and their contents, and replace with a separator
@@ -256,8 +265,7 @@ class BookFinder {
           if (lengthDiff) return lengthDiff
           return b.localeCompare(a)
         })
-        Logger.debug(`[BookFinder] Found ${candidates.length} fuzzy title candidates`)
-        Logger.debug(candidates)
+        Logger.debug(`[BookFinder] Found ${candidates.length} fuzzy title candidates`, candidates)
         for (const candidate of candidates) {
           if (++numFuzzySearches > maxFuzzySearches) return books
           books = await this.runSearch(candidate, cleanedAuthor, provider, asin, maxTitleDistance, maxAuthorDistance)
@@ -283,10 +291,21 @@ class BookFinder {
     return books
   }
 
+  /**
+   * Search for books
+   * 
+   * @param {string} title 
+   * @param {string} author 
+   * @param {string} provider 
+   * @param {string} asin only used for audible providers
+   * @param {number} maxTitleDistance only used for openlibrary provider
+   * @param {number} maxAuthorDistance only used for openlibrary provider
+   * @returns {Promise<Object[]>}
+   */
   async runSearch(title, author, provider, asin, maxTitleDistance, maxAuthorDistance) {
     Logger.debug(`Book Search: title: "${title}", author: "${author || ''}", provider: ${provider}`)
 
-    var books = []
+    let books = []
 
     if (provider === 'google') {
       books = await this.getGoogleBooksResults(title, author)

--- a/server/scanner/Scanner.js
+++ b/server/scanner/Scanner.js
@@ -36,7 +36,7 @@ class Scanner {
       var searchISBN = options.isbn || libraryItem.media.metadata.isbn
       var searchASIN = options.asin || libraryItem.media.metadata.asin
 
-      var results = await BookFinder.search(provider, searchTitle, searchAuthor, searchISBN, searchASIN)
+      var results = await BookFinder.search(provider, searchTitle, searchAuthor, searchISBN, searchASIN, { maxFuzzySearches: 2 })
       if (!results.length) {
         return {
           warning: `No ${provider} match found`


### PR DESCRIPTION
Problem:
Audiobookshelf requires a pretty strict folder structure. However, users sometimes have many books in existing folders that adhere to different (or no) standards, and they might be reluctant to fix their directory structure. But then book titles and authors are incorrectly read, and consequently, matching usually return no/wrong results, which requires users to manually fix the title and author before matching.

The option to prefer audio metadata over folder names somewhat improves the situation, but does not fix it, and is also not enabled by default.

Proposal:
As a first step, I'd like to suggest a heuristic fuzzy matching, that kicks in if the initial title and author search returns no results (a rudimentary version of this already exists in the code, potentially sending one additional search request with a "clean" version of the title and author - it is subsumed in the new proposal):

- If the initial search returns no results, we first further clean the title, and then heuristically split it into hyphen-separated parts. 
- We then create a Set of title candidates, and add each part to the set. We also try to generate additional title candidates by applying various heuristics on each part, and add those candidates to the set as well. 
- The resulting list of unique candidates is then heuristically sorted to minimize the number of additional search requests while still keeping the request as specific as possible.
- Additional search requests are then sent until one returns results, or until maxFuzzySearches (the maximum number of allowed additional search requests) has been reached
- If no results were found, search requests are also repeated without the author (again, until maxFuzzySearches has been reached)

This proposal is implemented here.
I've evaluated it on 50 books that have audible.com metadata from my unmodified audiobook torrents directory, which has no standard folder structure. The existing matching finds the correct result only for 24% of books. Fuzzy matching V1 finds the correct result for 96% of books, and finds the correct result @1 for 92%. I have not calculated the average number of additional search requests, but it looks like it is usually between 0-3.
