### PR TITLE
Fix log source in log file

### DIFF
--- a/server/Logger.js
+++ b/server/Logger.js
@@ -70,14 +70,15 @@ class Logger {
   }
 
   /**
-   * 
-   * @param {number} level 
-   * @param {string[]} args 
+   *
+   * @param {number} level
+   * @param {string[]} args
+   * @param {string} src
    */
-  async handleLog(level, args) {
+  async handleLog(level, args, src) {
     const logObj = {
       timestamp: this.timestamp,
-      source: this.source,
+      source: src,
       message: args.join(' '),
       levelName: this.getLogLevelString(level),
       level
@@ -104,31 +105,31 @@ class Logger {
   trace(...args) {
     if (this.logLevel > LogLevel.TRACE) return
     console.trace(`[${this.timestamp}] TRACE:`, ...args)
-    this.handleLog(LogLevel.TRACE, args)
+    this.handleLog(LogLevel.TRACE, args, this.source)
   }
 
   debug(...args) {
     if (this.logLevel > LogLevel.DEBUG) return
     console.debug(`[${this.timestamp}] DEBUG:`, ...args, `(${this.source})`)
-    this.handleLog(LogLevel.DEBUG, args)
+    this.handleLog(LogLevel.DEBUG, args, this.source)
   }
 
   info(...args) {
     if (this.logLevel > LogLevel.INFO) return
     console.info(`[${this.timestamp}] INFO:`, ...args)
-    this.handleLog(LogLevel.INFO, args)
+    this.handleLog(LogLevel.INFO, args, this.source)
   }
 
   warn(...args) {
     if (this.logLevel > LogLevel.WARN) return
     console.warn(`[${this.timestamp}] WARN:`, ...args, `(${this.source})`)
-    this.handleLog(LogLevel.WARN, args)
+    this.handleLog(LogLevel.WARN, args, this.source)
   }
 
   error(...args) {
     if (this.logLevel > LogLevel.ERROR) return
     console.error(`[${this.timestamp}] ERROR:`, ...args, `(${this.source})`)
-    this.handleLog(LogLevel.ERROR, args)
+    this.handleLog(LogLevel.ERROR, args, this.source)
   }
 
   /**
@@ -139,12 +140,12 @@ class Logger {
    */
   fatal(...args) {
     console.error(`[${this.timestamp}] FATAL:`, ...args, `(${this.source})`)
-    return this.handleLog(LogLevel.FATAL, args)
+    return this.handleLog(LogLevel.FATAL, args, this.source)
   }
 
   note(...args) {
     console.log(`[${this.timestamp}] NOTE:`, ...args)
-    this.handleLog(LogLevel.NOTE, args)
+    this.handleLog(LogLevel.NOTE, args, this.source)
   }
 }
 module.exports = new Logger()


### PR DESCRIPTION
The logger should include a source containing the location where the logger was called. This works well for logging to `stdout`. Unfortunately, the file logs contain the locations where the file logging is called inside of the logger. This is not helpful:

```
{"timestamp":"2023-11-19 16:35:43","source":"Logger.js:114","message":"[oldDbFiles] Processed db data file with 1 entities","levelName":"INFO","level":2}
{"timestamp":"2023-11-19 16:35:43","source":"Logger.js:114","message":"[oldDbFiles] Finished loading db data with 2 entities","levelName":"INFO","level":2}
{"timestamp":"2023-11-19 16:35:43","source":"Logger.js:114","message":"[oldDbFiles] 2 settings loaded","levelName":"INFO","level":2}
```

This patch fixes the issue, ensureing that the actual source location will be logged:

```
{"timestamp":"2024-02-29 18:12:59.832","source":"DailyLog.js:132","message":"[DailyLog] 2024-02-29: Loaded 20 Logs","levelName":"DEBUG","level":1}
{"timestamp":"2024-02-29 18:12:59.638","source":"Server.js:172","message":"=== Starting Server ===","levelName":"INFO","level":2}
{"timestamp":"2024-02-29 18:12:59.638","source":"Server.js:103","message":"[Server] Init v2.8.0","levelName":"INFO","level":2}
```