### PR TITLE
Add a SIGINT handler for proper server shutdown

### DIFF
--- a/server/Server.js
+++ b/server/Server.js
@@ -276,6 +276,19 @@ class Server {
     })
     app.get('/healthcheck', (req, res) => res.sendStatus(200))
 
+    let sigintAlreadyReceived = false
+    process.on('SIGINT', async () => {
+      if (!sigintAlreadyReceived) {
+        sigintAlreadyReceived = true
+        Logger.info('SIGINT (Ctrl+C) received. Shutting down...')
+        await this.stop()
+        Logger.info('Server stopped. Exiting.')
+      } else {
+        Logger.info('SIGINT (Ctrl+C) received again. Exiting immediately.')        
+      }
+      process.exit(0)
+    })
+
     this.server.listen(this.Port, this.Host, () => {
       if (this.Host) Logger.info(`Listening on http://${this.Host}:${this.Port}`)
       else Logger.info(`Listening on port :${this.Port}`)
@@ -383,6 +396,7 @@ class Server {
   }
 
   async stop() {
+    Logger.info('=== Stopping Server ===')
     await this.watcher.close()
     Logger.info('Watcher Closed')
 


### PR DESCRIPTION
I've noticed that once in a while (can't reproduce consistently), when hitting Ctrl+C to close ABS, the port is not properly released, and the next time I start the server I get EADDRINUSE error. I'm not sure what's the reason for that, but I thought adding a SIGINT handler that calls the server's stop method would be good practice anyway, and It would also provide a way for proper stopping in the upcoming Windows tray app.

I implemented this like many standard SIGINT handlers - the first SIGINT waits for server stop, the second exits immediately (the current behavior).