### PR TITLE
Add: OPF file supports multiple series as sequence of : calibre:series and calibre:series_index; including tests

### DIFF
--- a/server/scanner/OpfFileScanner.js
+++ b/server/scanner/OpfFileScanner.js
@@ -32,11 +32,8 @@ class OpfFileScanner {
             bookMetadata.narrators = opfMetadata.narrators
           }
         } else if (key === 'series') {
-          if (opfMetadata.series) {
-            bookMetadata.series = [{
-              name: opfMetadata.series,
-              sequence: opfMetadata.sequence || null
-            }]
+          if (opfMetadata.series?.length) {
+            bookMetadata.series = opfMetadata.series
           }
         } else if (opfMetadata[key] && key !== 'sequence') {
           bookMetadata[key] = opfMetadata[key]

--- a/server/utils/parsers/parseOpfMetadata.js
+++ b/server/utils/parsers/parseOpfMetadata.js
@@ -103,12 +103,11 @@ function fetchSeries(metadataMeta) {
   if (!metadataMeta) return []
   const result = []
   for (let i = 0; i < metadataMeta.length; i++) {
-    if (metadataMeta[i].$.name === "calibre:series") {
-      const name = metadataMeta[i].$.content
+    if (metadataMeta[i].$?.name === "calibre:series" && metadataMeta[i].$.content?.trim()) {
+      const name = metadataMeta[i].$.content.trim()
       let sequence = null
-      if (i + 1 < metadataMeta.length &&
-          metadataMeta[i + 1].$.name === "calibre:series_index" && metadataMeta[i + 1].$.content) {
-        sequence = metadataMeta[i + 1].$.content
+      if (metadataMeta[i + 1]?.$?.name === "calibre:series_index" && metadataMeta[i + 1].$?.content?.trim()) {
+        sequence = metadataMeta[i + 1].$.content.trim()
       }
       result.push({ name, sequence })
     }

--- a/server/utils/parsers/parseOpfMetadata.js
+++ b/server/utils/parsers/parseOpfMetadata.js
@@ -100,13 +100,20 @@ function fetchLanguage(metadata) {
 }
 
 function fetchSeries(metadataMeta) {
-  if (!metadataMeta) return null
-  return fetchTagString(metadataMeta, "calibre:series")
-}
-
-function fetchVolumeNumber(metadataMeta) {
-  if (!metadataMeta) return null
-  return fetchTagString(metadataMeta, "calibre:series_index")
+  if (!metadataMeta) return []
+  const result = []
+  for (let i = 0; i < metadataMeta.length; i++) {
+    if (metadataMeta[i].$.name === "calibre:series") {
+      const name = metadataMeta[i].$.content
+      let sequence = null
+      if (i + 1 < metadataMeta.length &&
+          metadataMeta[i + 1].$.name === "calibre:series_index" && metadataMeta[i + 1].$.content) {
+        sequence = metadataMeta[i + 1].$.content
+      }
+      result.push({ name, sequence })
+    }
+  }
+  return result
 }
 
 function fetchNarrators(creators, metadata) {
@@ -173,8 +180,7 @@ module.exports.parseOpfMetadataXML = async (xml) => {
     description: fetchDescription(metadata),
     genres: fetchGenres(metadata),
     language: fetchLanguage(metadata),
-    series: fetchSeries(metadata.meta),
-    sequence: fetchVolumeNumber(metadata.meta),
+    series: fetchSeries(metadataMeta),
     tags: fetchTags(metadata)
   }
   return data

--- a/test/server/utils/parsers/parseOpfMetadata.test.js
+++ b/test/server/utils/parsers/parseOpfMetadata.test.js
@@ -1,0 +1,85 @@
+const chai = require('chai')
+const expect = chai.expect
+const { parseOpfMetadataXML } = require('../../../../server/utils/parsers/parseOpfMetadata')
+
+
+describe('parseOpfMetadata - test series',  async () => {
+    it('test one serie', async() => {
+        const opf = `
+            <?xml version='1.0' encoding='UTF-8'?>
+            <package xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:opf="http://www.idpf.org/2007/opf" xml:lang="en" version="3.0" unique-identifier="bookid">
+              <metadata>        
+                  <meta name="calibre:series" content="Serie"/>
+                  <meta name="calibre:series_index" content="1"/>
+              </metadata>
+            </package>          
+        `
+        const parsedOpf = await parseOpfMetadataXML(opf)
+        expect(parsedOpf.series).to.deep.equal([{"name": "Serie","sequence": "1"}])
+    })
+
+    it('test more then 1 serie - in correct order', async() => {
+        const opf = `
+            <?xml version='1.0' encoding='UTF-8'?>
+            <package xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:opf="http://www.idpf.org/2007/opf" xml:lang="en" version="3.0" unique-identifier="bookid">
+              <metadata>        
+                  <meta name="calibre:series" content="Serie 1"/>
+                  <meta name="calibre:series_index" content="1"/>
+                  <meta name="calibre:series" content="Serie 2"/>
+                  <meta name="calibre:series_index" content="2"/>
+                  <meta name="calibre:series" content="Serie 3"/>
+                  <meta name="calibre:series_index" content="3"/>
+              </metadata>
+            </package>          
+        `
+        const parsedOpf = await parseOpfMetadataXML(opf)
+        expect(parsedOpf.series).to.deep.equal([
+            {"name": "Serie 1","sequence": "1"},
+            {"name": "Serie 2","sequence": "2"},
+            {"name": "Serie 3","sequence": "3"},
+        ])
+    })
+
+    it('test messed order of series content and index', async() => {
+        const opf = `
+            <?xml version='1.0' encoding='UTF-8'?>
+            <package xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:opf="http://www.idpf.org/2007/opf" xml:lang="en" version="3.0" unique-identifier="bookid">
+              <metadata>        
+                  <meta name="calibre:series" content="Serie 1"/>
+                  <meta name="calibre:series_index" content="1"/>
+                  <meta name="calibre:series_index" content="2"/>
+                  <meta name="calibre:series_index" content="3"/>
+                  <meta name="calibre:series" content="Serie 3"/>
+              </metadata>
+            </package>          
+        `
+        const parsedOpf = await parseOpfMetadataXML(opf)
+        expect(parsedOpf.series).to.deep.equal([
+            {"name": "Serie 1","sequence": "1"},
+            {"name": "Serie 3","sequence": null},
+        ])
+    })
+
+    it('test different values of series content and index', async() => {
+        const opf = `
+            <?xml version='1.0' encoding='UTF-8'?>
+            <package xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:opf="http://www.idpf.org/2007/opf" xml:lang="en" version="3.0" unique-identifier="bookid">
+              <metadata>        
+                  <meta name="calibre:series" content="Serie 1"/>
+                  <meta name="calibre:series_index"/>
+                  <meta name="calibre:series" content="Serie 2"/>
+                  <meta name="calibre:series_index" content="abc"/>
+                  <meta name="calibre:series" content="Serie 3"/>
+                  <meta name="calibre:series_index" content=""/>
+              </metadata>
+            </package>          
+        `
+        const parsedOpf = await parseOpfMetadataXML(opf)
+        // console.log(JSON.stringify(parsedOpf, null, 4))
+        expect(parsedOpf.series).to.deep.equal([
+            {"name": "Serie 1", "sequence": null},
+            {"name": "Serie 2", "sequence": "abc"},
+            {"name": "Serie 3", "sequence": null},
+        ])
+    })
+})

--- a/test/server/utils/parsers/parseOpfMetadata.test.js
+++ b/test/server/utils/parsers/parseOpfMetadata.test.js
@@ -2,27 +2,26 @@ const chai = require('chai')
 const expect = chai.expect
 const { parseOpfMetadataXML } = require('../../../../server/utils/parsers/parseOpfMetadata')
 
-
-describe('parseOpfMetadata - test series',  async () => {
-    it('test one serie', async() => {
+describe('parseOpfMetadata - test series', async () => {
+    it('test one series', async () => {
         const opf = `
             <?xml version='1.0' encoding='UTF-8'?>
             <package xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:opf="http://www.idpf.org/2007/opf" xml:lang="en" version="3.0" unique-identifier="bookid">
-              <metadata>        
+              <metadata>
                   <meta name="calibre:series" content="Serie"/>
                   <meta name="calibre:series_index" content="1"/>
               </metadata>
-            </package>          
+            </package>
         `
         const parsedOpf = await parseOpfMetadataXML(opf)
-        expect(parsedOpf.series).to.deep.equal([{"name": "Serie","sequence": "1"}])
+        expect(parsedOpf.series).to.deep.equal([{ "name": "Serie", "sequence": "1" }])
     })
 
-    it('test more then 1 serie - in correct order', async() => {
+    it('test more then 1 series - in correct order', async () => {
         const opf = `
             <?xml version='1.0' encoding='UTF-8'?>
             <package xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:opf="http://www.idpf.org/2007/opf" xml:lang="en" version="3.0" unique-identifier="bookid">
-              <metadata>        
+              <metadata>
                   <meta name="calibre:series" content="Serie 1"/>
                   <meta name="calibre:series_index" content="1"/>
                   <meta name="calibre:series" content="Serie 2"/>
@@ -30,41 +29,41 @@ describe('parseOpfMetadata - test series',  async () => {
                   <meta name="calibre:series" content="Serie 3"/>
                   <meta name="calibre:series_index" content="3"/>
               </metadata>
-            </package>          
+            </package>
         `
         const parsedOpf = await parseOpfMetadataXML(opf)
         expect(parsedOpf.series).to.deep.equal([
-            {"name": "Serie 1","sequence": "1"},
-            {"name": "Serie 2","sequence": "2"},
-            {"name": "Serie 3","sequence": "3"},
+            { "name": "Serie 1", "sequence": "1" },
+            { "name": "Serie 2", "sequence": "2" },
+            { "name": "Serie 3", "sequence": "3" },
         ])
     })
 
-    it('test messed order of series content and index', async() => {
+    it('test messed order of series content and index', async () => {
         const opf = `
             <?xml version='1.0' encoding='UTF-8'?>
             <package xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:opf="http://www.idpf.org/2007/opf" xml:lang="en" version="3.0" unique-identifier="bookid">
-              <metadata>        
+              <metadata>
                   <meta name="calibre:series" content="Serie 1"/>
                   <meta name="calibre:series_index" content="1"/>
                   <meta name="calibre:series_index" content="2"/>
                   <meta name="calibre:series_index" content="3"/>
                   <meta name="calibre:series" content="Serie 3"/>
               </metadata>
-            </package>          
+            </package>
         `
         const parsedOpf = await parseOpfMetadataXML(opf)
         expect(parsedOpf.series).to.deep.equal([
-            {"name": "Serie 1","sequence": "1"},
-            {"name": "Serie 3","sequence": null},
+            { "name": "Serie 1", "sequence": "1" },
+            { "name": "Serie 3", "sequence": null },
         ])
     })
 
-    it('test different values of series content and index', async() => {
+    it('test different values of series content and index', async () => {
         const opf = `
             <?xml version='1.0' encoding='UTF-8'?>
             <package xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:opf="http://www.idpf.org/2007/opf" xml:lang="en" version="3.0" unique-identifier="bookid">
-              <metadata>        
+              <metadata>
                   <meta name="calibre:series" content="Serie 1"/>
                   <meta name="calibre:series_index"/>
                   <meta name="calibre:series" content="Serie 2"/>
@@ -72,14 +71,43 @@ describe('parseOpfMetadata - test series',  async () => {
                   <meta name="calibre:series" content="Serie 3"/>
                   <meta name="calibre:series_index" content=""/>
               </metadata>
-            </package>          
+            </package>
         `
         const parsedOpf = await parseOpfMetadataXML(opf)
-        // console.log(JSON.stringify(parsedOpf, null, 4))
         expect(parsedOpf.series).to.deep.equal([
-            {"name": "Serie 1", "sequence": null},
-            {"name": "Serie 2", "sequence": "abc"},
-            {"name": "Serie 3", "sequence": null},
+            { "name": "Serie 1", "sequence": null },
+            { "name": "Serie 2", "sequence": "abc" },
+            { "name": "Serie 3", "sequence": null },
+        ])
+    })
+
+    it('test empty series content', async () => {
+        const opf = `
+            <?xml version='1.0' encoding='UTF-8'?>
+            <package xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:opf="http://www.idpf.org/2007/opf" xml:lang="en" version="3.0" unique-identifier="bookid">
+              <metadata>
+                  <meta name="calibre:series" content=""/>
+                  <meta name="calibre:series_index" content=""/>
+              </metadata>
+            </package>
+        `
+        const parsedOpf = await parseOpfMetadataXML(opf)
+        expect(parsedOpf.series).to.deep.equal([])
+    })
+
+    it('test series and index using an xml namespace', async () => {
+        const opf = `
+            <?xml version='1.0' encoding='UTF-8'?>
+            <ns0:package xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:opf="http://www.idpf.org/2007/opf" xml:lang="en" version="3.0" unique-identifier="bookid">
+              <ns0:metadata>
+                  <ns0:meta name="calibre:series" content="Serie 1"/>
+                  <ns0:meta name="calibre:series_index" content=""/>
+              </ns0:metadata>
+            </ns0:package>
+        `
+        const parsedOpf = await parseOpfMetadataXML(opf)
+        expect(parsedOpf.series).to.deep.equal([
+            { "name": "Serie 1", "sequence": null }
         ])
     })
 })


### PR DESCRIPTION
I see that some people like me using this software are missing multiple series in OPF file.

```xml
<meta name="calibre:series" content="Serie 1"/>
<meta name="calibre:series_index" content="1"/>
<meta name="calibre:series" content="Serie 2"/>
<meta name="calibre:series_index" content="2"/>
```

so here it is, along with unit tests.