### PR TITLE
Allow user to override log level

### DIFF
--- a/server/Logger.js
+++ b/server/Logger.js
@@ -5,7 +5,16 @@ class Logger {
   constructor() {
     this.isDev = process.env.NODE_ENV !== 'production'
     this.logLevel = !this.isDev ? LogLevel.INFO : LogLevel.TRACE
-    this.hideDevLogs = process.env.HIDE_DEV_LOGS === undefined ? !this.isDev : process.env.HIDE_DEV_LOGS === '1'
+
+    // Allow the user to override the log level if desired
+    if (process.env.LOG_LEVEL) {
+      this.logLevel = parseInt(LogLevel.strToLevel(process.env.LOG_LEVEL))
+    } else {
+      this.hideDevLogs = process.env.HIDE_DEV_LOGS === undefined
+        ? !this.isDev
+        : process.env.HIDE_DEV_LOGS === '1'
+    }
+
     this.socketListeners = []
 
     this.logManager = null

--- a/server/utils/constants.js
+++ b/server/utils/constants.js
@@ -23,7 +23,28 @@ module.exports.LogLevel = {
   WARN: 3,
   ERROR: 4,
   FATAL: 5,
-  NOTE: 6
+  NOTE: 6,
+
+  strToLevel(str) {
+    switch (str.toUpperCase()) {
+      case 'TRACE':
+        return this.TRACE
+      case 'DEBUG':
+        return this.DEBUG
+      case 'INFO':
+        return this.INFO
+      case 'WARN':
+        return this.WARN
+      case 'ERROR':
+        return this.ERROR
+      case 'FATAL':
+        return this.FATAL
+      case 'NOTE':
+        return this.NOTE
+      default:
+        return this.INFO
+    }
+  }
 }
 
 module.exports.PlayMethod = {


### PR DESCRIPTION
This PR adds an environment variable `LOG_LEVEL` that can be used to control the application log level.  For example, this would allow you to view dev logs while in production, should you so choose.

If the env var is not set, behavior should not change from the current behavior.

Env var can be set with the log level string (case insensitive).  For example:  `LOG_LEVEL=debug`