### PR TITLE
Improve formatting configuration

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+charset = utf-8
+insert_final_newline = false
+trim_trailing_whitespace = true

--- a/.editorconfig
+++ b/.editorconfig
@@ -4,5 +4,5 @@ root = true
 indent_style = space
 indent_size = 2
 charset = utf-8
-insert_final_newline = false
+insert_final_newline = true
 trim_trailing_whitespace = true

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,17 @@
+{
+  "semi": false,
+  "singleQuote": true,
+  "printWidth": 400,
+  "proseWrap": "never",
+  "trailingComma": "none",
+  "overrides": [
+    {
+      "files": ["*.html"],
+      "options": {
+        "singleQuote": false,
+        "wrapAttributes": false,
+        "sortAttributes": false
+      }
+    }
+  ]
+}

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,5 @@
 {
+  "editorconfig": true,
   "semi": false,
   "singleQuote": true,
   "printWidth": 400,

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,4 @@
 {
-  "editorconfig": true,
   "semi": false,
   "singleQuote": true,
   "printWidth": 400,

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["esbenp.prettier-vscode", "octref.vetur"]
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,3 @@
 {
-  "recommendations": ["esbenp.prettier-vscode", "octref.vetur"]
+  "recommendations": ["EditorConfig.EditorConfig", "esbenp.prettier-vscode", "octref.vetur"]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,11 @@
   "editor.detectIndentation": true,
   "editor.tabSize": 2,
 
+  "files.encoding": "utf8",
+  "files.insertFinalNewline": false,
+  "files.trimTrailingWhitespace": true,
+  "files.trimFinalNewlines": true,
+
   "[javascript][json][jsonc]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,7 +4,7 @@
   "editor.tabSize": 2,
 
   "files.encoding": "utf8",
-  "files.insertFinalNewline": false,
+  "files.insertFinalNewline": true,
   "files.trimTrailingWhitespace": true,
   "files.trimFinalNewlines": true,
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,20 +1,12 @@
 {
-  "vetur.format.defaultFormatterOptions": {
-    "prettier": {
-      "semi": false,
-      "singleQuote": true,
-      "printWidth": 400,
-      "proseWrap": "never",
-      "trailingComma": "none"
-    },
-    "prettyhtml": {
-      "printWidth": 400,
-      "singleQuote": false,
-      "wrapAttributes": false,
-      "sortAttributes": false
-    }
-  },
   "editor.formatOnSave": true,
   "editor.detectIndentation": true,
-  "editor.tabSize": 2
+  "editor.tabSize": 2,
+
+  "[javascript][json][jsonc]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[vue]": {
+    "editor.defaultFormatter": "octref.vetur"
+  }
 }

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -31,6 +31,7 @@
         "@nuxtjs/tailwindcss": "^4.2.1",
         "autoprefixer": "^10.4.7",
         "postcss": "^8.3.6",
+        "prettier": "^3.0.3",
         "tailwindcss": "^3.1.4"
       }
     },
@@ -3575,6 +3576,21 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/postcss/"
+      }
+    },
+    "node_modules/@vue/component-compiler-utils/node_modules/prettier": {
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "optional": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/@vue/component-compiler-utils/node_modules/yallist": {
@@ -13156,15 +13172,15 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
-      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
-      "optional": true,
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.3.tgz",
+      "integrity": "sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==",
+      "dev": true,
       "bin": {
-        "prettier": "bin-prettier.js"
+        "prettier": "bin/prettier.cjs"
       },
       "engines": {
-        "node": ">=10.13.0"
+        "node": ">=14"
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
@@ -20132,6 +20148,12 @@
             "picocolors": "^0.2.1",
             "source-map": "^0.6.1"
           }
+        },
+        "prettier": {
+          "version": "2.8.8",
+          "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+          "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+          "optional": true
         },
         "yallist": {
           "version": "2.1.2",
@@ -27487,10 +27509,10 @@
       "integrity": "sha512-PhmXi5XmoyKw1Un4E+opM2KcsJInDvKyuOumcjjw3waw86ZNjHwVUOOWLc4bCzLdcKNaWBH9e99sbWzDQsVaYg=="
     },
     "prettier": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
-      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
-      "optional": true
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.3.tgz",
+      "integrity": "sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==",
+      "dev": true
     },
     "pretty-bytes": {
       "version": "5.6.0",

--- a/client/package.json
+++ b/client/package.json
@@ -8,7 +8,8 @@
     "dev2": "nuxt --hostname localhost --port 1337",
     "build": "nuxt build",
     "start": "nuxt start",
-    "generate": "nuxt generate"
+    "generate": "nuxt generate",
+    "format": "prettier --write **/*.js"
   },
   "author": "advplyr",
   "license": "ISC",
@@ -35,6 +36,7 @@
     "@nuxtjs/tailwindcss": "^4.2.1",
     "autoprefixer": "^10.4.7",
     "postcss": "^8.3.6",
-    "tailwindcss": "^3.1.4"
+    "tailwindcss": "^3.1.4",
+    "prettier": "^3.0.3"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,8 @@
         "audiobookshelf": "prod.js"
       },
       "devDependencies": {
-        "nodemon": "^2.0.20"
+        "nodemon": "^2.0.20",
+        "prettier": "^3.0.3"
       }
     },
     "node_modules/@gar/promisify": {
@@ -1868,6 +1869,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.3.tgz",
+      "integrity": "sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/promise-inflight": {
@@ -4078,6 +4094,12 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true
+    },
+    "prettier": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.3.tgz",
+      "integrity": "sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==",
       "dev": true
     },
     "promise-inflight": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "docker-amd64-local": "docker buildx build --platform linux/amd64 --load .  -t advplyr/audiobookshelf-amd64-local",
     "docker-arm64-local": "docker buildx build --platform linux/arm64 --load .  -t advplyr/audiobookshelf-arm64-local",
     "docker-armv7-local": "docker buildx build --platform linux/arm/v7 --load .  -t advplyr/audiobookshelf-armv7-local",
-    "deploy-linux": "node deploy/linux"
+    "deploy-linux": "node deploy/linux",
+    "format": "prettier --write *.js server/**/*.js"
   },
   "bin": "prod.js",
   "pkg": {
@@ -42,6 +43,7 @@
     "xml2js": "^0.5.0"
   },
   "devDependencies": {
-    "nodemon": "^2.0.20"
+    "nodemon": "^2.0.20",
+    "prettier": "^3.0.3"
   }
 }


### PR DESCRIPTION
When developing my first contrbution to this repo in #2182 , I noticed that the configuration of the formatting could be improved slightly to help people developing in VSCode and other IDEs, as well as aid with keeping consistent formatting across the codebase - assuming this is what you want. This was particularly relevant to me as I noticed when editing some existing files in my other PR, that my IDE was trying to format it differently to how it currently was, which i had to be careful to avoid.

I have moved your prettier config from the vscode settings to a `.prettierrc` file so that it is IDE agnostic - vetur will still use this config. Additionally i have added prettier to the dev dependancies and added a task to run prettier across all files should you wish to do this at some point (I did not run this for this PR).

I hope these improvements simply help contributers know the formatting this project would like, allows them to easily ensure they are meeting the style and helps avoid changing the formatting of existing files. 

If this is not what is wanted, please let me know, it just seemed like an easy win that I think is helpful (well for me at least)