### PR TITLE
feat(i18n): made the empty library page translatable on home page

### DIFF
--- a/client/components/app/BookShelfCategorized.vue
+++ b/client/components/app/BookShelfCategorized.vue
@@ -4,14 +4,14 @@
     <widgets-cover-size-widget class="fixed right-4 z-50" :style="{ bottom: streamLibraryItem ? '181px' : '16px' }" />
 
     <div v-if="loaded && !shelves.length && !search" class="w-full flex flex-col items-center justify-center py-12">
-      <p class="text-center text-2xl mb-4 py-4">{{ libraryName }} Library is empty!</p>
+      <p class="text-center text-2xl mb-4 py-4">{{ $getString('MessageXLibraryIsEmpty', [libraryName]) }}</p>
       <div v-if="userIsAdminOrUp" class="flex">
-        <ui-btn to="/config" color="primary" class="w-52 mr-2">Configure Scanner</ui-btn>
-        <ui-btn color="success" class="w-52" @click="scan">Scan Library</ui-btn>
+        <ui-btn to="/config" color="primary" class="w-52 mr-2">{{ $strings.ButtonConfigureScanner }}</ui-btn>
+        <ui-btn color="success" class="w-52" @click="scan">{{ $strings.ButtonScanLibrary }}</ui-btn>
       </div>
     </div>
     <div v-else-if="loaded && !shelves.length && search" class="w-full h-40 flex items-center justify-center">
-      <p class="text-center text-xl py-4">No results for query</p>
+      <p class="text-center text-xl py-4">{{ $strings.MessageNoQueryResults }}</p>
     </div>
     <!-- Alternate plain view -->
     <div v-else-if="isAlternativeBookshelfView" class="w-full mb-24">
@@ -276,11 +276,11 @@ export default {
       this.$store
         .dispatch('libraries/requestLibraryScan', { libraryId: this.$store.state.libraries.currentLibraryId })
         .then(() => {
-          this.$toast.success('Library scan started')
+          this.$toast.success(this.$strings.ToastLibraryScanStarted)
         })
         .catch((error) => {
           console.error('Failed to start scan', error)
-          this.$toast.error('Failed to start scan')
+          this.$toast.error(this.$strings.ToastLibraryScanFailedToStart)
         })
     },
     userUpdated(user) {

--- a/client/strings/de.json
+++ b/client/strings/de.json
@@ -653,6 +653,7 @@
   "MessageNoMediaProgress": "Kein Medienfortschritt",
   "MessageNoNotifications": "Keine Benachrichtigungen",
   "MessageNoPodcastsFound": "Keine Podcasts gefunden",
+  "MessageNoQueryResults": "Keine Suchergebnisse für die Anfrage",
   "MessageNoResults": "Keine Ergebnisse",
   "MessageNoSearchResultsFor": "Keine Suchergebnisse für \"{0}\"",
   "MessageNoSeries": "Keine Serien",

--- a/client/strings/en-us.json
+++ b/client/strings/en-us.json
@@ -653,6 +653,7 @@
   "MessageNoMediaProgress": "No Media Progress",
   "MessageNoNotifications": "No Notifications",
   "MessageNoPodcastsFound": "No podcasts found",
+  "MessageNoQueryResults": "No results for query",
   "MessageNoResults": "No Results",
   "MessageNoSearchResultsFor": "No search results for \"{0}\"",
   "MessageNoSeries": "No Series",


### PR DESCRIPTION
This PR makes the empty library message and buttons translatable on the home and library page