### PR TITLE
Support markdown in book descriptions

### DIFF
--- a/client/pages/item/_id/index.vue
+++ b/client/pages/item/_id/index.vue
@@ -125,7 +125,7 @@
           </div>
 
           <div class="my-4 max-w-2xl">
-            <p class="text-base text-gray-100 whitespace-pre-line">{{ description }}</p>
+            <div class="text-base text-gray-100 default-style" v-html="description" />
           </div>
 
           <div v-if="invalidAudioFiles.length" class="bg-error border-red-800 shadow-md p-4">
@@ -153,6 +153,8 @@
 </template>
 
 <script>
+import { marked } from '@/static/libs/marked/index.js'
+
 export default {
   async asyncData({ store, params, app, redirect, route }) {
     if (!store.state.user.user) {
@@ -323,7 +325,7 @@ export default {
       return this.media.audioFile
     },
     description() {
-      return this.mediaMetadata.description || ''
+      return marked(this.mediaMetadata.description || '')
     },
     userMediaProgress() {
       if (this.isMusic) return null

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "sequelize": "^6.32.1",
         "socket.io": "^4.5.4",
         "sqlite3": "^5.1.6",
+        "turndown": "^7.1.2",
         "xml2js": "^0.5.0"
       },
       "bin": {
@@ -640,6 +641,11 @@
       "funding": {
         "url": "https://github.com/fb55/domhandler?sponsor=1"
       }
+    },
+    "node_modules/domino": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/domino/-/domino-2.1.6.tgz",
+      "integrity": "sha512-3VdM/SXBZX2omc9JF9nOPCtDaYQ67BGp5CoLpIQlO2KCAPETs8TcDHacF26jXadGbvUteZzRTeos2fhID5+ucQ=="
     },
     "node_modules/domutils": {
       "version": "3.0.1",
@@ -2517,6 +2523,14 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
+    "node_modules/turndown": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/turndown/-/turndown-7.1.2.tgz",
+      "integrity": "sha512-ntI9R7fcUKjqBP6QU8rBK2Ehyt8LAzt3UBT9JR9tgo6GtuKvyUzpayWmeMKJw1DPdXzktvtIT8m2mVXz+bL/Qg==",
+      "dependencies": {
+        "domino": "^2.1.6"
+      }
+    },
     "node_modules/type-is": {
       "version": "1.6.18",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
@@ -3166,6 +3180,11 @@
       "requires": {
         "domelementtype": "^2.3.0"
       }
+    },
+    "domino": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/domino/-/domino-2.1.6.tgz",
+      "integrity": "sha512-3VdM/SXBZX2omc9JF9nOPCtDaYQ67BGp5CoLpIQlO2KCAPETs8TcDHacF26jXadGbvUteZzRTeos2fhID5+ucQ=="
     },
     "domutils": {
       "version": "3.0.1",
@@ -4538,6 +4557,14 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "turndown": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/turndown/-/turndown-7.1.2.tgz",
+      "integrity": "sha512-ntI9R7fcUKjqBP6QU8rBK2Ehyt8LAzt3UBT9JR9tgo6GtuKvyUzpayWmeMKJw1DPdXzktvtIT8m2mVXz+bL/Qg==",
+      "requires": {
+        "domino": "^2.1.6"
+      }
     },
     "type-is": {
       "version": "1.6.18",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "sequelize": "^6.32.1",
     "socket.io": "^4.5.4",
     "sqlite3": "^5.1.6",
+    "turndown": "^7.1.2",
     "xml2js": "^0.5.0"
   },
   "devDependencies": {

--- a/server/providers/Audible.js
+++ b/server/providers/Audible.js
@@ -1,5 +1,6 @@
 const axios = require('axios')
-const htmlSanitizer = require('../utils/htmlSanitizer')
+const TurndownService = require('turndown')
+var turndownService = new TurndownService()
 const Logger = require('../Logger')
 
 class Audible {
@@ -45,7 +46,7 @@ class Audible {
             narrator: narrators ? narrators.map(({ name }) => name).join(', ') : null,
             publisher: publisherName,
             publishedYear: releaseDate ? releaseDate.split('-')[0] : null,
-            description: summary ? htmlSanitizer.stripAllTags(summary) : null,
+            description: summary ? turndownService.turndown(summary) : null,
             cover: image,
             asin,
             genres: genresFiltered.length ? genresFiltered : null,

--- a/server/providers/iTunes.js
+++ b/server/providers/iTunes.js
@@ -1,6 +1,8 @@
 const axios = require('axios')
 const Logger = require('../Logger')
 const htmlSanitizer = require('../utils/htmlSanitizer')
+const TurndownService = require('turndown')
+var turndownService = new TurndownService()
 
 class iTunes {
   constructor() { }
@@ -69,7 +71,7 @@ class iTunes {
       artistId: data.artistId,
       title: data.collectionName,
       author,
-      description: htmlSanitizer.stripAllTags(data.description || ''),
+      description: turndownService.turndown(data.description || ''),
       publishedYear: data.releaseDate ? data.releaseDate.split('-')[0] : null,
       genres: data.primaryGenreName ? [data.primaryGenreName] : null,
       cover: this.getCoverArtwork(data)

--- a/server/utils/parsers/parseOpfMetadata.js
+++ b/server/utils/parsers/parseOpfMetadata.js
@@ -1,5 +1,6 @@
 const { xmlToJSON } = require('../index')
-const htmlSanitizer = require('../htmlSanitizer')
+const TurndownService = require('turndown')
+var turndownService = new TurndownService()
 
 function parseCreators(metadata) {
   if (!metadata['dc:creator']) return null
@@ -87,7 +88,7 @@ function fetchDescription(metadata) {
   // check if description is HTML or plain text. only plain text allowed
   // calibre stores < and > as &lt; and &gt;
   description = description.replace(/&lt;/g, '<').replace(/&gt;/g, '>')
-  return htmlSanitizer.stripAllTags(description)
+  return turndownService.turndown(description)
 }
 
 function fetchGenres(metadata) {


### PR DESCRIPTION
It would be pretty nice to have a little rich text in book descriptions, mostly so line breaks are preserved when fetching metadata.
This pull request uses [turndown](https://github.com/mixmark-io/turndown) to convert book descriptions grabbed from Audible or iTunes into markdown, and since [marked](https://github.com/markedjs/marked) is already included to render the changelog, rendering markdown in the descriptions is pretty easy. 

Alternatively, we could use the trix editor currently used for podcast episodes instead of using markdown. If this is something planned for the future, it might make more sense to store rich text descriptions as sanitized html instead of markdown. I could also make a pull request with the trix editor instead if wanted.

resolves #617 
resolves #1820 