### PR TITLE
[server] x-accel: encode all paths to URIs

### DIFF
--- a/server/controllers/BackupController.js
+++ b/server/controllers/BackupController.js
@@ -1,4 +1,5 @@
 const Logger = require('../Logger')
+const { encodeUriPath } = require('../utils/fileUtils')
 
 class BackupController {
   constructor() { }
@@ -37,8 +38,9 @@ class BackupController {
    */
   download(req, res) {
     if (global.XAccel) {
-      Logger.debug(`Use X-Accel to serve static file ${req.backup.fullPath}`)
-      return res.status(204).header({ 'X-Accel-Redirect': global.XAccel + req.backup.fullPath }).send()
+      const encodedURI = encodeUriPath(global.XAccel + req.backup.fullPath)
+      Logger.debug(`Use X-Accel to serve static file ${encodedURI}`)
+      return res.status(204).header({ 'X-Accel-Redirect': encodedURI }).send()
     }
     res.sendFile(req.backup.fullPath)
   }

--- a/server/controllers/LibraryItemController.js
+++ b/server/controllers/LibraryItemController.js
@@ -7,7 +7,7 @@ const Database = require('../Database')
 const zipHelpers = require('../utils/zipHelpers')
 const { reqSupportsWebp } = require('../utils/index')
 const { ScanResult } = require('../utils/constants')
-const { getAudioMimeTypeFromExtname } = require('../utils/fileUtils')
+const { getAudioMimeTypeFromExtname, encodeUriPath } = require('../utils/fileUtils')
 const LibraryItemScanner = require('../scanner/LibraryItemScanner')
 const AudioFileScanner = require('../scanner/AudioFileScanner')
 const Scanner = require('../scanner/Scanner')
@@ -235,8 +235,9 @@ class LibraryItemController {
       }
 
       if (global.XAccel) {
-        Logger.debug(`Use X-Accel to serve static file ${libraryItem.media.coverPath}`)
-        return res.status(204).header({ 'X-Accel-Redirect': global.XAccel + libraryItem.media.coverPath }).send()
+        const encodedURI = encodeUriPath(global.XAccel + libraryItem.media.coverPath)
+        Logger.debug(`Use X-Accel to serve static file ${encodedURI}`)
+        return res.status(204).header({ 'X-Accel-Redirect': encodedURI }).send()
       }
       return res.sendFile(libraryItem.media.coverPath)
     }
@@ -575,8 +576,9 @@ class LibraryItemController {
     const libraryFile = req.libraryFile
 
     if (global.XAccel) {
-      Logger.debug(`Use X-Accel to serve static file ${libraryFile.metadata.path}`)
-      return res.status(204).header({ 'X-Accel-Redirect': global.XAccel + libraryFile.metadata.path }).send()
+      const encodedURI = encodeUriPath(global.XAccel + libraryFile.metadata.path)
+      Logger.debug(`Use X-Accel to serve static file ${encodedURI}`)
+      return res.status(204).header({ 'X-Accel-Redirect': encodedURI }).send()
     }
 
     // Express does not set the correct mimetype for m4b files so use our defined mimetypes if available
@@ -632,8 +634,9 @@ class LibraryItemController {
     Logger.info(`[LibraryItemController] User "${req.user.username}" requested file download at "${libraryFile.metadata.path}"`)
 
     if (global.XAccel) {
-      Logger.debug(`Use X-Accel to serve static file ${libraryFile.metadata.path}`)
-      return res.status(204).header({ 'X-Accel-Redirect': global.XAccel + libraryFile.metadata.path }).send()
+      const encodedURI = encodeUriPath(global.XAccel + libraryFile.metadata.path)
+      Logger.debug(`Use X-Accel to serve static file ${encodedURI}`)
+      return res.status(204).header({ 'X-Accel-Redirect': encodedURI }).send()
     }
 
     // Express does not set the correct mimetype for m4b files so use our defined mimetypes if available
@@ -673,8 +676,9 @@ class LibraryItemController {
     const ebookFilePath = ebookFile.metadata.path
 
     if (global.XAccel) {
-      Logger.debug(`Use X-Accel to serve static file ${ebookFilePath}`)
-      return res.status(204).header({ 'X-Accel-Redirect': global.XAccel + ebookFilePath }).send()
+      const encodedURI = encodeUriPath(global.XAccel + ebookFilePath)
+      Logger.debug(`Use X-Accel to serve static file ${encodedURI}`)
+      return res.status(204).header({ 'X-Accel-Redirect': encodedURI }).send()
     }
 
     res.sendFile(ebookFilePath)

--- a/server/managers/CacheManager.js
+++ b/server/managers/CacheManager.js
@@ -3,6 +3,7 @@ const fs = require('../libs/fsExtra')
 const stream = require('stream')
 const Logger = require('../Logger')
 const { resizeImage } = require('../utils/ffmpegHelpers')
+const { encodeUriPath } = require('../utils/fileUtils')
 
 class CacheManager {
   constructor() {
@@ -50,8 +51,9 @@ class CacheManager {
     // Cache exists
     if (await fs.pathExists(path)) {
       if (global.XAccel) {
-        Logger.debug(`Use X-Accel to serve static file ${path}`)
-        return res.status(204).header({ 'X-Accel-Redirect': global.XAccel + path }).send()
+        const encodedURI = encodeUriPath(global.XAccel + path)
+        Logger.debug(`Use X-Accel to serve static file ${encodedURI}`)
+        return res.status(204).header({ 'X-Accel-Redirect': encodedURI }).send()
       }
 
       const r = fs.createReadStream(path)
@@ -73,8 +75,9 @@ class CacheManager {
     if (!writtenFile) return res.sendStatus(500)
 
     if (global.XAccel) {
-      Logger.debug(`Use X-Accel to serve static file ${writtenFile}`)
-      return res.status(204).header({ 'X-Accel-Redirect': global.XAccel + writtenFile }).send()
+      const encodedURI = encodeUriPath(global.XAccel + writtenFile)
+      Logger.debug(`Use X-Accel to serve static file ${encodedURI}`)
+      return res.status(204).header({ 'X-Accel-Redirect': encodedURI }).send()
     }
 
     var readStream = fs.createReadStream(writtenFile)

--- a/server/utils/fileUtils.js
+++ b/server/utils/fileUtils.js
@@ -293,5 +293,6 @@ module.exports.removeFile = (path) => {
 }
 
 module.exports.encodeUriPath = (path) => {
-  return filePathToPOSIX(path).replace(/%/g, '%25').replace(/#/g, '%23')
+  const uri = new URL(path, "file://")
+  return uri.pathname
 }


### PR DESCRIPTION
updates util function  encodeUriPath to use node:url with a file:// path prefix, and updates all instances x-accel redirection to use this helper util instead of sending unencoded paths into the header.

Using a local dev container with an external nginx reverse proxy for x-accel: I tested covers, audio files, and ebooks which all played correctly, even with unicode chars. I was unable to get download working, but I think that was just because of my test setup. I don't see any reason it should function differently in a proper setup...


fixes errors such as:
```
[2023-09-16 22:46:05] DEBUG: Use X-Accel to serve static file /audiobooks/Craig Alanson/Ascendant/1. Ascendantː Book 1/Ascendantː Book 1.webm (LibraryItemController.js:578)
node:internal/errors:478
    ErrorCaptureStackTrace(err);
    ^

TypeError [ERR_INVALID_CHAR]: Invalid character in header content ["X-Accel-Redirect"]
    at ServerResponse.setHeader (node:_http_outgoing:647:3)
    at ServerResponse.header (/node_modules/express/lib/response.js:794:10)
    at ServerResponse.header (/node_modules/express/lib/response.js:797:12)
    at ApiRouter.getLibraryFile (/server/controllers/LibraryItemController.js:579:30)
    at Layer.handle [as handle_request] (/node_modules/express/lib/router/layer.js:95:5)
    at next (/node_modules/express/lib/router/route.js:144:13)
    at ApiRouter.middleware (/server/controllers/LibraryItemController.js:742:5) {
  code: 'ERR_INVALID_CHAR'
```
[the error in this specific file is the colon which is `modifier letter triangular colon (U+02D0)`]

this also changes the log to output the full encoded x-accel path (which means it now includes the prefix):
```
[2023-09-17 22:36:24] DEBUG: Use X-Accel to serve static file /protected/audiobooks/Craig%20Alanson/Ascendant/1.%20Ascendant%CB%90%20Book%201/Ascendant%CB%90%20Book%201.webm (LibraryItemController.js:579)
```