### PR TITLE
Hide collection duration if 0

### DIFF
--- a/client/components/tables/collection/BookTableRow.vue
+++ b/client/components/tables/collection/BookTableRow.vue
@@ -30,7 +30,7 @@
               ><span :key="author.id + '-comma'" v-if="index < bookAuthors.length - 1">,&nbsp;</span>
             </template>
           </div>
-          <p class="text-xs md:text-sm text-gray-400" v-if="media.duration > 0">{{ bookDuration }}</p>
+          <p v-if="media.duration" class="text-xs md:text-sm text-gray-400">{{ bookDuration }}</p>
         </div>
       </div>
     </div>

--- a/client/components/tables/collection/BookTableRow.vue
+++ b/client/components/tables/collection/BookTableRow.vue
@@ -30,7 +30,7 @@
               ><span :key="author.id + '-comma'" v-if="index < bookAuthors.length - 1">,&nbsp;</span>
             </template>
           </div>
-          <p class="text-xs md:text-sm text-gray-400">{{ bookDuration }}</p>
+          <p class="text-xs md:text-sm text-gray-400" v-if="media.duration > 0">{{ bookDuration }}</p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
This fixes #2278 by hiding the duration of a book in a collection if it is 0 (or less). I suppose some audiobooks could also have a duration of 0, but this seems rare (and perhaps hiding the duration in those cases also makes sense?). I opted not to go with progress as that would result in the value having different meanings depending on the media type, which sounds like a potentially confusing user experience.

While this fixes the reported bug, I wonder if it makes sense to have page count as the "duration". Although that would require more effort to implement I think.