### PR TITLE
Fix typo in fixParsedNameCase

### DIFF
--- a/server/utils/parsers/parseFullName.js
+++ b/server/utils/parsers/parseFullName.js
@@ -70,8 +70,8 @@ module.exports = (nameToParse, partToReturn, fixCase, stopOnError, useLongLists)
                 namePartWords[j].slice(3).toLowerCase();
             } else if (
               namePartLabels[j] === 'suffix' &&
-              nameParts[j].slice(-1) !== '.' &&
-              !suffixList.indexOf(nameParts[j].toLowerCase())
+              namePartWords[j].slice(-1) !== '.' &&
+              !suffixList.indexOf(namePartWords[j].toLowerCase())
             ) { // Convert suffix abbreviations to UPPER CASE
               if (namePartWords[j] === namePartWords[j].toLowerCase()) {
                 namePartWords[j] = namePartWords[j].toUpperCase();


### PR DESCRIPTION
I noticed the following crash in my server:

```
/server/utils/parsers/parseFullName.js:73
              nameParts[j].slice(-1) !== '.' &&
                           ^

TypeError: Cannot read properties of undefined (reading 'slice')
    at fixParsedNameCase (/server/utils/parsers/parseFullName.js:73:28)
    at module.exports (/server/utils/parsers/parseFullName.js:344:16)
    at parseName (/server/utils/parsers/parseNameString.js:9:15)
    at /server/utils/parsers/parseNameString.js:81:20
    at Array.forEach (<anonymous>)
    at Object.module.exports.parse (/server/utils/parsers/parseNameString.js:80:18)
    at /server/scanner/BookScanner.js:650:54
    at Array.forEach (<anonymous>)
    at BookScanner.getBookMetadataFromScanData (/server/scanner/BookScanner.js:640:24)
    at BookScanner.rescanExistingBookLibraryItem (/server/scanner/BookScanner.js:172:37)
```

When I dug in, I found a suspicious use of `nameParts` where it didn't really make sense in that context. When I clicked through to the code where this util was copied from, I found that this typo (should be `namePartWords`) was [already fixed upstream](https://github.com/RateGravity/parse-full-name/commit/9795b35b2f5bf4aae4b65ed75f246395e6c1d02f), so I've just ported that fix back into this copy of the utility function