### PR TITLE
Make series sequence cleanup slighlty less aggressive

### DIFF
--- a/server/providers/Audible.js
+++ b/server/providers/Audible.js
@@ -29,8 +29,9 @@ class Audible {
      */
     cleanSeriesSequence(seriesName, sequence) {
         if (!sequence) return ''
-        let updatedSequence = sequence.replace(/Book /, '').trim()
-        updatedSequence = updatedSequence.replace(/(\d+)(, .*)/, '$1').trim()
+        // match any number with optional decimal (e.g, 1 or 1.5 or .5)
+        let numberFound = sequence.match(/\.\d+|\d+(?:\.\d+)?/)
+        let updatedSequence = numberFound ? numberFound[0] : sequence
         if (sequence !== updatedSequence) {
             Logger.debug(`[Audible] Series "${seriesName}" sequence was cleaned from "${sequence}" to "${updatedSequence}"`)
         }

--- a/server/providers/Audible.js
+++ b/server/providers/Audible.js
@@ -30,9 +30,7 @@ class Audible {
     cleanSeriesSequence(seriesName, sequence) {
         if (!sequence) return ''
         let updatedSequence = sequence.replace(/Book /, '').trim()
-        if (updatedSequence.includes(' ')) {
-            updatedSequence = updatedSequence.split(' ').shift().replace(/,$/, '')
-        }
+        updatedSequence = updatedSequence.replace(/(\d+)(, .*)/, '$1').trim()
         if (sequence !== updatedSequence) {
             Logger.debug(`[Audible] Series "${seriesName}" sequence was cleaned from "${sequence}" to "${updatedSequence}"`)
         }

--- a/test/server/providers/Audible.test.js
+++ b/test/server/providers/Audible.test.js
@@ -1,0 +1,48 @@
+const Audible = require('../../../server/providers/Audible')
+const { expect } = require('chai')
+const sinon = require('sinon')
+
+describe('Audible', () => {
+  let audible;
+
+  beforeEach(() => {
+    audible = new Audible();
+  });
+
+  describe('cleanSeriesSequence', () => {
+    it('should return an empty string if sequence is falsy', () => {
+      const result = audible.cleanSeriesSequence('Series Name', null)
+      expect(result).to.equal('')
+    })
+
+    it('should return the sequence as is if it does not contain a number', () => {
+      const result = audible.cleanSeriesSequence('Series Name', 'part a')
+      expect(result).to.equal('part a')
+    })
+
+    it('should return the sequence as is if contains just a number', () => {
+      const result = audible.cleanSeriesSequence('Series Name', '2')
+      expect(result).to.equal('2')
+    })
+
+    it('should return the sequence as is if contains just a number with decimals', () => {
+      const result = audible.cleanSeriesSequence('Series Name', '2.3')
+      expect(result).to.equal('2.3')
+    })
+
+    it('should extract and return the first number from the sequence', () => {
+      const result = audible.cleanSeriesSequence('Series Name', 'Book 1')
+      expect(result).to.equal('1')
+    })
+
+    it('should extract and return the number with decimals from the sequence', () => {
+      const result = audible.cleanSeriesSequence('Series Name', 'Book 1.5')
+      expect(result).to.equal('1.5')
+    })
+    
+    it('should extract and return the number even if it has no leading zero', () => {
+      const result = audible.cleanSeriesSequence('Series Name', 'Book .5')
+      expect(result).to.equal('.5')
+    })
+  })
+})


### PR DESCRIPTION
Fixes #2710.

The fix makes the sequence cleanup a bit less aggressive, so that the sequence number, which translates to: "first-season : 1", does not get trimmed to "first-season". 

The fix to #2380 still works.