### PR TITLE
Wrong port EXPOSEd in Dockerfile / Wrong port specified in Documentation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,6 @@ RUN npm ci --only=production
 
 RUN apk del make python3 g++
 
-EXPOSE 80
+EXPOSE 13378
 
 CMD ["node", "index.js"]


### PR DESCRIPTION
The Exposed Port should be the one that is specified in the documentation.


Port 80 causes routing issues.
I got "Bad Gateway, Connection Refused" when I try to connect to the webpage via Traefik
![image](https://github.com/advplyr/audiobookshelf/assets/32965886/cf536486-0136-4a7f-9c4c-e442cfbd4048)
![image](https://github.com/advplyr/audiobookshelf/assets/32965886/c9a0bae7-3cd4-4b7f-95a6-d3ed6a523e6e)

**Traefik logs**:

![image](https://github.com/advplyr/audiobookshelf/assets/32965886/e5bc998b-a022-430d-8d50-4c0260795bbc)

**audiobookshelf Docker logs**:
![image](https://github.com/advplyr/audiobookshelf/assets/32965886/10c194c3-20eb-4057-bfc5-d9df6dc29c7b)


Let's see it in another example - anki sync server

![image](https://github.com/advplyr/audiobookshelf/assets/32965886/342ff76c-04bf-425c-be8b-900cbbbf7968)
It's a correct one, because the docker-compose also points to this port:
![image](https://github.com/advplyr/audiobookshelf/assets/32965886/c8281744-157a-4b1f-a122-48fe2281341a)

**If it's impossible to change this port in Dockerfile, the docker-compose.yml example should contain 80 port**

![image](https://github.com/advplyr/audiobookshelf/assets/32965886/c02f9cec-11fb-4339-b747-43a7892772f7)
```
docker run -d \
  -p **80**:80 \
  -v </path/to/config>:/config \
  -v </path/to/metadata>:/metadata \
  -v </path/to/audiobooks>:/audiobooks \
  -v </path/to/podcasts>:/podcasts \
  --name audiobookshelf \
  ghcr.io/advplyr/audiobookshelf
```