### PR TITLE
fix: http_proxy is not supported.

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,6 +22,7 @@ const UID = process.env.AUDIOBOOKSHELF_UID
 const GID = process.env.AUDIOBOOKSHELF_GID
 const SOURCE = process.env.SOURCE || 'docker'
 const ROUTER_BASE_PATH = process.env.ROUTER_BASE_PATH || ''
+const DISABLE_SSRF = process.env.DISABLE_SSRF || false
 
 console.log('Config', CONFIG_PATH, METADATA_PATH)
 

--- a/index.js
+++ b/index.js
@@ -22,7 +22,6 @@ const UID = process.env.AUDIOBOOKSHELF_UID
 const GID = process.env.AUDIOBOOKSHELF_GID
 const SOURCE = process.env.SOURCE || 'docker'
 const ROUTER_BASE_PATH = process.env.ROUTER_BASE_PATH || ''
-const DISABLE_SSRF = process.env.DISABLE_SSRF || false
 
 console.log('Config', CONFIG_PATH, METADATA_PATH)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.8.0",
       "license": "GPL-3.0",
       "dependencies": {
-        "axios": "^0.27.2",
+        "axios": "^1.6.7",
         "cookie-parser": "^1.4.6",
         "express": "^4.17.1",
         "express-session": "^1.17.3",
@@ -1134,12 +1134,13 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/axios": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.7.tgz",
+      "integrity": "sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==",
       "dependencies": {
-        "follow-redirects": "^1.14.9",
-        "form-data": "^4.0.0"
+        "follow-redirects": "^1.15.4",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/balanced-match": {
@@ -4275,6 +4276,11 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/pstree.remy": {
       "version": "1.1.8",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "author": "advplyr",
   "license": "GPL-3.0",
   "dependencies": {
-    "axios": "^0.27.2",
+    "axios": "^1.6.7",
     "cookie-parser": "^1.4.6",
     "express": "^4.17.1",
     "express-session": "^1.17.3",

--- a/server/Server.js
+++ b/server/Server.js
@@ -52,6 +52,7 @@ class Server {
     global.MetadataPath = fileUtils.filePathToPOSIX(Path.normalize(METADATA_PATH))
     global.RouterBasePath = ROUTER_BASE_PATH
     global.XAccel = process.env.USE_X_ACCEL
+    global.DisableSSRF = process.env.DISABLE_SSRF
 
     if (!fs.pathExistsSync(global.ConfigPath)) {
       fs.mkdirSync(global.ConfigPath)

--- a/server/utils/fileUtils.js
+++ b/server/utils/fileUtils.js
@@ -251,8 +251,8 @@ module.exports.downloadFile = (url, filepath, contentTypeFilter = null) => {
       method: 'GET',
       responseType: 'stream',
       timeout: 30000,
-      httpAgent: ssrfFilter(url),
-      httpsAgent: ssrfFilter(url)
+      httpAgent: !global.DisableSSRF ? ssrfFilter(url) : undefined,
+      httpsAgent: !global.DisableSSRF ? ssrfFilter(url) : undefined
     }).then((response) => {
       // Validate content type
       if (contentTypeFilter && !contentTypeFilter?.(response.headers?.['content-type'])) {

--- a/server/utils/podcastUtils.js
+++ b/server/utils/podcastUtils.js
@@ -234,8 +234,8 @@ module.exports.getPodcastFeed = (feedUrl, excludeEpisodeMetadata = false) => {
     timeout: 12000,
     responseType: 'arraybuffer',
     headers: { Accept: 'application/rss+xml, application/xhtml+xml, application/xml, */*;q=0.8' },
-    httpAgent: ssrfFilter(feedUrl),
-    httpsAgent: ssrfFilter(feedUrl)
+    httpAgent: !global.DisableSSRF ? ssrfFilter(feedUrl) : undefined,
+    httpsAgent: !global.DisableSSRF ? ssrfFilter(feedUrl) : undefined
   }).then(async (data) => {
 
     // Adding support for ios-8859-1 encoded RSS feeds.


### PR DESCRIPTION
fixes #1313

**Problem:**
As stated in #1313, the http_proxy doesn't work for abs. Reasons are:
- ssrf-req-filter issue: <a href="https://github.com/y-mehta/ssrf-req-filter/issues/42">[HTTP Proxy is not well supported in HTTPS connection. · Issue #42 · y-mehta/ssrf-req-filter](https://github.com/y-mehta/ssrf-req-filter/issues/42)</a>
- axios issue: fixed 1.x version. version bisect says the fix is between 0.27.2 and 1.0.0. Changes are too much in middle.

**Changes:**
1. SSRF is necessary for public-exposing apps - while unnecessary for internal use. Make it can be disabled by env var DISABLE_SSRF and we can bring it back to enable for all when the issue aforementioned is fixed.
2. Upgrade `axios` to the latest version.

**Tests:**
Manually tested mainline scenarios and no issue is found.