### PR TITLE
Automating localization

### DIFF
--- a/.github/workflows/alphabetization_check.yml
+++ b/.github/workflows/alphabetization_check.yml
@@ -1,0 +1,29 @@
+name: Verify all i18n files are alphabetized
+
+on:
+  push:
+    paths:
+      - client/strings/** # Should only check if any strings changed
+
+jobs:
+  update_translations:
+    runs-on: ubuntu-latest
+    steps:
+    # Check out the repository
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    # Set up node to run the javascript
+    - name: Set up node
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+    
+    # Runs the custom script using the local action defined in `action.yaml`
+    #
+    # The only argument is the `directory`, which is where the i18n files are
+    # stored.
+    - name: Run Update JSON Files action
+      uses: audiobookshelf/audiobookshelf-i18n-updater@v1.0.0
+      with:
+        directory: 'client/strings/'  # Adjust the directory path as needed

--- a/.github/workflows/i18n-automatic-branch.yml
+++ b/.github/workflows/i18n-automatic-branch.yml
@@ -6,7 +6,7 @@ on:
       - main # Only care about the main branch, don't care about any PRs or forks
       - master
     paths:
-      - strings/** # Should only check if any strings changed
+      - client/strings/** # Should only check if any strings changed
 
 jobs:
   update_translations:
@@ -33,7 +33,7 @@ jobs:
     - name: Run Update JSON Files action
       uses: audiobookshelf/audiobookshelf-i18n-updater@v1.0.0-beta
       with:
-        directory: 'strings/'  # Adjust the directory path as needed
+        directory: 'client/strings/'  # Adjust the directory path as needed
 
     # Does a git diff to see if any language files were changed from running
     # the script. This will be false if the local script was already ran

--- a/.github/workflows/i18n-automatic-branch.yml
+++ b/.github/workflows/i18n-automatic-branch.yml
@@ -1,0 +1,68 @@
+name: Update JSON Files
+
+on:
+  push:
+    branches:
+      - main # Only care about the main branch, don't care about any PRs or forks
+      - master
+    paths:
+      - strings/** # Should only check if any strings changed
+
+jobs:
+  update_translations:
+    runs-on: ubuntu-latest
+    steps:
+    # Check out the repository
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    # Set up node to run the javascript
+    - name: Set up node
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+    
+    # Runs the custom script using the local action defined in `action.yaml`
+    #
+    # The action runs the `copy_keys.js` script, which copies any unused keys
+    # from the English language file to other language files, and orders each
+    # file by key alphabetically.
+    #   
+    # The only argument is the `directory`, which is where the i18n files are
+    # stored.
+    - name: Run Update JSON Files action
+      uses: audiobookshelf/audiobookshelf-i18n-updater@v1.0.0-beta
+      with:
+        directory: 'strings/'  # Adjust the directory path as needed
+
+    # Does a git diff to see if any language files were changed from running
+    # the script. This will be false if the local script was already ran
+    # locally so no changes are needed for the language files.
+    - name: Check diff of strings
+      run: |
+        if git diff --exit-code; then
+          echo "CHANGED=false" >>${GITHUB_ENV}
+        else
+          echo "CHANGED=true" >>${GITHUB_ENV}
+        fi
+
+
+    # If changes were detected, create a branch with the changes and open
+    # a PR to `main`. This requires changing the Workflow Permissions
+    # to be "read and write" to create the branch and commit, and then
+    # also need to enable "Allow GitHub actions to create and approve PR"
+    # so the PR can actually be made. Also set up secrets for user email
+    # name if anyone cares about that since it's available in git logs anyway.
+    - name: If changes, commit and open PR
+      if: ${{ env.CHANGED == 'true' }}
+      run: |
+        branch_name="update-strings-$(git log --format=%h -n 1)"
+        git config user.email "${{secrets.USER_EMAIL}}"
+        git config user.name "${{secrets.USER_NAME}}"
+        git checkout -b $branch_name
+        git add .
+        git commit -m "chore: Update strings"
+        git push origin $branch_name
+        gh pr create -B main -H $branch_name --title 'Automatic translation updates' --body 'Created by GH Action. Can be ignored if there are other open translation PRs.'
+      env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/i18n-automatic-branch.yml
+++ b/.github/workflows/i18n-automatic-branch.yml
@@ -1,4 +1,4 @@
-name: Update JSON Files
+name: Automatic update i18n files
 
 on:
   push:

--- a/.github/workflows/i18n-manual-branch.yml
+++ b/.github/workflows/i18n-manual-branch.yml
@@ -6,7 +6,7 @@ on:
       - main # Only care about the main branch, don't care about any PRs or forks
       - master
     paths:
-      - strings/** # Should only check if any strings changed
+      - client/strings/** # Should only check if any strings changed
 
 jobs:
   update_translations:
@@ -33,7 +33,7 @@ jobs:
     - name: Run Update JSON Files action
       uses: audiobookshelf/audiobookshelf-i18n-updater@v1.0.0-beta
       with:
-        directory: 'strings/'  # Adjust the directory path as needed
+        directory: 'client/strings/'  # Adjust the directory path as needed
 
     # Does a git diff to see if any language files were changed from running
     # the script. This will be false if the local script was already ran

--- a/.github/workflows/i18n-manual-branch.yml
+++ b/.github/workflows/i18n-manual-branch.yml
@@ -1,0 +1,68 @@
+name: Manual update i18n files
+
+on:
+  push:
+    branches:
+      - main # Only care about the main branch, don't care about any PRs or forks
+      - master
+    paths:
+      - strings/** # Should only check if any strings changed
+
+jobs:
+  update_translations:
+    runs-on: ubuntu-latest
+    steps:
+    # Check out the repository
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    # Set up node to run the javascript
+    - name: Set up node
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+    
+    # Runs the custom script using the local action defined in `action.yaml`
+    #
+    # The action runs the `copy_keys.js` script, which copies any unused keys
+    # from the English language file to other language files, and orders each
+    # file by key alphabetically.
+    #   
+    # The only argument is the `directory`, which is where the i18n files are
+    # stored.
+    - name: Run Update JSON Files action
+      uses: audiobookshelf/audiobookshelf-i18n-updater@v1.0.0-beta
+      with:
+        directory: 'strings/'  # Adjust the directory path as needed
+
+    # Does a git diff to see if any language files were changed from running
+    # the script. This will be false if the local script was already ran
+    # locally so no changes are needed for the language files.
+    - name: Check diff of strings
+      run: |
+        if git diff --exit-code; then
+          echo "CHANGED=false" >>${GITHUB_ENV}
+        else
+          echo "CHANGED=true" >>${GITHUB_ENV}
+        fi
+
+
+    # If changes were detected, create a branch with the changes and open
+    # a PR to `main`. This requires changing the Workflow Permissions
+    # to be "read and write" to create the branch and commit, and then
+    # also need to enable "Allow GitHub actions to create and approve PR"
+    # so the PR can actually be made. Also set up secrets for user email
+    # name if anyone cares about that since it's available in git logs anyway.
+    - name: If changes, commit and open PR
+      if: ${{ env.CHANGED == 'true' }}
+      run: |
+        branch_name="update-strings-$(git log --format=%h -n 1)"
+        git config user.email "${{secrets.USER_EMAIL}}"
+        git config user.name "${{secrets.USER_NAME}}"
+        git checkout -b $branch_name
+        git add .
+        git commit -m "chore: Update strings"
+        git push origin $branch_name
+        gh pr create -B main -H $branch_name --title 'Automatic translation updates' --body 'Created by GH Action. Can be ignored if there are other open translation PRs.'
+      env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/i18n-manual-branch.yml
+++ b/.github/workflows/i18n-manual-branch.yml
@@ -1,12 +1,7 @@
 name: Manual update i18n files
 
 on:
-  push:
-    branches:
-      - main # Only care about the main branch, don't care about any PRs or forks
-      - master
-    paths:
-      - client/strings/** # Should only check if any strings changed
+  workflow_dispatch:
 
 jobs:
   update_translations:


### PR DESCRIPTION
This PR includes 3 new workflows:
- `alphabetization_check` which performs an integration test to verify that all localization keys are alphabetical for all commits and PRs
- `i18n-automatic-branch` which automatically runs the key-copying script on pushes to the main/master branch and opens a branch with the updated files if there were any changes
- `i18n-manual-branch` which can be manually triggered

The `branch` workflows are identical other than the trigger condition to allow for disabling the `automatic` workflow without removing the ability to run the `manual` workflow. These two workflows will need write access to be able to create the branch and PR. These also require defining the `USER_EMAIL` and `USER_NAME` secrets for the git initialization. These don't necessarily  to be secrets, but felt better to do that instead of just including a default value.

These workflows make use of the https://github.com/audiobookshelf/audiobookshelf-i18n-updater GitHub action.

Edit: The action linked above ensures a newline at the end of each i18n file so the last line stops showing up as a change when viewing the diff.