### PR TITLE
Add ability to enable DEV logs of Sqlite queries

### DIFF
--- a/server/Database.js
+++ b/server/Database.js
@@ -177,7 +177,7 @@ class Database {
       // Setting QUERY_LOGGING=benchmark will log all Sequelize queries and their execution times, after they run
       Logger.info(`[Database] Query benchmarking enabled"`)
       logging = (query, time) => Logger.dev(`Ran the following query in ${time}ms:\n ${query}`)
-      benchmark = true;
+      benchmark = true
     }
 
     this.sequelize = new Sequelize({

--- a/server/Database.js
+++ b/server/Database.js
@@ -171,7 +171,7 @@ class Database {
     let benchmark = false;
     if (process.env.QUERY_LOGGING === "log") {
       // Setting QUERY_LOGGING=log will log all Sequelize queries before they run
-      Logger.info(`[Database] Query logging enabled"`)
+      Logger.info(`[Database] Query logging enabled`)
       logging = (query) => Logger.dev(`Running the following query:\n ${query}`)
     } else if (process.env.QUERY_LOGGING === "benchmark") {
       // Setting QUERY_LOGGING=benchmark will log all Sequelize queries and their execution times, after they run

--- a/server/Database.js
+++ b/server/Database.js
@@ -167,8 +167,8 @@ class Database {
   async connect() {
     Logger.info(`[Database] Initializing db at "${this.dbPath}"`)
 
-    let logging = false;
-    let benchmark = false;
+    let logging = false
+    let benchmark = false
     if (process.env.QUERY_LOGGING === "log") {
       // Setting QUERY_LOGGING=log will log all Sequelize queries before they run
       Logger.info(`[Database] Query logging enabled`)

--- a/server/Database.js
+++ b/server/Database.js
@@ -172,11 +172,11 @@ class Database {
     if (process.env.QUERY_LOGGING === "log") {
       // Setting QUERY_LOGGING=log will log all Sequelize queries before they run
       Logger.info(`[Database] Query logging enabled"`)
-      logging = (query) => Logger.dev(`Running the following query: ${query}`)
+      logging = (query) => Logger.dev(`Running the following query:\n ${query}`)
     } else if (process.env.QUERY_LOGGING === "benchmark") {
       // Setting QUERY_LOGGING=benchmark will log all Sequelize queries and their execution times, after they run
       Logger.info(`[Database] Query benchmarking enabled"`)
-      logging = (query, time) => Logger.dev(`Ran the following query in ${time}ms: ${query}`)
+      logging = (query, time) => Logger.dev(`Ran the following query in ${time}ms:\n ${query}`)
       benchmark = true;
     }
 

--- a/server/Database.js
+++ b/server/Database.js
@@ -166,10 +166,25 @@ class Database {
    */
   async connect() {
     Logger.info(`[Database] Initializing db at "${this.dbPath}"`)
+
+    let logging = false;
+    let benchmark = false;
+    if (process.env.QUERY_LOGGING === "log") {
+      // Setting QUERY_LOGGING=log will log all Sequelize queries before they run
+      Logger.info(`[Database] Query logging enabled"`)
+      logging = (query) => Logger.dev(`Running the following query: ${query}`)
+    } else if (process.env.QUERY_LOGGING === "benchmark") {
+      // Setting QUERY_LOGGING=benchmark will log all Sequelize queries and their execution times, after they run
+      Logger.info(`[Database] Query benchmarking enabled"`)
+      logging = (query, time) => Logger.dev(`Ran the following query in ${time}ms: ${query}`)
+      benchmark = true;
+    }
+
     this.sequelize = new Sequelize({
       dialect: 'sqlite',
       storage: this.dbPath,
-      logging: false,
+      logging: logging,
+      benchmark: benchmark,
       transactionType: 'IMMEDIATE'
     })
 


### PR DESCRIPTION
I've been doing some debugging of Sqlite query performance, and I found it useful to enable logging of DB queries as they happen, so I figured I'd send a PR in case it's useful to others as well.

Logging all queries is pretty noisy, so rather than just logging at some log level, I've gated this logging behind a `QUERY_LOGGING` environment variable. Set it to `QUERY_LOGGING=log` to log just the query. Set it to `QUERY_LOGGING=benchmark` to log both the query and how long it took to run.

I'm happy to switch to some other mechanism for enabling this, if using an env var is undesirable.

An example benchmarking log message would look like this:

```
[2023-09-15 05:57:48] DEV: Ran the following query in 3ms:
 Executed (default): SELECT `podcast`.`id`, `podcast`.`title`, COUNT('*') AS `item_count`, `libraryItem`.`id` AS `libraryItem.id`, `libraryItem`.`ino` AS `libraryItem.ino`, `libraryItem`.`path` AS `libraryItem.path`, `libraryItem`.`relPath` AS `libraryItem.relPath`, `libraryItem`.`mediaId` AS `libraryItem.mediaId`, `libraryItem`.`mediaType` AS `libraryItem.mediaType`, `libraryItem`.`isFile` AS `libraryItem.isFile`, `libraryItem`.`isMissing` AS `libraryItem.isMissing`, `libraryItem`.`isInvalid` AS `libraryItem.isInvalid`, `libraryItem`.`mtime` AS `libraryItem.mtime`, `libraryItem`.`ctime` AS `libraryItem.ctime`, `libraryItem`.`birthtime` AS `libraryItem.birthtime`, `libraryItem`.`size` AS `libraryItem.size`, `libraryItem`.`lastScan` AS `libraryItem.lastScan`, `libraryItem`.`lastScanVersion` AS `libraryItem.lastScanVersion`, `libraryItem`.`libraryFiles` AS `libraryItem.libraryFiles`, `libraryItem`.`extraData` AS `libraryItem.extraData`, `libraryItem`.`createdAt` AS `libraryItem.createdAt`, `libraryItem`.`updatedAt` AS `libraryItem.updatedAt`, `libraryItem`.`libraryId` AS `libraryItem.libraryId`, `libraryItem`.`libraryFolderId` AS `libraryItem.libraryFolderId` FROM `podcasts` AS `podcast` LEFT OUTER JOIN `libraryItems` AS `libraryItem` ON `podcast`.`id` = `libraryItem`.`mediaId` AND `libraryItem`.`mediaType` = 'podcast' GROUP BY `podcast`.`id`, `podcast`.`title` HAVING `item_count` = 0;
```