### PR TITLE
Add SocketAuthority.close()

### DIFF
--- a/server/Server.js
+++ b/server/Server.js
@@ -284,7 +284,7 @@ class Server {
         await this.stop()
         Logger.info('Server stopped. Exiting.')
       } else {
-        Logger.info('SIGINT (Ctrl+C) received again. Exiting immediately.')        
+        Logger.info('SIGINT (Ctrl+C) received again. Exiting immediately.')
       }
       process.exit(0)
     })
@@ -395,6 +395,10 @@ class Server {
     res.sendStatus(200)
   }
 
+  /**
+   * Gracefully stop server
+   * Stops watcher and socket server
+   */
   async stop() {
     Logger.info('=== Stopping Server ===')
     await this.watcher.close()

--- a/server/Server.js
+++ b/server/Server.js
@@ -401,7 +401,7 @@ class Server {
     Logger.info('Watcher Closed')
 
     return new Promise((resolve) => {
-      this.server.close((err) => {
+      SocketAuthority.close((err) => {
         if (err) {
           Logger.error('Failed to close server', err)
         } else {

--- a/server/SocketAuthority.js
+++ b/server/SocketAuthority.js
@@ -73,6 +73,15 @@ class SocketAuthority {
     }
   }
 
+  close(callback) {
+    Logger.info('[SocketAuthority] Shutting down')
+    // This will close all open socket connections, and also close the underlying http server
+    if (this.io) 
+      this.io.close(callback)
+    else
+      callback()
+  }
+
   initialize(Server) {
     this.Server = Server
 

--- a/server/SocketAuthority.js
+++ b/server/SocketAuthority.js
@@ -73,10 +73,15 @@ class SocketAuthority {
     }
   }
 
+  /**
+   * Closes the Socket.IO server and disconnect all clients
+   * 
+   * @param {Function} callback 
+   */
   close(callback) {
     Logger.info('[SocketAuthority] Shutting down')
     // This will close all open socket connections, and also close the underlying http server
-    if (this.io) 
+    if (this.io)
       this.io.close(callback)
     else
       callback()


### PR DESCRIPTION
This is a small fix for my previous PR #2445.

If there are connected SocketIO sockets, then calling server.close() on SIGINT will hang and not resolve.

Instead, we need to call SocketAuthority.io.close(), which will disconnect all connected sockets, and also close the underlying http server (see documentation [here](https://socket.io/docs/v4/server-api/#serverclosecallback)). Sorry for missing this initially.