### PR TITLE
Add try/catch to fileUtils.getFileMtimeMs

### DIFF
--- a/server/utils/fileUtils.js
+++ b/server/utils/fileUtils.js
@@ -81,7 +81,12 @@ module.exports.getFileSize = async (path) => {
  * @returns {Promise<number>} epoch timestamp
  */
 module.exports.getFileMTimeMs = async (path) => {
-  return (await getFileStat(path))?.mtimeMs || 0
+  try {
+    return (await getFileStat(path))?.mtimeMs || 0
+  } catch (err) {
+    Logger.error(`[fileUtils] Failed to getFileMtimeMs`, err)
+    return 0
+  }
 }
 
 /**


### PR DESCRIPTION
Added a try/catch to the fileUtils.js getFileMtimeMs function.  This addresses the exception thrown when an ephemeral file is added to a library and flagged by Watcher to be scanned.   I tested this against 2.6.0 and 2.7.0 and it resolves my situation mentioned in https://github.com/advplyr/audiobookshelf/issues/2332 and it should resolve the reported issue completely.