### PR TITLE
Allow enabling dev logs

### DIFF
--- a/server/Logger.js
+++ b/server/Logger.js
@@ -5,6 +5,7 @@ class Logger {
   constructor() {
     this.isDev = process.env.NODE_ENV !== 'production'
     this.logLevel = !this.isDev ? LogLevel.INFO : LogLevel.TRACE
+    this.hideDevLogs = process.env.HIDE_DEV_LOGS === undefined ? !this.isDev : process.env.HIDE_DEV_LOGS === '1'
     this.socketListeners = []
 
     this.logManager = null
@@ -92,7 +93,7 @@ class Logger {
    * @param  {...any} args
    */
   dev(...args) {
-    if (!this.isDev || process.env.HIDE_DEV_LOGS === '1') return
+    if (this.hideDevLogs) return
     console.log(`[${this.timestamp}] DEV:`, ...args)
   }
 


### PR DESCRIPTION
This patch allows users to enable dev logs on production systems by setting the `HIDE_DEV_LOGS` environment variable.

Before, you could only use this on a non-production environment. On production, the logs would be disabled. This patch changes the behavior and uses the `NODE_ENV` only as default. On production they are disabled if `HIDE_DEV_LOGS` is undefined but can be enabled by setting `HIDE_DEV_LOGS=0` on dev, they are enabled if undefined, but can be disabled by setting `HIDE_DEV_LOGS=1`.