### PR TITLE
Add highlight annotations to ebooks

### DIFF
--- a/client/components/readers/Sidebar.vue
+++ b/client/components/readers/Sidebar.vue
@@ -1,0 +1,96 @@
+<template>
+  <div>
+    <div v-if="sidebarOpen" class="w-full h-full overflow-y-scroll absolute inset-0 bg-black/20 z-20" @click.stop.prevent="toggleSidebar"></div>
+    <div class="w-96 h-full max-h-full absolute top-0 left-0 shadow-xl transition-transform z-50 group-data-[theme=dark]:bg-primary group-data-[theme=dark]:text-white group-data-[theme=light]:bg-white group-data-[theme=light]:text-black" :class="sidebarOpen ? 'translate-x-0' : '-translate-x-96'" @click.stop.prevent>
+      <div class="flex flex-col p-4 h-full">
+        <div class="flex items-center mb-2">
+          <button @click.stop.prevent="toggleSidebar" type="button" aria-label="Close table of contents" class="inline-flex opacity-80 hover:opacity-100">
+            <span class="material-icons text-2xl">arrow_back</span>
+          </button>
+
+          <p class="text-lg font-semibold ml-2">{{ sidebarTitle }}</p>
+        </div>
+
+        <template v-if="!bookmarksOpen">
+          <form @submit.prevent="searchBook">
+            <ui-text-input clearable ref="input" @clear="searchBook" v-model="searchQuery" :placeholder="$strings.PlaceholderSearch" class="h-8 w-full text-sm flex mb-2" />
+          </form>
+        </template>
+        <div class="overflow-y-auto">
+          <div v-if="isSearching && !searchResults.length" class="w-full h-40 justify-center">
+            <p class="text-center text-xl py-4">{{ $strings.MessageNoResults }}</p>
+          </div>
+
+          <div v-if="bookmarksOpen && !bookmarks.length" class="w-full h-40 justify-center">
+            <p class="text-center text-xl py-4">{{ $strings.MessageNoBookmarks }}</p>
+          </div>
+          <div v-else-if="!chapters.length" class="w-full h-40 justify-center">
+            <p class="text-center text-xl py-4">{{ $strings.MessageNoChapters }}</p>
+          </div>
+
+          <ul>
+            <li v-for="chapter in contents" :key="chapter.id" class="py-1">
+              <a :href="chapter.href" class="opacity-80 hover:opacity-100" @click.prevent="goToChapter(chapter.href)">{{ chapter.title }}</a>
+              <div v-for="searchResults in chapter.searchResults" :key="searchResults.cfi" class="text-sm py-1 pl-4">
+                <a :href="searchResults.cfi" class="opacity-50 hover:opacity-100" @click.prevent="goToChapter(searchResults.cfi)">{{ searchResults.excerpt }}</a>
+              </div>
+
+              <ul v-if="chapter.subitems.length">
+                <li v-for="subchapter in chapter.subitems" :key="subchapter.id" class="py-1 pl-4">
+                  <a :href="subchapter.href" class="opacity-80 hover:opacity-100" @click.prevent="goToChapter(subchapter.href)">{{ subchapter.title }}</a>
+                  <div v-for="subChapterSearchResults in subchapter.searchResults" :key="subChapterSearchResults.cfi" class="text-sm py-1 pl-4">
+                    <a :href="subChapterSearchResults.cfi" class="opacity-50 hover:opacity-100" @click.prevent="goToChapter(subChapterSearchResults.cfi)">{{ subChapterSearchResults.excerpt }}</a>
+                  </div>
+                </li>
+              </ul>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  data() {
+    return {
+      searchQuery: '',
+      isSearching: false,
+      searchResults: []
+    }
+  },
+  props: {
+    sidebarOpen: false,
+    bookmarksOpen: false,
+    chapters: [],
+    bookmarks: []
+  },
+  computed: {
+    sidebarTitle() {
+      return this.bookmarksOpen ? this.$strings.LabelYourBookmarks : this.$strings.HeaderTableOfContents
+    },
+    contents() {
+      return !this.bookmarksOpen ? (this.isSearching ? this.searchResults : this.chapters) : this.bookmarks
+    }
+  },
+
+  methods: {
+    toggleSidebar() {
+      this.$emit('toggle-sidebar')
+    },
+    goToChapter(target) {
+      this.$emit('goToChapter', target)
+    },
+    async searchBook() {
+      if (this.searchQuery.length > 1) {
+        this.searchResults = await this.$parent.$refs.readerComponent.searchBook(this.searchQuery)
+        this.isSearching = true
+      } else {
+        this.isSearching = false
+        this.searchResults = []
+      }
+    }
+  }
+}
+</script>

--- a/client/store/user.js
+++ b/client/store/user.js
@@ -28,9 +28,10 @@ export const getters = {
       return li.libraryItemId == libraryItemId
     })
   },
-  getUserBookmarksForItem: (state) => (libraryItemId) => {
+  getUserBookmarksForItem: (state) => (libraryItemId, bookmarkType) => {
     if (!state.user.bookmarks) return []
-    return state.user.bookmarks.filter(bm => bm.libraryItemId === libraryItemId)
+    bookmarkType = bookmarkType || 'audio'
+    return state.user.bookmarks.filter(bm => bm.libraryItemId === libraryItemId && bm.type === bookmarkType)
   },
   getUserSetting: (state) => (key) => {
     return state.settings?.[key] || null

--- a/server/objects/user/AudioBookmark.js
+++ b/server/objects/user/AudioBookmark.js
@@ -1,6 +1,7 @@
 class AudioBookmark {
   constructor(bookmark) {
     this.libraryItemId = null
+    this.type = null
     this.title = null
     this.time = null
     this.createdAt = null
@@ -13,6 +14,7 @@ class AudioBookmark {
   toJSON() {
     return {
       libraryItemId: this.libraryItemId,
+      type: this.type || 'audio',
       title: this.title || '',
       time: this.time,
       createdAt: this.createdAt
@@ -21,13 +23,15 @@ class AudioBookmark {
 
   construct(bookmark) {
     this.libraryItemId = bookmark.libraryItemId
+    this.type = bookmark.type || 'audio'
     this.title = bookmark.title || ''
     this.time = bookmark.time || 0
     this.createdAt = bookmark.createdAt
   }
 
-  setData(libraryItemId, time, title) {
+  setData(libraryItemId, type, time, title) {
     this.libraryItemId = libraryItemId
+    this.type = type
     this.title = title
     this.time = time
     this.createdAt = Date.now()

--- a/server/objects/user/User.js
+++ b/server/objects/user/User.js
@@ -350,25 +350,25 @@ class User {
     return this.checkCanAccessLibraryItemWithTags(tags)
   }
 
-  findBookmark(libraryItemId, time) {
-    return this.bookmarks.find(bm => bm.libraryItemId === libraryItemId && bm.time == time)
+  findBookmark(libraryItemId, type, time) {
+    return this.bookmarks.find(bm => bm.libraryItemId === libraryItemId && bm.time == time && bm.type === type)
   }
 
-  createBookmark(libraryItemId, time, title) {
-    var existingBookmark = this.findBookmark(libraryItemId, time)
+  createBookmark(libraryItemId, type, time, title) {
+    var existingBookmark = this.findBookmark(libraryItemId, type, time)
     if (existingBookmark) {
       Logger.warn('[User] Create Bookmark already exists for this time')
       existingBookmark.title = title
       return existingBookmark
     }
     var newBookmark = new AudioBookmark()
-    newBookmark.setData(libraryItemId, time, title)
+    newBookmark.setData(libraryItemId, type, time, title)
     this.bookmarks.push(newBookmark)
     return newBookmark
   }
 
-  updateBookmark(libraryItemId, time, title) {
-    var bookmark = this.findBookmark(libraryItemId, time)
+  updateBookmark(libraryItemId, type, time, title) {
+    var bookmark = this.findBookmark(libraryItemId, type, time)
     if (!bookmark) {
       Logger.error(`[User] updateBookmark not found`)
       return null
@@ -377,8 +377,8 @@ class User {
     return bookmark
   }
 
-  removeBookmark(libraryItemId, time) {
-    this.bookmarks = this.bookmarks.filter(bm => (bm.libraryItemId !== libraryItemId || bm.time !== time))
+  removeBookmark(libraryItemId, type, time) {
+    this.bookmarks = this.bookmarks.filter(bm => (bm.libraryItemId !== libraryItemId || bm.time !== time || bm.type !== type))
   }
 
   checkShouldHideSeriesFromContinueListening(seriesId) {


### PR DESCRIPTION
This pull request adds the ability to highlight and save text in ebooks. Saved bookmarks reuse the existing "search book" ui.

![image](https://github.com/advplyr/audiobookshelf/assets/44880075/2be5ebe1-6c48-4af4-ab9a-5402b2bd8813)

To accomplish this, I used the existing bookmark schema, with the `time` property storing the CFI of the highlighted text.
This posed a dilemma if a library item has both an audiobook and an ebook because they share the same id, so I extended the bookmark schema and api with a `type` property, which defaults to `audio`. This could cause problems if the ebook file changes after bookmarks are added, but that could probably be solved with some type of fingerprinting.


resolves #1558 
resolves #1709

Should be compatible with #2584, but if not, I'll resolve any conflicts.