### PR TITLE
Add tini as PID 1 handler in container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,8 @@ RUN apk update && \
     ffmpeg \
     make \
     python3 \
-    g++
+    g++ \
+    tini
 
 COPY --from=tone /usr/local/bin/tone /usr/local/bin/
 COPY --from=build /client/dist /client/dist
@@ -31,4 +32,5 @@ RUN apk del make python3 g++
 
 EXPOSE 80
 
+ENTRYPOINT ["tini", "--"]
 CMD ["node", "index.js"]


### PR DESCRIPTION
This PR adds `tini` to the container image and uses it as PID 1 when starting the container.  This ensures that proper PID 1 signal-handling is implemented and passed to the underlying node.js process, thereby ensuring that the ABS process has a chance to receive and handle signals other than `SIGKILL`, such as the important `SIGINT`.

This is somewhat related to #2445 . Without this, the signal handled by 2445 won't be received when running in a container.

Some background:

In linux, PID 1 has special duties involving signal handling that are different than other processes.  Node doesn't properly handle these signals, which can lead to a number of problems ranging from annoying to disruptive.  PID 1 also has reaping duties that can lead to resource exhaustion if not properly handled.

For example, the container ignores `SIGINT` (Ctrl+C) as well as `docker stop`, which can be annoying in development as you have to kill or wait for the timeout to be reached.  In a production environment (such as Kubernetes) this can lead to signal escalation and unnecessarily adds delays to deployments and restarts as K8s has to wait for the timeout to be reached before sending `SIGKILL`.

At best this is annoying and unnecessarily adds
delays.  At worst this can lead to file/data corruption as the process doesn't get a chance to clean anything up when it is sent `SIGKILL`. Without a proper PID 1 to forward signals, only SIGKILL can be used to terminate the running process.