### PR TITLE
Add milliseconds to logging

### DIFF
--- a/server/Logger.js
+++ b/server/Logger.js
@@ -11,7 +11,7 @@ class Logger {
   }
 
   get timestamp() {
-    return date.format(new Date(), 'YYYY-MM-DD HH:mm:ss')
+    return date.format(new Date(), 'YYYY-MM-DD HH:mm:ss.SSS')
   }
 
   get levelString() {


### PR DESCRIPTION
This patch adds milliseconds to the time string used for logging. This helps when debugging some timing issues and should have no real negative side effect.