### PR TITLE
make server url configurable in dev mode

### DIFF
--- a/client/components/covers/AuthorImage.vue
+++ b/client/components/covers/AuthorImage.vue
@@ -56,10 +56,6 @@ export default {
     },
     imgSrc() {
       if (!this.imagePath) return null
-      if (process.env.NODE_ENV !== 'production') {
-        // Testing
-        return `http://localhost:3333${this.$config.routerBasePath}/api/authors/${this.authorId}/image?token=${this.userToken}&ts=${this.updatedAt}`
-      }
       return `/api/authors/${this.authorId}/image?token=${this.userToken}&ts=${this.updatedAt}`
     }
   },

--- a/client/components/modals/rssfeed/OpenCloseModal.vue
+++ b/client/components/modals/rssfeed/OpenCloseModal.vue
@@ -139,7 +139,6 @@ export default {
         slug: this.newFeedSlug,
         metadataDetails: this.metadataDetails
       }
-      if (this.$isDev) payload.serverAddress = `http://localhost:3333${this.$config.routerBasePath}`
 
       console.log('Payload', payload)
       this.$axios

--- a/client/nuxt.config.js
+++ b/client/nuxt.config.js
@@ -6,7 +6,7 @@ module.exports = {
   target: 'static',
   dev: process.env.NODE_ENV !== 'production',
   env: {
-    serverUrl: process.env.NODE_ENV === 'production' ? process.env.ROUTER_BASE_PATH || '' : 'http://localhost:3333',
+    serverUrl: process.env.NODE_ENV === 'production' ? process.env.ROUTER_BASE_PATH || '' : process.env.DEV_SERVER_URL || 'http://localhost:3333',
     chromecastReceiver: 'FD1F76C5'
   },
   telemetry: false,
@@ -70,14 +70,14 @@ module.exports = {
   ],
 
   proxy: {
-    '/api/': { target: process.env.NODE_ENV !== 'production' ? 'http://localhost:3333' : '/' },
-    '/dev/': { target: 'http://localhost:3333', pathRewrite: { '^/dev/': '' } }
+    '/api/': { target: process.env.NODE_ENV !== 'production' ? process.env.DEV_SERVER_URL || 'http://localhost:3333' : '/' },
+    '/dev/': { target: process.env.DEV_SERVER_URL || 'http://localhost:3333', pathRewrite: { '^/dev/': '' } }
   },
 
   io: {
     sockets: [{
       name: 'dev',
-      url: 'http://localhost:3333'
+      url: process.env.DEV_SERVER_URL || 'http://localhost:3333'
     },
     {
       name: 'prod'

--- a/client/pages/audiobook/_id/chapters.vue
+++ b/client/pages/audiobook/_id/chapters.vue
@@ -414,9 +414,6 @@ export default {
 
       const audioEl = this.audioEl || document.createElement('audio')
       var src = audioTrack.contentUrl + `?token=${this.userToken}`
-      if (this.$isDev) {
-        src = `http://localhost:3333${this.$config.routerBasePath}${src}`
-      }
 
       audioEl.src = src
       audioEl.id = 'chapter-audio'

--- a/client/store/globals.js
+++ b/client/store/globals.js
@@ -95,19 +95,12 @@ export const getters = {
     const lastUpdate = libraryItem.updatedAt || Date.now()
     const libraryItemId = libraryItem.libraryItemId || libraryItem.id // Workaround for /users/:id page showing media progress covers
 
-    if (process.env.NODE_ENV !== 'production') { // Testing
-      return `http://localhost:3333${rootState.routerBasePath}/api/items/${libraryItemId}/cover?token=${userToken}&ts=${lastUpdate}${raw ? '&raw=1' : ''}`
-    }
-
     return `${rootState.routerBasePath}/api/items/${libraryItemId}/cover?token=${userToken}&ts=${lastUpdate}${raw ? '&raw=1' : ''}`
   },
   getLibraryItemCoverSrcById: (state, getters, rootState, rootGetters) => (libraryItemId, timestamp = null, raw = false) => {
     const placeholder = `${rootState.routerBasePath}/book_placeholder.jpg`
     if (!libraryItemId) return placeholder
     const userToken = rootGetters['user/getToken']
-    if (process.env.NODE_ENV !== 'production') { // Testing
-      return `http://localhost:3333${rootState.routerBasePath}/api/items/${libraryItemId}/cover?token=${userToken}${raw ? '&raw=1' : ''}${timestamp ? `&ts=${timestamp}` : ''}`
-    }
     return `${rootState.routerBasePath}/api/items/${libraryItemId}/cover?token=${userToken}${raw ? '&raw=1' : ''}${timestamp ? `&ts=${timestamp}` : ''}`
   },
   getIsBatchSelectingMediaItems: (state) => {


### PR DESCRIPTION
Currently when the server is running in dev mode it always assumes it's running on localhost.
With this changes it becomes configurable via the DEV_SERVER_URL environment variable.

Also some - probably no longer neeed - hardcoded localhost URLs in some javascript files have been removed.