### PR TITLE
Add API to update a path on a watched library folder

### DIFF
--- a/server/controllers/MiscController.js
+++ b/server/controllers/MiscController.js
@@ -528,14 +528,16 @@ class MiscController {
   }
 
   /**
-  * POST: /api/watcher/update
-  * Update a watch path
-  * Req.body { libraryId, path, type, [oldPath] } 
-  * type = add, unlink, rename
-  * oldPath = required only for rename
-  * @param {*} req 
-  * @param {*} res 
-  */
+   * POST: /api/watcher/update
+   * Update a watch path
+   * Req.body { libraryId, path, type, [oldPath] } 
+   * type = add, unlink, rename
+   * oldPath = required only for rename
+   * @this import('../routers/ApiRouter')
+   * 
+   * @param {import('express').Request} req 
+   * @param {import('express').Response} res 
+   */
   updateWatchedPath(req, res) {
     if (!req.user.isAdminOrUp) {
       Logger.error(`[MiscController] Non-admin user attempted to updateWatchedPath`)
@@ -552,7 +554,7 @@ class MiscController {
 
     switch (type) {
       case 'add':
-        this.watcher.onNewFile(libraryId, path)
+        this.watcher.onFileAdded(libraryId, path)
         break;
       case 'unlink':
         this.watcher.onFileRemoved(libraryId, path)
@@ -563,7 +565,7 @@ class MiscController {
           Logger.error(`[MiscController] Invalid request body for updateWatchedPath. oldPath is required for rename.`)
           return res.sendStatus(400)
         }
-        this.watcher.onRename(libraryId, oldPath, path)
+        this.watcher.onFileRename(libraryId, oldPath, path)
         break;
       default:
         Logger.error(`[MiscController] Invalid type for updateWatchedPath. type: "${type}"`)
@@ -571,9 +573,7 @@ class MiscController {
     }
 
     res.sendStatus(200)
-
   }
-
 
   validateCronExpression(req, res) {
     const expression = req.body.expression

--- a/server/routers/ApiRouter.js
+++ b/server/routers/ApiRouter.js
@@ -39,6 +39,7 @@ class ApiRouter {
     this.playbackSessionManager = Server.playbackSessionManager
     this.abMergeManager = Server.abMergeManager
     this.backupManager = Server.backupManager
+    /** @type {import('../Watcher')} */
     this.watcher = Server.watcher
     this.podcastManager = Server.podcastManager
     this.audioMetadataManager = Server.audioMetadataManager

--- a/server/routers/ApiRouter.js
+++ b/server/routers/ApiRouter.js
@@ -308,6 +308,7 @@ class ApiRouter {
     this.router.post('/genres/rename', MiscController.renameGenre.bind(this))
     this.router.delete('/genres/:genre', MiscController.deleteGenre.bind(this))
     this.router.post('/validate-cron', MiscController.validateCronExpression.bind(this))
+    this.router.post('/watcher/update', MiscController.updateWatchedPath.bind(this))
   }
 
   async getDirectories(dir, relpath, excludedDirs, level = 0) {


### PR DESCRIPTION
This adds a an API for notifying the server of an update to a watched library folder. Each call to the API essentially mimics a watcher event, and calls the same event listener that listens to real watcher events.

It is meant to be used by an external watcher (e.g. one that would run on a Docker host), in an attempt to mitigate #2204 (watcher not firing events when watching bind mounts on docker). I'm currently working on such an external watcher that could be run on node.js on the docker host and which will use this API. Hopefully this external watcher can also be packaged as an executable, and could be installed as a service on the host machine.