### PR TITLE
Add support for the old Apple Podcasts iOS app

### DIFF
--- a/server/Server.js
+++ b/server/Server.js
@@ -155,7 +155,7 @@ class Server {
       Logger.info(`[Server] Requesting rss feed ${req.params.slug}`)
       this.rssFeedManager.getFeed(req, res)
     })
-    router.get('/feed/:slug/cover', (req, res) => {
+    router.get('/feed/:slug/cover*', (req, res) => {
       this.rssFeedManager.getFeedCover(req, res)
     })
     router.get('/feed/:slug/item/:episodeId/*', (req, res) => {

--- a/server/objects/Feed.js
+++ b/server/objects/Feed.js
@@ -1,3 +1,4 @@
+const Path = require('path')
 const uuidv4 = require("uuid").v4
 const FeedMeta = require('./FeedMeta')
 const FeedEpisode = require('./FeedEpisode')
@@ -101,11 +102,13 @@ class Feed {
     this.serverAddress = serverAddress
     this.feedUrl = feedUrl
 
+    const coverFileExtension = this.coverPath ? Path.extname(media.coverPath) : null
+
     this.meta = new FeedMeta()
     this.meta.title = mediaMetadata.title
     this.meta.description = mediaMetadata.description
     this.meta.author = author
-    this.meta.imageUrl = media.coverPath ? `${serverAddress}/feed/${slug}/cover` : `${serverAddress}/Logo.png`
+    this.meta.imageUrl = media.coverPath ? `${serverAddress}/feed/${slug}/cover${coverFileExtension}` : `${serverAddress}/Logo.png`
     this.meta.feedUrl = feedUrl
     this.meta.link = `${serverAddress}/item/${libraryItem.id}`
     this.meta.explicit = !!mediaMetadata.explicit
@@ -145,10 +148,12 @@ class Feed {
     this.entityUpdatedAt = libraryItem.updatedAt
     this.coverPath = media.coverPath || null
 
+    const coverFileExtension = this.coverPath ? Path.extname(media.coverPath) : null
+
     this.meta.title = mediaMetadata.title
     this.meta.description = mediaMetadata.description
     this.meta.author = author
-    this.meta.imageUrl = media.coverPath ? `${this.serverAddress}/feed/${this.slug}/cover` : `${this.serverAddress}/Logo.png`
+    this.meta.imageUrl = media.coverPath ? `${this.serverAddress}/feed/${this.slug}/cover${coverFileExtension}` : `${this.serverAddress}/Logo.png`
     this.meta.explicit = !!mediaMetadata.explicit
     this.meta.type = mediaMetadata.type
     this.meta.language = mediaMetadata.language
@@ -190,11 +195,13 @@ class Feed {
     this.serverAddress = serverAddress
     this.feedUrl = feedUrl
 
+    const coverFileExtension = this.coverPath ? Path.extname(media.coverPath) : null
+
     this.meta = new FeedMeta()
     this.meta.title = collectionExpanded.name
     this.meta.description = collectionExpanded.description || ''
     this.meta.author = this.getAuthorsStringFromLibraryItems(itemsWithTracks)
-    this.meta.imageUrl = this.coverPath ? `${serverAddress}/feed/${slug}/cover` : `${serverAddress}/Logo.png`
+    this.meta.imageUrl = this.coverPath ? `${serverAddress}/feed/${slug}/cover${coverFileExtension}` : `${serverAddress}/Logo.png`
     this.meta.feedUrl = feedUrl
     this.meta.link = `${serverAddress}/collection/${collectionExpanded.id}`
     this.meta.explicit = !!itemsWithTracks.some(li => li.media.metadata.explicit) // explicit if any item is explicit
@@ -225,10 +232,12 @@ class Feed {
     this.entityUpdatedAt = collectionExpanded.lastUpdate
     this.coverPath = firstItemWithCover?.coverPath || null
 
+    const coverFileExtension = this.coverPath ? Path.extname(media.coverPath) : null
+
     this.meta.title = collectionExpanded.name
     this.meta.description = collectionExpanded.description || ''
     this.meta.author = this.getAuthorsStringFromLibraryItems(itemsWithTracks)
-    this.meta.imageUrl = this.coverPath ? `${this.serverAddress}/feed/${this.slug}/cover` : `${this.serverAddress}/Logo.png`
+    this.meta.imageUrl = this.coverPath ? `${this.serverAddress}/feed/${this.slug}/cover${coverFileExtension}` : `${this.serverAddress}/Logo.png`
     this.meta.explicit = !!itemsWithTracks.some(li => li.media.metadata.explicit) // explicit if any item is explicit
 
     this.episodes = []
@@ -267,11 +276,13 @@ class Feed {
     this.serverAddress = serverAddress
     this.feedUrl = feedUrl
 
+    const coverFileExtension = this.coverPath ? Path.extname(media.coverPath) : null
+
     this.meta = new FeedMeta()
     this.meta.title = seriesExpanded.name
     this.meta.description = seriesExpanded.description || ''
     this.meta.author = this.getAuthorsStringFromLibraryItems(itemsWithTracks)
-    this.meta.imageUrl = this.coverPath ? `${serverAddress}/feed/${slug}/cover` : `${serverAddress}/Logo.png`
+    this.meta.imageUrl = this.coverPath ? `${serverAddress}/feed/${slug}/cover${coverFileExtension}` : `${serverAddress}/Logo.png`
     this.meta.feedUrl = feedUrl
     this.meta.link = `${serverAddress}/library/${libraryId}/series/${seriesExpanded.id}`
     this.meta.explicit = !!itemsWithTracks.some(li => li.media.metadata.explicit) // explicit if any item is explicit
@@ -305,10 +316,12 @@ class Feed {
     this.entityUpdatedAt = seriesExpanded.updatedAt
     this.coverPath = firstItemWithCover?.coverPath || null
 
+    const coverFileExtension = this.coverPath ? Path.extname(media.coverPath) : null
+
     this.meta.title = seriesExpanded.name
     this.meta.description = seriesExpanded.description || ''
     this.meta.author = this.getAuthorsStringFromLibraryItems(itemsWithTracks)
-    this.meta.imageUrl = this.coverPath ? `${this.serverAddress}/feed/${this.slug}/cover` : `${this.serverAddress}/Logo.png`
+    this.meta.imageUrl = this.coverPath ? `${this.serverAddress}/feed/${this.slug}/cover${coverFileExtension}` : `${this.serverAddress}/Logo.png`
     this.meta.explicit = !!itemsWithTracks.some(li => li.media.metadata.explicit) // explicit if any item is explicit
 
     this.episodes = []

--- a/server/objects/FeedEpisode.js
+++ b/server/objects/FeedEpisode.js
@@ -1,3 +1,4 @@
+const Path = require('path')
 const uuidv4 = require("uuid").v4
 const date = require('../libs/dateAndTime')
 const { secondsToTimestamp } = require('../utils/index')
@@ -69,7 +70,8 @@ class FeedEpisode {
   }
 
   setFromPodcastEpisode(libraryItem, serverAddress, slug, episode, meta) {
-    const contentUrl = `/feed/${slug}/item/${episode.id}/${episode.audioFile.metadata.filename}`
+    const contentFileExtension = Path.extname(episode.audioFile.metadata.filename)
+    const contentUrl = `/feed/${slug}/item/${episode.id}/media${contentFileExtension}`
     const media = libraryItem.media
     const mediaMetadata = media.metadata
 
@@ -108,7 +110,8 @@ class FeedEpisode {
     // e.g. Track 1 will have a pub date before Track 2
     const audiobookPubDate = date.format(new Date(libraryItem.addedAt + timeOffset), 'ddd, DD MMM YYYY HH:mm:ss [GMT]')
 
-    const contentUrl = `/feed/${slug}/item/${episodeId}/${audioTrack.metadata.filename}`
+    const contentFileExtension = Path.extname(audioTrack.metadata.filename)
+    const contentUrl = `/feed/${slug}/item/${episodeId}/media${contentFileExtension}`
     const media = libraryItem.media
     const mediaMetadata = media.metadata
 


### PR DESCRIPTION
Following my [enhancement request](https://github.com/advplyr/audiobookshelf/issues/2263) to add support for an old version (1.2.3) of the Apple Podcasts iOS app, I found that the RSS feed needed:
1. the artwork URL to include the file extension;
2. the audio file URL not to contain any non-ASCII character and to include the file extension.

With this patch:
1. The artwork URL on the RSS feed now includes the artwork file extension.
2. The content URL does not contain anymore the full filename (`/feed/${slug}/item/${episode.id}/${episode.audioFile.metadata.filename}`) but is now generic keeping a correct file extension (`/feed/${slug}/item/${episode.id}/media${contentFileExtension}`).

Feel free to comment or suggest any prettier code, I digged recently into this project.   