### PR TITLE
Fix incorrect subpath checks in server/watcher.js

### DIFF
--- a/server/Watcher.js
+++ b/server/Watcher.js
@@ -6,7 +6,7 @@ const LibraryScanner = require('./scanner/LibraryScanner')
 const Task = require('./objects/Task')
 const TaskManager = require('./managers/TaskManager')
 
-const { filePathToPOSIX } = require('./utils/fileUtils')
+const { filePathToPOSIX, isSameOrSubPath } = require('./utils/fileUtils')
 
 /**
  * @typedef PendingFileUpdate
@@ -183,7 +183,7 @@ class FolderWatcher extends EventEmitter {
     }
 
     // Get file folder
-    const folder = libwatcher.folders.find(fold => path.startsWith(filePathToPOSIX(fold.fullPath)))
+    const folder = libwatcher.folders.find(fold => isSameOrSubPath(fold.fullPath, path))
     if (!folder) {
       Logger.error(`[Watcher] New file folder not found in library "${libwatcher.name}" with path "${path}"`)
       return
@@ -233,7 +233,7 @@ class FolderWatcher extends EventEmitter {
 
   checkShouldIgnorePath(path) {
     return !!this.ignoreDirs.find(dirpath => {
-      return filePathToPOSIX(path).startsWith(dirpath)
+      return isSameOrSubPath(dirpath, path)
     })
   }
 

--- a/server/utils/fileUtils.js
+++ b/server/utils/fileUtils.js
@@ -19,6 +19,13 @@ const filePathToPOSIX = (path) => {
 }
 module.exports.filePathToPOSIX = filePathToPOSIX
 
+/**
+ * Check path is a child of or equal to another path
+ * 
+ * @param {string} parentPath 
+ * @param {string} childPath 
+ * @returns {boolean}
+ */
 function isSameOrSubPath(parentPath, childPath) {
   parentPath = filePathToPOSIX(parentPath)
   childPath = filePathToPOSIX(childPath)

--- a/server/utils/fileUtils.js
+++ b/server/utils/fileUtils.js
@@ -19,6 +19,18 @@ const filePathToPOSIX = (path) => {
 }
 module.exports.filePathToPOSIX = filePathToPOSIX
 
+function isSameOrSubPath(parentPath, childPath) {
+  parentPath = filePathToPOSIX(parentPath)
+  childPath = filePathToPOSIX(childPath)
+  if (parentPath === childPath) return true
+  const relativePath = Path.relative(parentPath, childPath)
+  return (
+    relativePath === '' // Same path (e.g. parentPath = '/a/b/', childPath = '/a/b')
+    || !relativePath.startsWith('..') && !Path.isAbsolute(relativePath) // Sub path
+  )
+}
+module.exports.isSameOrSubPath = isSameOrSubPath
+
 async function getFileStat(path) {
   try {
     var stat = await fs.stat(path)


### PR DESCRIPTION
Fixes #2244.
This fix applies [this solution](https://stackoverflow.com/questions/37521893/determine-if-a-path-is-subdirectory-of-another-in-node-js) to perform proper subpath checking.