### PR TITLE
Return png from AudiobookCovers.com

### DIFF
--- a/server/providers/AudiobookCovers.js
+++ b/server/providers/AudiobookCovers.js
@@ -14,7 +14,7 @@ class AudiobookCovers {
       Logger.error('[AudiobookCovers] Cover search error', error)
       return []
     })
-    return items.map(item => ({ cover: item.filename }))
+    return items.map(item => ({ cover: item.versions.png.original }))
   }
 }
 


### PR DESCRIPTION
Changes AudiobookCovers.com provider to return the full size png file from the server. The original file url has the incorrect content-type header set, which caused issues downloading new cover images.