### PR TITLE
Exclude @eaDir and #snapshot from recursive library searching

### DIFF
--- a/server/utils/fileUtils.js
+++ b/server/utils/fileUtils.js
@@ -167,7 +167,8 @@ async function recurseFiles(path, relPathToReplace = null) {
     extensions: true,
     deep: true,
     realPath: true,
-    normalizePath: true
+    normalizePath: true,
+    exclude: ['@eaDir', '#snapshot']
   }
   let list = await rra.list(path, options)
   if (list.error) {


### PR DESCRIPTION
This partially solve issue #1641. The `@eaDir` is created by Synology DSM to store additional files, e.g. metadata. Synology DSM mount BTRFS snapshots into `#snapshot` folder which is subdirectory of shared folder.   