### PR TITLE
Search epub text

### DIFF
--- a/client/components/readers/EpubReader.vue
+++ b/client/components/readers/EpubReader.vue
@@ -401,6 +401,26 @@ export default {
         this.chapters = tocTree
       })
     },
+    flattenChapters(chapters) {
+      // Convert the nested epub chapters into something that looks like audiobook chapters for player-ui
+      const unwrap = (chapters) => {
+        return chapters.reduce((acc, chapter) => {
+          return chapter.subitems ? [...acc, chapter, ...unwrap(chapter.subitems)] : [...acc, chapter]
+        }, [])
+      }
+      let flattenedChapters = unwrap(chapters)
+
+      flattenedChapters = flattenedChapters.sort((a, b) => a.start - b.start)
+      for (let i = 0; i < flattenedChapters.length; i++) {
+        flattenedChapters[i].id = i
+        if (i < flattenedChapters.length - 1) {
+          flattenedChapters[i].end = flattenedChapters[i + 1].start
+        } else {
+          flattenedChapters[i].end = 1
+        }
+      }
+      return flattenedChapters
+    },
     resize() {
       this.windowWidth = window.innerWidth
       this.windowHeight = window.innerHeight

--- a/client/components/readers/Reader.vue
+++ b/client/components/readers/Reader.vue
@@ -26,9 +26,9 @@
     <component v-if="componentName" ref="readerComponent" :is="componentName" :library-item="selectedLibraryItem" :player-open="!!streamLibraryItem" :keep-progress="keepProgress" :file-id="ebookFileId" @touchstart="touchstart" @touchend="touchend" @hook:mounted="readerMounted" />
 
     <!-- TOC side nav -->
-    <div v-if="tocOpen" class="w-full h-full fixed inset-0 bg-black/20 z-20" @click.stop.prevent="toggleToC"></div>
+    <div v-if="tocOpen" class="w-full h-full overflow-y-scroll absolute inset-0 bg-black/20 z-20" @click.stop.prevent="toggleToC"></div>
     <div v-if="isEpub" class="w-96 h-full max-h-full absolute top-0 left-0 shadow-xl transition-transform z-30 group-data-[theme=dark]:bg-primary group-data-[theme=dark]:text-white group-data-[theme=light]:bg-white group-data-[theme=light]:text-black" :class="tocOpen ? 'translate-x-0' : '-translate-x-96'" @click.stop.prevent="toggleToC">
-      <div class="p-4 h-full">
+      <div class="flex flex-col p-4 h-full">
         <div class="flex items-center mb-2">
           <button @click.stop.prevent="toggleToC" type="button" aria-label="Close table of contents" class="inline-flex opacity-80 hover:opacity-100">
             <span class="material-icons text-2xl">arrow_back</span>
@@ -36,13 +36,28 @@
 
           <p class="text-lg font-semibold ml-2">{{ $strings.HeaderTableOfContents }}</p>
         </div>
-        <div class="tocContent">
+        <form @submit.prevent="searchBook" @click.stop.prevent>
+          <ui-text-input clearable ref="input" @submit="searchBook" v-model="searchQuery" :placeholder="$strings.PlaceholderSearch" class="h-8 w-full text-sm flex mb-2" />
+        </form>
+
+        <div class="overflow-y-auto">
+          <div v-if="isSearching && !this.searchResults.length" class="w-full h-40 justify-center">
+            <p class="text-center text-xl py-4">{{ $strings.MessageNoResults }}</p>
+          </div>
+
           <ul>
-            <li v-for="chapter in chapters" :key="chapter.id" class="py-1">
-              <a :href="chapter.href" class="opacity-80 hover:opacity-100" @click.prevent="$refs.readerComponent.goToChapter(chapter.href)">{{ chapter.label }}</a>
+            <li v-for="chapter in isSearching ? this.searchResults : chapters" :key="chapter.id" class="py-1">
+              <a :href="chapter.href" class="opacity-80 hover:opacity-100" @click.prevent="$refs.readerComponent.goToChapter(chapter.href)">{{ chapter.title }}</a>
+              <div v-for="searchResults in chapter.searchResults" :key="searchResults.cfi" class="text-sm py-1 pl-4">
+                <a :href="searchResults.cfi" class="opacity-50 hover:opacity-100" @click.prevent="$refs.readerComponent.goToChapter(searchResults.cfi)">{{ searchResults.excerpt }}</a>
+              </div>
+
               <ul v-if="chapter.subitems.length">
                 <li v-for="subchapter in chapter.subitems" :key="subchapter.id" class="py-1 pl-4">
-                  <a :href="subchapter.href" class="opacity-80 hover:opacity-100" @click.prevent="$refs.readerComponent.goToChapter(subchapter.href)">{{ subchapter.label }}</a>
+                  <a :href="subchapter.href" class="opacity-80 hover:opacity-100" @click.prevent="$refs.readerComponent.goToChapter(subchapter.href)">{{ subchapter.title }}</a>
+                  <div v-for="subChapterSearchResults in subchapter.searchResults" :key="subChapterSearchResults.cfi" class="text-sm py-1 pl-4">
+                    <a :href="subChapterSearchResults.cfi" class="opacity-50 hover:opacity-100" @click.prevent="$refs.readerComponent.goToChapter(subChapterSearchResults.cfi)">{{ subChapterSearchResults.excerpt }}</a>
+                  </div>
                 </li>
               </ul>
             </li>
@@ -105,6 +120,9 @@ export default {
       touchstartTime: 0,
       touchIdentifier: null,
       chapters: [],
+      isSearching: false,
+      searchResults: [],
+      searchQuery: '',
       tocOpen: false,
       showSettings: false,
       ereaderSettings: {
@@ -281,6 +299,15 @@ export default {
         this.close()
       }
     },
+    async searchBook() {
+      if (this.searchQuery.length > 1) {
+        this.searchResults = await this.$refs.readerComponent.searchBook(this.searchQuery)
+        this.isSearching = true
+      } else {
+        this.isSearching = false
+        this.searchResults = []
+      }
+    },
     next() {
       if (this.$refs.readerComponent?.next) this.$refs.readerComponent.next()
     },
@@ -359,6 +386,8 @@ export default {
     },
     close() {
       this.unregisterListeners()
+      this.isSearching = false
+      this.searchQuery = ''
       this.show = false
     }
   },
@@ -372,10 +401,6 @@ export default {
 </script>
 
 <style>
-.tocContent {
-  height: calc(100% - 36px);
-  overflow-y: auto;
-}
 #reader {
   height: 100%;
 }

--- a/client/components/readers/Reader.vue
+++ b/client/components/readers/Reader.vue
@@ -27,7 +27,7 @@
 
     <!-- TOC side nav -->
     <div v-if="tocOpen" class="w-full h-full overflow-y-scroll absolute inset-0 bg-black/20 z-20" @click.stop.prevent="toggleToC"></div>
-    <div v-if="isEpub" class="w-96 h-full max-h-full absolute top-0 left-0 shadow-xl transition-transform z-30 group-data-[theme=dark]:bg-primary group-data-[theme=dark]:text-white group-data-[theme=light]:bg-white group-data-[theme=light]:text-black" :class="tocOpen ? 'translate-x-0' : '-translate-x-96'" @click.stop.prevent="toggleToC">
+    <div v-if="isEpub" class="w-96 h-full max-h-full absolute top-0 left-0 shadow-xl transition-transform z-30 group-data-[theme=dark]:bg-primary group-data-[theme=dark]:text-white group-data-[theme=light]:bg-white group-data-[theme=light]:text-black" :class="tocOpen ? 'translate-x-0' : '-translate-x-96'" @click.stop.prevent>
       <div class="flex flex-col p-4 h-full">
         <div class="flex items-center mb-2">
           <button @click.stop.prevent="toggleToC" type="button" aria-label="Close table of contents" class="inline-flex opacity-80 hover:opacity-100">
@@ -37,7 +37,7 @@
           <p class="text-lg font-semibold ml-2">{{ $strings.HeaderTableOfContents }}</p>
         </div>
         <form @submit.prevent="searchBook" @click.stop.prevent>
-          <ui-text-input clearable ref="input" @submit="searchBook" v-model="searchQuery" :placeholder="$strings.PlaceholderSearch" class="h-8 w-full text-sm flex mb-2" />
+          <ui-text-input clearable ref="input" @clear="searchBook" v-model="searchQuery" :placeholder="$strings.PlaceholderSearch" class="h-8 w-full text-sm flex mb-2" />
         </form>
 
         <div class="overflow-y-auto">
@@ -47,16 +47,16 @@
 
           <ul>
             <li v-for="chapter in isSearching ? this.searchResults : chapters" :key="chapter.id" class="py-1">
-              <a :href="chapter.href" class="opacity-80 hover:opacity-100" @click.prevent="$refs.readerComponent.goToChapter(chapter.href)">{{ chapter.title }}</a>
+              <a :href="chapter.href" class="opacity-80 hover:opacity-100" @click.prevent="goToChapter(chapter.href)">{{ chapter.title }}</a>
               <div v-for="searchResults in chapter.searchResults" :key="searchResults.cfi" class="text-sm py-1 pl-4">
-                <a :href="searchResults.cfi" class="opacity-50 hover:opacity-100" @click.prevent="$refs.readerComponent.goToChapter(searchResults.cfi)">{{ searchResults.excerpt }}</a>
+                <a :href="searchResults.cfi" class="opacity-50 hover:opacity-100" @click.prevent="goToChapter(searchResults.cfi)">{{ searchResults.excerpt }}</a>
               </div>
 
               <ul v-if="chapter.subitems.length">
                 <li v-for="subchapter in chapter.subitems" :key="subchapter.id" class="py-1 pl-4">
-                  <a :href="subchapter.href" class="opacity-80 hover:opacity-100" @click.prevent="$refs.readerComponent.goToChapter(subchapter.href)">{{ subchapter.title }}</a>
+                  <a :href="subchapter.href" class="opacity-80 hover:opacity-100" @click.prevent="goToChapter(subchapter.href)">{{ subchapter.title }}</a>
                   <div v-for="subChapterSearchResults in subchapter.searchResults" :key="subChapterSearchResults.cfi" class="text-sm py-1 pl-4">
-                    <a :href="subChapterSearchResults.cfi" class="opacity-50 hover:opacity-100" @click.prevent="$refs.readerComponent.goToChapter(subChapterSearchResults.cfi)">{{ subChapterSearchResults.excerpt }}</a>
+                    <a :href="subChapterSearchResults.cfi" class="opacity-50 hover:opacity-100" @click.prevent="goToChapter(subChapterSearchResults.cfi)">{{ subChapterSearchResults.excerpt }}</a>
                   </div>
                 </li>
               </ul>
@@ -181,11 +181,11 @@ export default {
         font: [
           {
             text: 'Sans',
-            value: 'sans-serif',
+            value: 'sans-serif'
           },
           {
             text: 'Serif',
-            value: 'serif',
+            value: 'serif'
           }
         ]
       }
@@ -272,6 +272,10 @@ export default {
     }
   },
   methods: {
+    goToChapter(uri) {
+      this.toggleToC()
+      this.$refs.readerComponent.goToChapter(uri)
+    },
     readerMounted() {
       if (this.isEpub) {
         this.loadEreaderSettings()

--- a/client/components/ui/TextInput.vue
+++ b/client/components/ui/TextInput.vue
@@ -68,7 +68,7 @@ export default {
   methods: {
     clear() {
       this.inputValue = ''
-      this.$emit('submit')
+      this.$emit('clear')
     },
     focused() {
       this.isFocused = true

--- a/client/components/ui/TextInput.vue
+++ b/client/components/ui/TextInput.vue
@@ -68,6 +68,7 @@ export default {
   methods: {
     clear() {
       this.inputValue = ''
+      this.$emit('submit')
     },
     focused() {
       this.isFocused = true


### PR DESCRIPTION
Adds a search box in the table of contents sidebar to search for text within epubs.

Search results are displayed under the chapter they are found in, but at the moment, only the first two chapter levels are displayed in the ToC, so search results in chapters more than two levels deep won't appear. I could see about using a recursive component to display ToC entries instead, although I haven't found a book with more than three chapter levels yet.

This also makes adds a flattenChapters method, which converts ebook chapters into something that looks like audiobook chapters so that the seek bar will work with ebooks too (in a future pull request)

Closes #2045 

![image](https://github.com/advplyr/audiobookshelf/assets/44880075/23d9f5b1-282f-4571-9f86-263ca8dfce7a)
