### PR TITLE
Fix file names with URL control characters

### DIFF
--- a/server/utils/fileUtils.js
+++ b/server/utils/fileUtils.js
@@ -357,7 +357,10 @@ module.exports.removeFile = (path) => {
 }
 
 module.exports.encodeUriPath = (path) => {
-  const uri = new URL(path, "file://")
+  const uri = new URL('/', "file://")
+  // we assign the path here to assure that URL control characters like # are
+  // actually interpreted as part of the URL path
+  uri.pathname = path
   return uri.pathname
 }
 


### PR DESCRIPTION
This patch ensures that files names like `series #3 xy.jpg` are actually handled correctly instead of the part after `#` being interpreted as fragment and being discarded.

I noticed that in a few rare cases the App wouldn't properly display cover images. It turns out that due the file names containing a `#`, the file path got corrupted, causing Audiobookshelf to return a 403.

---

To reproduce the issue (there are likely more ways):

1. Enable XAccel, e.g. by putting in the `docker-compose.yml` (even if you don't configure Nginx for this, you should still be able to confirm the issue):
    ```yml
      audiobookshelf:
        image: ghcr.io/advplyr/audiobookshelf:2.8.0
        environment:
          - USE_X_ACCEL=/protected
    ```
2. Upload a book with a path that includes a `#` like `/data/audiobooks/Author/Series #1 - xy/cover.jpg`
3. Go into the web interface and try downloading the file. This will not work, but copy the URL. It should be something like:
    https://audiobook.example.com/api/items/87ee14eb-f2fc-412f-1213-69bf27ff3947/file/3954651/download?token=…`
4. On the host system, communicate with the container directly, sending an HTTP request for the file. If you don't have a reverse proxy, you can just use the original URL:
    ```
    % curl -i 'http://127.0.0.1:8081/api/items/87ee14eb-f2fc-412f-1213-69bf27ff3947/file/3954651/download?token=…'
    HTTP/1.1 204 No Content
    X-Accel-Redirect: /protected/audiobooks/Author/Series%20
    ```
    The redirect URL will end at the `#` character in the path. This will result in the file not being found.

The patch will fix the issue and the correct path will be returned.