### PR TITLE
Fix input width in MultiSelect UI components

### DIFF
--- a/client/components/ui/MultiSelect.vue
+++ b/client/components/ui/MultiSelect.vue
@@ -11,7 +11,7 @@
             </div>
             {{ item }}
           </div>
-          <input v-show="!readonly" ref="input" v-model="textInput" :disabled="disabled" style="min-width: 40px; width: 40px" class="h-full bg-primary focus:outline-none px-1" @keydown="keydownInput" @focus="inputFocus" @blur="inputBlur" @paste="inputPaste" />
+          <input v-show="!readonly" ref="input" v-model="textInput" :disabled="disabled" style="min-width: 40px; width: fit-content" class="h-full bg-primary focus:outline-none px-1" @keydown="keydownInput" @focus="inputFocus" @blur="inputBlur" @paste="inputPaste" />
         </div>
       </form>
 
@@ -110,15 +110,6 @@ export default {
       this.typingTimeout = setTimeout(() => {
         this.currentSearch = this.textInput
       }, 100)
-      this.setInputWidth()
-    },
-    setInputWidth() {
-      setTimeout(() => {
-        var value = this.$refs.input.value
-        var len = value.length * 7 + 24
-        this.$refs.input.style.width = len + 'px'
-        this.recalcMenuPos()
-      }, 50)
     },
     recalcMenuPos() {
       if (!this.menu || !this.$refs.inputWrapper) return

--- a/client/components/ui/MultiSelectQueryInput.vue
+++ b/client/components/ui/MultiSelectQueryInput.vue
@@ -14,7 +14,7 @@
           <div v-if="showEdit && !disabled" class="rounded-full cursor-pointer w-6 h-6 mx-0.5 bg-bg flex items-center justify-center">
             <span class="material-icons text-white hover:text-success pt-px pr-px" style="font-size: 1.1rem" @click.stop="addItem">add</span>
           </div>
-          <input v-show="!readonly" ref="input" v-model="textInput" :disabled="disabled" style="min-width: 40px; width: 40px" class="h-full bg-primary focus:outline-none px-1" @keydown="keydownInput" @focus="inputFocus" @blur="inputBlur" @paste="inputPaste" />
+          <input v-show="!readonly" ref="input" v-model="textInput" :disabled="disabled" style="min-width: 40px; width: fit-content" class="h-full bg-primary focus:outline-none px-1" @keydown="keydownInput" @focus="inputFocus" @blur="inputBlur" @paste="inputPaste" />
         </div>
       </form>
 
@@ -127,15 +127,6 @@ export default {
       this.typingTimeout = setTimeout(() => {
         this.search()
       }, 250)
-      this.setInputWidth()
-    },
-    setInputWidth() {
-      setTimeout(() => {
-        var value = this.$refs.input.value
-        var len = value.length * 7 + 24
-        this.$refs.input.style.width = len + 'px'
-        this.recalcMenuPos()
-      }, 50)
     },
     recalcMenuPos() {
       if (!this.menu || !this.$refs.inputWrapper) return


### PR DESCRIPTION
Fixes #2700 (see details in the bug).

Note that setInputWidth was removed, and with it the call to this.RecalcMenuPos(). 
I'm not sure why this call is required. If it is, let me know and I'll try to re-incorporate it where it makes sense.
