### PR TITLE
Added isbn to CustomProviderAdapter

### DIFF
--- a/server/finders/BookFinder.js
+++ b/server/finders/BookFinder.js
@@ -152,11 +152,12 @@ class BookFinder {
   /**
    * 
    * @param {string} title 
-   * @param {string} author 
+   * @param {string} author
+   * @param {string} isbn 
    * @param {string} providerSlug 
    * @returns {Promise<Object[]>}
    */
-  async getCustomProviderResults(title, author, providerSlug) {
+  async getCustomProviderResults(title, author, isbn, providerSlug) {
     const books = await this.customProviderAdapter.search(title, author, providerSlug, 'book')
     if (this.verbose) Logger.debug(`Custom provider '${providerSlug}' Search Results: ${books.length || 0}`)
 
@@ -333,7 +334,7 @@ class BookFinder {
 
     // Custom providers are assumed to be correct
     if (provider.startsWith('custom-')) {
-      return this.getCustomProviderResults(title, author, provider)
+      return this.getCustomProviderResults(title, author, isbn, provider)
     }
 
     if (!title)

--- a/server/providers/CustomProviderAdapter.js
+++ b/server/providers/CustomProviderAdapter.js
@@ -9,11 +9,12 @@ class CustomProviderAdapter {
      * 
      * @param {string} title 
      * @param {string} author 
+     * @param {string} isbn 
      * @param {string} providerSlug 
      * @param {string} mediaType
      * @returns {Promise<Object[]>}
      */
-    async search(title, author, providerSlug, mediaType) {
+    async search(title, author, isbn, providerSlug, mediaType) {
         const providerId = providerSlug.split('custom-')[1]
         const provider = await Database.customMetadataProviderModel.findByPk(providerId)
 
@@ -28,6 +29,9 @@ class CustomProviderAdapter {
         }
         if (author) {
             queryObj.author = author
+        }
+        if (isbn) {
+            queryObj.isbn = isbn
         }
         const queryString = (new URLSearchParams(queryObj)).toString()
 


### PR DESCRIPTION
This adds the isbn to the CustomProviderAdapter so that it can be used as a identifier like the asin is used by Audible.