### PR TITLE
SSO/OpenID: Use a mobile-redirect route (Fixes #2379 and #2381)

### DIFF
--- a/client/components/ui/MultiSelect.vue
+++ b/client/components/ui/MultiSelect.vue
@@ -50,7 +50,11 @@ export default {
     label: String,
     disabled: Boolean,
     readonly: Boolean,
-    showEdit: Boolean
+    showEdit: Boolean,
+    menuDisabled: {
+      type: Boolean,
+      default: false
+    },
   },
   data() {
     return {
@@ -77,7 +81,7 @@ export default {
       }
     },
     showMenu() {
-      return this.isFocused
+      return this.isFocused && !this.menuDisabled
     },
     wrapperClass() {
       var classes = []

--- a/client/pages/config/authentication.vue
+++ b/client/pages/config/authentication.vue
@@ -46,6 +46,9 @@
 
             <ui-text-input-with-label ref="openidClientSecret" v-model="newAuthSettings.authOpenIDClientSecret" :disabled="savingSettings" :label="'Client Secret'" class="mb-2" />
 
+            <ui-multi-select ref="redirectUris" v-model="newAuthSettings.authOpenIDMobileRedirectURIs" :items="newAuthSettings.authOpenIDMobileRedirectURIs" :label="$strings.LabelMobileRedirectURIs" class="mb-2" :menuDisabled="true" :disabled="savingSettings" />
+            <p class="pl-4 text-sm text-gray-300 mb-2" v-html="$strings.LabelMobileRedirectURIsDescription" />
+
             <ui-text-input-with-label ref="buttonTextInput" v-model="newAuthSettings.authOpenIDButtonText" :disabled="savingSettings" :label="$strings.LabelButtonText" class="mb-2" />
 
             <div class="flex items-center pt-1 mb-2">
@@ -186,6 +189,25 @@ export default {
       if (!this.newAuthSettings.authOpenIDClientSecret) {
         this.$toast.error('Client Secret required')
         isValid = false
+      }
+
+      function isValidRedirectURI(uri) {
+        // Check for somestring://someother/string
+        const pattern = new RegExp('^\\w+://[\\w\\.-]+$', 'i')
+        return pattern.test(uri)
+      }
+
+      const uris = this.newAuthSettings.authOpenIDMobileRedirectURIs
+      if (uris.includes('*') && uris.length > 1) {
+        this.$toast.error('Mobile Redirect URIs: Asterisk (*) must be the only entry if used')
+        isValid = false
+      } else {
+        uris.forEach(uri => {
+          if (uri !== '*' && !isValidRedirectURI(uri)) {
+            this.$toast.error(`Mobile Redirect URIs: Invalid URI ${uri}`)
+            isValid = false
+          }
+        })
       }
       return isValid
     },

--- a/client/strings/de.json
+++ b/client/strings/de.json
@@ -337,6 +337,8 @@
   "LabelMinute": "Minute",
   "LabelMissing": "Fehlend",
   "LabelMissingParts": "Fehlende Teile",
+  "LabelMobileRedirectURIs": "Erlaubte Weiterleitungs-URIs für die mobile App",
+  "LabelMobileRedirectURIsDescription": "Dies ist eine Whitelist gültiger Umleitungs-URIs für mobile Apps. Der Standardwert ist <code>audiobookshelf://oauth</code>, den Sie entfernen oder durch zusätzliche URIs für die Integration von Drittanbieter-Apps ergänzen können. Die Verwendung eines Sternchens (<code>*</code>) als alleiniger Eintrag erlaubt jede URI.",
   "LabelMore": "Mehr",
   "LabelMoreInfo": "Mehr Info",
   "LabelName": "Name",

--- a/client/strings/en-us.json
+++ b/client/strings/en-us.json
@@ -343,6 +343,8 @@
   "LabelMinute": "Minute",
   "LabelMissing": "Missing",
   "LabelMissingParts": "Missing Parts",
+  "LabelMobileRedirectURIs": "Allowed Mobile Redirect URIs",
+  "LabelMobileRedirectURIsDescription": "This is a whitelist of valid redirect URIs for mobile apps. The default one is <code>audiobookshelf://oauth</code>, which you can remove or supplement with additional URIs for third-party app integration. Using an asterisk (<code>*</code>) as the sole entry permits any URI.",
   "LabelMore": "More",
   "LabelMoreInfo": "More Info",
   "LabelName": "Name",

--- a/server/controllers/MiscController.js
+++ b/server/controllers/MiscController.js
@@ -629,6 +629,23 @@ class MiscController {
         } else {
           Logger.warn(`[MiscController] Invalid value for authActiveAuthMethods`)
         }
+      } else if (key === 'authOpenIDMobileRedirectURIs') {
+        function isValidRedirectURI(uri) {
+          const pattern = new RegExp('^\\w+://[\\w.-]+$', 'i');
+          return pattern.test(uri);
+        }
+
+        const uris = settingsUpdate[key]
+        if (!Array.isArray(uris) || 
+            (uris.includes('*') && uris.length > 1) || 
+            uris.some(uri => uri !== '*' && !isValidRedirectURI(uri))) {
+          Logger.warn(`[MiscController] Invalid value for authOpenIDMobileRedirectURIs`)
+          continue
+        }
+
+        // Update the URIs
+        Database.serverSettings[key] = uris
+        hasUpdates = true
       } else {
         const updatedValueType = typeof settingsUpdate[key]
         if (['authOpenIDAutoLaunch', 'authOpenIDAutoRegister'].includes(key)) {

--- a/server/objects/settings/ServerSettings.js
+++ b/server/objects/settings/ServerSettings.js
@@ -71,6 +71,7 @@ class ServerSettings {
     this.authOpenIDAutoLaunch = false
     this.authOpenIDAutoRegister = false
     this.authOpenIDMatchExistingBy = null
+    this.authOpenIDMobileRedirectURIs = ['audiobookshelf://oauth']
 
     if (settings) {
       this.construct(settings)
@@ -126,6 +127,7 @@ class ServerSettings {
     this.authOpenIDAutoLaunch = !!settings.authOpenIDAutoLaunch
     this.authOpenIDAutoRegister = !!settings.authOpenIDAutoRegister
     this.authOpenIDMatchExistingBy = settings.authOpenIDMatchExistingBy || null
+    this.authOpenIDMobileRedirectURIs = settings.authOpenIDMobileRedirectURIs || ['audiobookshelf://oauth']
 
     if (!Array.isArray(this.authActiveAuthMethods)) {
       this.authActiveAuthMethods = ['local']
@@ -211,7 +213,8 @@ class ServerSettings {
       authOpenIDButtonText: this.authOpenIDButtonText,
       authOpenIDAutoLaunch: this.authOpenIDAutoLaunch,
       authOpenIDAutoRegister: this.authOpenIDAutoRegister,
-      authOpenIDMatchExistingBy: this.authOpenIDMatchExistingBy
+      authOpenIDMatchExistingBy: this.authOpenIDMatchExistingBy, 
+      authOpenIDMobileRedirectURIs: this.authOpenIDMobileRedirectURIs // Do not return to client
     }
   }
 
@@ -220,6 +223,7 @@ class ServerSettings {
     delete json.tokenSecret
     delete json.authOpenIDClientID
     delete json.authOpenIDClientSecret
+    delete json.authOpenIDMobileRedirectURIs
     return json
   }
 
@@ -254,7 +258,8 @@ class ServerSettings {
       authOpenIDButtonText: this.authOpenIDButtonText,
       authOpenIDAutoLaunch: this.authOpenIDAutoLaunch,
       authOpenIDAutoRegister: this.authOpenIDAutoRegister,
-      authOpenIDMatchExistingBy: this.authOpenIDMatchExistingBy
+      authOpenIDMatchExistingBy: this.authOpenIDMatchExistingBy,
+      authOpenIDMobileRedirectURIs: this.authOpenIDMobileRedirectURIs // Do not return to client
     }
   }
 


### PR DESCRIPTION
- Implement `/auth/openid/mobile-redirect` this will redirect to an app-link like audiobookshelf://oauth
- An app must provide an `redirect_uri` parameter with the app-link in the authorization request to /auth/openid
- The user will have to whitelist possible URLs, or explicitly allow all
- Also modified MultiSelect to allow to hide the menu/popup

The user needs to allow redirect-uris for mobile applications in the ABS settings, because they are now hidden from the SSO provider.
I set as default `audiobookshelf://oauth`, the user can also add multiple others, or just provide an asterisk allowing all URLs (or even delete the default). This way we can easily support 3rd-party apps.

In the SSO Provider, as valid redirect_uris the user now has to set:
```
https://absurl/auth/openid/callback
https://absurl/auth/openid/mobile-redirect
```
or if his auth providers supports wildcards, simply:
```
https://absurl/auth/openid/*
```

I also thought about adding a another route after the auth-request where the user is not directly forwarded to the auth provider, but to an ABS page, where ABS explains that an App wants to login.  Similar to the idea suggested in #2381
However Im not sure if it would make sense, because usually the user knows in which App he is... and it does not increase security because the App name provided can simply be faked.
But if we want to do it for some reason anyways, it is possible on top of this PR.

Still a (third party) app can - and maybe should - provide a `client_id` in the first request with the Apps name which we could use later (possibly for logging, statistics, user sessions list etc.). I also provided it in the mobile PR.
Also the mobile app (or 3rd party app developers) now need to provide their redirect url as app-link in the auth request to `/auth/openid/auth`  
While everything is standard oauth2, I will probably provide some guidelines in the API docs of how a 3rd party app dev can use the oauth endpoints.



Required Mobile app change: https://github.com/advplyr/audiobookshelf-app/pull/969