### PR TITLE
Client side cover image caching

### DIFF
--- a/client/components/modals/item/tabs/Match.vue
+++ b/client/components/modals/item/tabs/Match.vue
@@ -49,8 +49,8 @@
             </div>
             <div v-if="media.coverPath">
               <p class="text-center text-gray-200">Current</p>
-              <a :href="$store.getters['globals/getLibraryItemCoverSrcById'](libraryItemId, null, true)" target="_blank" class="bg-primary">
-                <covers-preview-cover :src="$store.getters['globals/getLibraryItemCoverSrcById'](libraryItemId, null, true)" :width="100" :book-cover-aspect-ratio="bookCoverAspectRatio" />
+              <a :href="$store.getters['globals/getLibraryItemCoverSrc'](libraryItem, null, true)" target="_blank" class="bg-primary">
+                <covers-preview-cover :src="$store.getters['globals/getLibraryItemCoverSrc'](libraryItem, null, true)" :width="100" :book-cover-aspect-ratio="bookCoverAspectRatio" />
               </a>
             </div>
           </div>

--- a/client/pages/library/_library/podcast/latest.vue
+++ b/client/pages/library/_library/podcast/latest.vue
@@ -8,11 +8,11 @@
         <p v-if="!recentEpisodes.length && !processing" class="text-center text-xl">{{ $strings.MessageNoEpisodes }}</p>
         <template v-for="(episode, index) in episodesMapped">
           <div :key="episode.id" class="flex py-5 cursor-pointer relative" @click.stop="clickEpisode(episode)">
-            <covers-preview-cover :src="$store.getters['globals/getLibraryItemCoverSrcById'](episode.libraryItemId)" :width="96" :book-cover-aspect-ratio="bookCoverAspectRatio" :show-resolution="false" class="hidden md:block" />
+            <covers-preview-cover :src="$store.getters['globals/getLibraryItemCoverSrcById'](episode.libraryItemId, episode.updatedAt)" :width="96" :book-cover-aspect-ratio="bookCoverAspectRatio" :show-resolution="false" class="hidden md:block" />
             <div class="flex-grow pl-4 max-w-2xl">
               <!-- mobile -->
               <div class="flex md:hidden mb-2">
-                <covers-preview-cover :src="$store.getters['globals/getLibraryItemCoverSrcById'](episode.libraryItemId)" :width="48" :book-cover-aspect-ratio="bookCoverAspectRatio" :show-resolution="false" class="md:hidden" />
+                <covers-preview-cover :src="$store.getters['globals/getLibraryItemCoverSrcById'](episode.libraryItemId, episode.updatedAt)" :width="48" :book-cover-aspect-ratio="bookCoverAspectRatio" :show-resolution="false" class="md:hidden" />
                 <div class="flex-grow px-2">
                   <div class="flex items-center">
                     <div class="flex" @click.stop>

--- a/server/controllers/LibraryItemController.js
+++ b/server/controllers/LibraryItemController.js
@@ -283,6 +283,9 @@ class LibraryItemController {
       return res.sendStatus(404)
     }
 
+    if (req.query.ts)
+      res.set('Cache-Control', 'private, max-age=86400')
+
     if (raw) { // any value
       if (global.XAccel) {
         const encodedURI = encodeUriPath(global.XAccel + libraryItem.media.coverPath)


### PR DESCRIPTION
This adds client-side caching for book and podacst cover images.

Caching is performed only for timestamped requests, with cachce-control header set to 'private, max-age=86400'. This means:
- Caching is only done on the client, and not in any proxies. I chose this because currently the URL contains the authorization token, which somewhat of a security flaw, and also makes caching useful only for a specific client and user.
- Caching TTL is one day. Later we can add 'immutable', since the timestamp is updated when the image changes on the server, so cache-busting is possible.

Most important cases in which cover images are displayed on the client already have server-originated timestamp (updatedAt). I [updated a couple of places](https://github.com/advplyr/audiobookshelf/commit/4fe672f09d794c05d31a9375b2a686ed1c0dfe10) where updatedAt was available but not used.

Depending on various parameters (http vs. https, local vs. remote), this can reduce image loading latency by a factor of 2-4.

Example:
Home page before cover caching (home network, HTTP):
![Screenshot 2024-02-26 131331](https://github.com/advplyr/audiobookshelf/assets/22557398/a62f65c2-dea1-4211-a4ea-c32ea2df6ee5)
Home page after cover caching (home network HTTP):
![Screenshot 2024-02-26 131847](https://github.com/advplyr/audiobookshelf/assets/22557398/882ed37d-4ab8-41b1-a990-7d7bb4e45ccb)

You can see covers load latency goes down from ~500ms to ~200 ms. 

Another example:
Home page before cover caching (home network though reverse proxy, HTTPS):
![Screenshot 2024-02-26 134125](https://github.com/advplyr/audiobookshelf/assets/22557398/bcd41c73-8a0b-46d8-80f4-6b3253b8bb99)
Home page after cover caching (home network though reverse proxy, HTTPS):
![Screenshot 2024-02-26 134518](https://github.com/advplyr/audiobookshelf/assets/22557398/2a8f65bb-80b1-44ec-9b23-a694b600f725)

Here you can see covers load latency go down from ~270ms to about 70ms

The gains would probably be even more impressive if measured over remote connections.