### PR TITLE
Add library toggle setting for skipping earlier instalments in Continue Series

### DIFF
--- a/client/components/modals/libraries/EditModal.vue
+++ b/client/components/modals/libraries/EditModal.vue
@@ -127,6 +127,7 @@ export default {
           skipMatchingMediaWithIsbn: false,
           autoScanCronExpression: null,
           hideSingleBookSeries: false,
+          onlyShowLaterBooksInContinueSeries: false,
           metadataPrecedence: ['folderStructure', 'audioMetatags', 'nfoFile', 'txtFiles', 'opfFile', 'absMetadata']
         }
       }

--- a/client/components/modals/libraries/LibrarySettings.vue
+++ b/client/components/modals/libraries/LibrarySettings.vue
@@ -49,6 +49,17 @@
         </ui-tooltip>
       </div>
     </div>
+    <div v-if="isBookLibrary" class="py-3">
+      <div class="flex items-center">
+        <ui-toggle-switch v-model="onlyShowLaterBooksInContinueSeries" @input="formUpdated" />
+        <ui-tooltip :text="$strings.LabelSettingsOnlyShowLaterBooksInContinueSeriesHelp">
+          <p class="pl-4 text-base">
+            {{ $strings.LabelSettingsOnlyShowLaterBooksInContinueSeries }}
+            <span class="material-icons icon-text text-sm">info_outlined</span>
+          </p>
+        </ui-tooltip>
+      </div>
+    </div>
     <div v-if="isPodcastLibrary" class="py-3">
       <ui-dropdown :label="$strings.LabelPodcastSearchRegion" v-model="podcastSearchRegion" :items="$podcastSearchRegionOptions" small class="max-w-52" @input="formUpdated" />
     </div>
@@ -73,6 +84,7 @@ export default {
       skipMatchingMediaWithIsbn: false,
       audiobooksOnly: false,
       hideSingleBookSeries: false,
+      onlyShowLaterBooksInContinueSeries: false,
       podcastSearchRegion: 'us'
     }
   },
@@ -107,6 +119,7 @@ export default {
           skipMatchingMediaWithIsbn: !!this.skipMatchingMediaWithIsbn,
           audiobooksOnly: !!this.audiobooksOnly,
           hideSingleBookSeries: !!this.hideSingleBookSeries,
+          onlyShowLaterBooksInContinueSeries: !!this.onlyShowLaterBooksInContinueSeries,
           podcastSearchRegion: this.podcastSearchRegion
         }
       }
@@ -121,6 +134,7 @@ export default {
       this.skipMatchingMediaWithIsbn = !!this.librarySettings.skipMatchingMediaWithIsbn
       this.audiobooksOnly = !!this.librarySettings.audiobooksOnly
       this.hideSingleBookSeries = !!this.librarySettings.hideSingleBookSeries
+      this.onlyShowLaterBooksInContinueSeries = !!this.librarySettings.onlyShowLaterBooksInContinueSeries
       this.podcastSearchRegion = this.librarySettings.podcastSearchRegion || 'us'
     }
   },

--- a/client/strings/cs.json
+++ b/client/strings/cs.json
@@ -466,6 +466,8 @@
   "LabelSettingsHideSingleBookSeriesHelp": "Série, které mají jedinou knihu, budou skryty na stránce série a na domovské stránce.",
   "LabelSettingsHomePageBookshelfView": "Domovská stránka používá zobrazení police s knihami",
   "LabelSettingsLibraryBookshelfView": "Knihovna používá zobrazení police s knihami",
+  "LabelSettingsOnlyShowLaterBooksInContinueSeries": "Skip earlier books in Continue Series",
+  "LabelSettingsOnlyShowLaterBooksInContinueSeriesHelp": "The Continue Series home page shelf shows the first book not started in series that have at least one book finished and no books in progress. Enabling this setting will continue series from the furthest completed book instead of the first book not started.",
   "LabelSettingsParseSubtitles": "Analzyovat podtitul",
   "LabelSettingsParseSubtitlesHelp": "Rozparsovat podtitul z názvů složek audioknih.<br>Podtiul musí být oddělen znakem \" - \"<br>tj. \"Název knihy - Zde Podtitul\"  má podtitul \"Zde podtitul\"",
   "LabelSettingsPreferMatchedMetadata": "Preferovat spárovaná metadata",

--- a/client/strings/da.json
+++ b/client/strings/da.json
@@ -466,6 +466,8 @@
   "LabelSettingsHideSingleBookSeriesHelp": "Serier med en enkelt bog vil blive skjult fra serie-siden og hjemmesidehylder.",
   "LabelSettingsHomePageBookshelfView": "Brug bogreolvisning på startside",
   "LabelSettingsLibraryBookshelfView": "Brug bogreolvisning i biblioteket",
+  "LabelSettingsOnlyShowLaterBooksInContinueSeries": "Skip earlier books in Continue Series",
+  "LabelSettingsOnlyShowLaterBooksInContinueSeriesHelp": "The Continue Series home page shelf shows the first book not started in series that have at least one book finished and no books in progress. Enabling this setting will continue series from the furthest completed book instead of the first book not started.",
   "LabelSettingsParseSubtitles": "Fortolk undertekster",
   "LabelSettingsParseSubtitlesHelp": "Udtræk undertekster fra lydbogsmappenavne.<br>Undertitler skal adskilles af \" - \"<br>f.eks. \"Bogtitel - En undertitel her\" har undertitlen \"En undertitel her\"",
   "LabelSettingsPreferMatchedMetadata": "Foretræk matchede metadata",

--- a/client/strings/de.json
+++ b/client/strings/de.json
@@ -466,6 +466,8 @@
   "LabelSettingsHideSingleBookSeriesHelp": "Serien, die nur ein einzelnes Buch enthalten, werden auf der Startseite und in der Serienansicht ausgeblendet.",
   "LabelSettingsHomePageBookshelfView": "Startseite verwendet die Bücherregalansicht",
   "LabelSettingsLibraryBookshelfView": "Bibliothek verwendet die Bücherregalansicht",
+  "LabelSettingsOnlyShowLaterBooksInContinueSeries": "Skip earlier books in Continue Series",
+  "LabelSettingsOnlyShowLaterBooksInContinueSeriesHelp": "The Continue Series home page shelf shows the first book not started in series that have at least one book finished and no books in progress. Enabling this setting will continue series from the furthest completed book instead of the first book not started.",
   "LabelSettingsParseSubtitles": "Analysiere Untertitel",
   "LabelSettingsParseSubtitlesHelp": "Extrahiere den Untertitel von Medium-Ordnernamen.<br>Untertitel müssen vom eigentlichem Titel durch ein \" - \" getrennt sein. <br>Beispiel: \"Titel - Untertitel\"",
   "LabelSettingsPreferMatchedMetadata": "Bevorzuge online abgestimmte Metadaten",

--- a/client/strings/en-us.json
+++ b/client/strings/en-us.json
@@ -467,7 +467,7 @@
   "LabelSettingsHomePageBookshelfView": "Home page use bookshelf view",
   "LabelSettingsLibraryBookshelfView": "Library use bookshelf view",
   "LabelSettingsOnlyShowLaterBooksInContinueSeries": "Skip earlier books in Continue Series",
-  "LabelSettingsOnlyShowLaterBooksInContinueSeriesHelp": "Avoids showing books that are earlier in a series than the ones you have already read.",
+  "LabelSettingsOnlyShowLaterBooksInContinueSeriesHelp": "The Continue Series home page shelf shows the first book not started in series that have at least one book finished and no books in progress. Enabling this setting will continue series from the furthest completed book instead of the first book not started.",
   "LabelSettingsParseSubtitles": "Parse subtitles",
   "LabelSettingsParseSubtitlesHelp": "Extract subtitles from audiobook folder names.<br>Subtitle must be seperated by \" - \"<br>i.e. \"Book Title - A Subtitle Here\" has the subtitle \"A Subtitle Here\"",
   "LabelSettingsPreferMatchedMetadata": "Prefer matched metadata",

--- a/client/strings/en-us.json
+++ b/client/strings/en-us.json
@@ -466,6 +466,8 @@
   "LabelSettingsHideSingleBookSeriesHelp": "Series that have a single book will be hidden from the series page and home page shelves.",
   "LabelSettingsHomePageBookshelfView": "Home page use bookshelf view",
   "LabelSettingsLibraryBookshelfView": "Library use bookshelf view",
+  "LabelSettingsOnlyShowLaterBooksInContinueSeries": "Skip earlier books in Continue Series",
+  "LabelSettingsOnlyShowLaterBooksInContinueSeriesHelp": "Avoids showing books that are earlier in a series than the ones you have already read.",
   "LabelSettingsParseSubtitles": "Parse subtitles",
   "LabelSettingsParseSubtitlesHelp": "Extract subtitles from audiobook folder names.<br>Subtitle must be seperated by \" - \"<br>i.e. \"Book Title - A Subtitle Here\" has the subtitle \"A Subtitle Here\"",
   "LabelSettingsPreferMatchedMetadata": "Prefer matched metadata",

--- a/client/strings/es.json
+++ b/client/strings/es.json
@@ -466,6 +466,8 @@
   "LabelSettingsHideSingleBookSeriesHelp": "Las series con un solo libro no aparecerán en la página de series ni la repisa para series de la página principal.",
   "LabelSettingsHomePageBookshelfView": "Usar la vista de librero en la página principal",
   "LabelSettingsLibraryBookshelfView": "Usar la vista de librero en la biblioteca",
+  "LabelSettingsOnlyShowLaterBooksInContinueSeries": "Skip earlier books in Continue Series",
+  "LabelSettingsOnlyShowLaterBooksInContinueSeriesHelp": "The Continue Series home page shelf shows the first book not started in series that have at least one book finished and no books in progress. Enabling this setting will continue series from the furthest completed book instead of the first book not started.",
   "LabelSettingsParseSubtitles": "Extraer Subtítulos",
   "LabelSettingsParseSubtitlesHelp": "Extraer subtítulos de los nombres de las carpetas de los audiolibros.<br>Los subtítulos deben estar separados por \" - \"<br>Por ejemplo: \"Ejemplo de Título - Subtítulo Aquí\" tiene el subtítulo \"Subtítulo Aquí\"",
   "LabelSettingsPreferMatchedMetadata": "Preferir metadatos encontrados",

--- a/client/strings/et.json
+++ b/client/strings/et.json
@@ -466,6 +466,8 @@
   "LabelSettingsHideSingleBookSeriesHelp": "Ühe raamatuga seeriaid peidetakse seeria lehelt ja avalehe riiulitelt.",
   "LabelSettingsHomePageBookshelfView": "Avaleht kasutage raamatukoguvaadet",
   "LabelSettingsLibraryBookshelfView": "Raamatukogu kasutamiseks kasutage raamatukoguvaadet",
+  "LabelSettingsOnlyShowLaterBooksInContinueSeries": "Skip earlier books in Continue Series",
+  "LabelSettingsOnlyShowLaterBooksInContinueSeriesHelp": "The Continue Series home page shelf shows the first book not started in series that have at least one book finished and no books in progress. Enabling this setting will continue series from the furthest completed book instead of the first book not started.",
   "LabelSettingsParseSubtitles": "Lugege subtiitreid",
   "LabelSettingsParseSubtitlesHelp": "Eraldage subtiitrid heliraamatu kaustade nimedest.<br>Subtiitrid peavad olema eraldatud \" - \".<br>Näiteks: \"Raamatu pealkiri - Siin on alapealkiri\" alapealkiri on \"Siin on alapealkiri\"",
   "LabelSettingsPreferMatchedMetadata": "Eelista sobitatud metaandmeid",

--- a/client/strings/fr.json
+++ b/client/strings/fr.json
@@ -466,6 +466,8 @@
   "LabelSettingsHideSingleBookSeriesHelp": "Les séries qui ne comportent qu’un seul livre seront masquées sur la page de la série et sur les étagères de la page d’accueil.",
   "LabelSettingsHomePageBookshelfView": "La page d’accueil utilise la vue étagère",
   "LabelSettingsLibraryBookshelfView": "La bibliothèque utilise la vue étagère",
+  "LabelSettingsOnlyShowLaterBooksInContinueSeries": "Skip earlier books in Continue Series",
+  "LabelSettingsOnlyShowLaterBooksInContinueSeriesHelp": "The Continue Series home page shelf shows the first book not started in series that have at least one book finished and no books in progress. Enabling this setting will continue series from the furthest completed book instead of the first book not started.",
   "LabelSettingsParseSubtitles": "Analyser les sous-titres",
   "LabelSettingsParseSubtitlesHelp": "Extrait les sous-titres depuis le dossier du livre audio.<br>Les sous-titres doivent être séparés par «  -  »<br>c’est-à-dire : « Titre du livre - Ceci est un sous-titre » aura le sous-titre « Ceci est un sous-titre »",
   "LabelSettingsPreferMatchedMetadata": "Préférer les métadonnées par correspondance",

--- a/client/strings/gu.json
+++ b/client/strings/gu.json
@@ -466,6 +466,8 @@
   "LabelSettingsHideSingleBookSeriesHelp": "Series that have a single book will be hidden from the series page and home page shelves.",
   "LabelSettingsHomePageBookshelfView": "Home page use bookshelf view",
   "LabelSettingsLibraryBookshelfView": "Library use bookshelf view",
+  "LabelSettingsOnlyShowLaterBooksInContinueSeries": "Skip earlier books in Continue Series",
+  "LabelSettingsOnlyShowLaterBooksInContinueSeriesHelp": "The Continue Series home page shelf shows the first book not started in series that have at least one book finished and no books in progress. Enabling this setting will continue series from the furthest completed book instead of the first book not started.",
   "LabelSettingsParseSubtitles": "Parse subtitles",
   "LabelSettingsParseSubtitlesHelp": "Extract subtitles from audiobook folder names.<br>Subtitle must be seperated by \" - \"<br>i.e. \"Book Title - A Subtitle Here\" has the subtitle \"A Subtitle Here\"",
   "LabelSettingsPreferMatchedMetadata": "Prefer matched metadata",

--- a/client/strings/hi.json
+++ b/client/strings/hi.json
@@ -466,6 +466,8 @@
   "LabelSettingsHideSingleBookSeriesHelp": "Series that have a single book will be hidden from the series page and home page shelves.",
   "LabelSettingsHomePageBookshelfView": "Home page use bookshelf view",
   "LabelSettingsLibraryBookshelfView": "Library use bookshelf view",
+  "LabelSettingsOnlyShowLaterBooksInContinueSeries": "Skip earlier books in Continue Series",
+  "LabelSettingsOnlyShowLaterBooksInContinueSeriesHelp": "The Continue Series home page shelf shows the first book not started in series that have at least one book finished and no books in progress. Enabling this setting will continue series from the furthest completed book instead of the first book not started.",
   "LabelSettingsParseSubtitles": "Parse subtitles",
   "LabelSettingsParseSubtitlesHelp": "Extract subtitles from audiobook folder names.<br>Subtitle must be seperated by \" - \"<br>i.e. \"Book Title - A Subtitle Here\" has the subtitle \"A Subtitle Here\"",
   "LabelSettingsPreferMatchedMetadata": "Prefer matched metadata",

--- a/client/strings/hr.json
+++ b/client/strings/hr.json
@@ -466,6 +466,8 @@
   "LabelSettingsHideSingleBookSeriesHelp": "Series that have a single book will be hidden from the series page and home page shelves.",
   "LabelSettingsHomePageBookshelfView": "Koristi bookshelf pogled za početnu stranicu",
   "LabelSettingsLibraryBookshelfView": "Koristi bookshelf pogled za biblioteku",
+  "LabelSettingsOnlyShowLaterBooksInContinueSeries": "Skip earlier books in Continue Series",
+  "LabelSettingsOnlyShowLaterBooksInContinueSeriesHelp": "The Continue Series home page shelf shows the first book not started in series that have at least one book finished and no books in progress. Enabling this setting will continue series from the furthest completed book instead of the first book not started.",
   "LabelSettingsParseSubtitles": "Parsaj podnapise",
   "LabelSettingsParseSubtitlesHelp": "Izvadi podnapise iz imena od audiobook foldera.<br>Podnapis mora biti odvojen sa \" - \"<br>npr. \"Ime knjige - Podnapis ovdje\" ima podnapis \"Podnapis ovdje\"",
   "LabelSettingsPreferMatchedMetadata": "Preferiraj matchane metapodatke",

--- a/client/strings/hu.json
+++ b/client/strings/hu.json
@@ -466,6 +466,8 @@
   "LabelSettingsHideSingleBookSeriesHelp": "A csak egy könyvet tartalmazó sorozatok el lesznek rejtve a sorozatok oldalról és a kezdőlap polcairól.",
   "LabelSettingsHomePageBookshelfView": "Kezdőlap használja a könyvespolc nézetet",
   "LabelSettingsLibraryBookshelfView": "Könyvtár használja a könyvespolc nézetet",
+  "LabelSettingsOnlyShowLaterBooksInContinueSeries": "Skip earlier books in Continue Series",
+  "LabelSettingsOnlyShowLaterBooksInContinueSeriesHelp": "The Continue Series home page shelf shows the first book not started in series that have at least one book finished and no books in progress. Enabling this setting will continue series from the furthest completed book instead of the first book not started.",
   "LabelSettingsParseSubtitles": "Feliratok elemzése",
   "LabelSettingsParseSubtitlesHelp": "Feliratok kinyerése a hangoskönyv mappaneveiből.<br>A feliratnak el kell különülnie egy \" - \" jellel<br>például: \"Könyv címe - Egy felirat itt\" esetén a felirat \"Egy felirat itt\"",
   "LabelSettingsPreferMatchedMetadata": "Preferált egyeztetett metaadatok",

--- a/client/strings/it.json
+++ b/client/strings/it.json
@@ -466,6 +466,8 @@
   "LabelSettingsHideSingleBookSeriesHelp": "Le serie che hanno un solo libro saranno nascoste dalla pagina della serie e dagli scaffali della home page.",
   "LabelSettingsHomePageBookshelfView": "Home page con sfondo legno",
   "LabelSettingsLibraryBookshelfView": "Libreria con sfondo legno",
+  "LabelSettingsOnlyShowLaterBooksInContinueSeries": "Skip earlier books in Continue Series",
+  "LabelSettingsOnlyShowLaterBooksInContinueSeriesHelp": "The Continue Series home page shelf shows the first book not started in series that have at least one book finished and no books in progress. Enabling this setting will continue series from the furthest completed book instead of the first book not started.",
   "LabelSettingsParseSubtitles": "Analizza sottotitoli",
   "LabelSettingsParseSubtitlesHelp": "Estrai i sottotitoli dai nomi delle cartelle degli audiolibri. <br> I sottotitoli devono essere separati da \" - \"<br> Per esempio \"Il signore degli anelli - Le due Torri \" avrà il sottotitolo \"Le due Torri\"",
   "LabelSettingsPreferMatchedMetadata": "Preferisci i metadata trovati",

--- a/client/strings/lt.json
+++ b/client/strings/lt.json
@@ -466,6 +466,8 @@
   "LabelSettingsHideSingleBookSeriesHelp": "Serijos, turinčios tik vieną knygą, bus paslėptos nuo serijų puslapio ir pagrindinio puslapio lentynų.",
   "LabelSettingsHomePageBookshelfView": "Naudoti pagrindinio puslapio knygų lentynų vaizdą",
   "LabelSettingsLibraryBookshelfView": "Naudoti bibliotekos knygų lentynų vaizdą",
+  "LabelSettingsOnlyShowLaterBooksInContinueSeries": "Skip earlier books in Continue Series",
+  "LabelSettingsOnlyShowLaterBooksInContinueSeriesHelp": "The Continue Series home page shelf shows the first book not started in series that have at least one book finished and no books in progress. Enabling this setting will continue series from the furthest completed book instead of the first book not started.",
   "LabelSettingsParseSubtitles": "Analizuoti subtitrus",
   "LabelSettingsParseSubtitlesHelp": "Išskleisti subtitrus iš audioknygos aplanko pavadinimų.<br>Subtitrai turi būti atskirti brūkšniu \"-\"<br>pavyzdžiui, \"Knygos pavadinimas - Čia yra subtitrai\" turi subtitrą \"Čia yra subtitrai\"",
   "LabelSettingsPreferMatchedMetadata": "Pirmenybė atitaikytiems metaduomenis",

--- a/client/strings/nl.json
+++ b/client/strings/nl.json
@@ -466,6 +466,8 @@
   "LabelSettingsHideSingleBookSeriesHelp": "Series die slechts een enkel boek bevatten worden verborgen op de seriespagina en de homepagina-planken.",
   "LabelSettingsHomePageBookshelfView": "Boekenplank-view voor homepagina",
   "LabelSettingsLibraryBookshelfView": "Boekenplank-view voor bibliotheek",
+  "LabelSettingsOnlyShowLaterBooksInContinueSeries": "Skip earlier books in Continue Series",
+  "LabelSettingsOnlyShowLaterBooksInContinueSeriesHelp": "The Continue Series home page shelf shows the first book not started in series that have at least one book finished and no books in progress. Enabling this setting will continue series from the furthest completed book instead of the first book not started.",
   "LabelSettingsParseSubtitles": "Parseer subtitel",
   "LabelSettingsParseSubtitlesHelp": "Haal subtitels uit mapnaam van audioboek.<br>Subtitel moet gescheiden zijn met \" - \"<br>b.v. \"Boektitel - Een Subtitel Hier\" heeft als subtitel \"Een Subtitel Hier\"",
   "LabelSettingsPreferMatchedMetadata": "Prefereer gematchte metadata",

--- a/client/strings/no.json
+++ b/client/strings/no.json
@@ -466,6 +466,8 @@
   "LabelSettingsHideSingleBookSeriesHelp": "Serier som har kun en bok vil bli gjemt på serie- og hjemmeside hyllen.",
   "LabelSettingsHomePageBookshelfView": "Hjemmeside bruk bokhyllevisning",
   "LabelSettingsLibraryBookshelfView": "Bibliotek bruk bokhyllevisning",
+  "LabelSettingsOnlyShowLaterBooksInContinueSeries": "Skip earlier books in Continue Series",
+  "LabelSettingsOnlyShowLaterBooksInContinueSeriesHelp": "The Continue Series home page shelf shows the first book not started in series that have at least one book finished and no books in progress. Enabling this setting will continue series from the furthest completed book instead of the first book not started.",
   "LabelSettingsParseSubtitles": "Analyser undertekster",
   "LabelSettingsParseSubtitlesHelp": "Trekk ut undertekster fra lydbok mappenavn.<br>undertekster må være separert med \" - \"<br>f.eks. \"Boktittel - Undertekst her\" har Undertekst \"Undertekst her\"",
   "LabelSettingsPreferMatchedMetadata": "Foretrekk funnet metadata",

--- a/client/strings/pl.json
+++ b/client/strings/pl.json
@@ -466,6 +466,8 @@
   "LabelSettingsHideSingleBookSeriesHelp": "Series that have a single book will be hidden from the series page and home page shelves.",
   "LabelSettingsHomePageBookshelfView": "Widok półki z książkami na stronie głównej",
   "LabelSettingsLibraryBookshelfView": "Widok półki z książkami na stronie biblioteki",
+  "LabelSettingsOnlyShowLaterBooksInContinueSeries": "Skip earlier books in Continue Series",
+  "LabelSettingsOnlyShowLaterBooksInContinueSeriesHelp": "The Continue Series home page shelf shows the first book not started in series that have at least one book finished and no books in progress. Enabling this setting will continue series from the furthest completed book instead of the first book not started.",
   "LabelSettingsParseSubtitles": "Przetwarzaj podtytuły",
   "LabelSettingsParseSubtitlesHelp": "Opcja pozwala na pobranie podtytułu z nazwy folderu z audiobookiem. <br>Podtytuł musi być rozdzielony za pomocą separatora \" - \"<br>Przykład: \"Book Title - A Subtitle Here\" podtytuł \"A Subtitle Here\"",
   "LabelSettingsPreferMatchedMetadata": "Preferowanie dopasowanych metadanych",

--- a/client/strings/pt-br.json
+++ b/client/strings/pt-br.json
@@ -466,6 +466,8 @@
   "LabelSettingsHideSingleBookSeriesHelp": "Séries com um só livro serão ocultadas na página de séries e na prateleira de séries na página principal.",
   "LabelSettingsHomePageBookshelfView": "Usar visão estante na página principal",
   "LabelSettingsLibraryBookshelfView": "Usar visão estante na página da biblioteca",
+  "LabelSettingsOnlyShowLaterBooksInContinueSeries": "Skip earlier books in Continue Series",
+  "LabelSettingsOnlyShowLaterBooksInContinueSeriesHelp": "The Continue Series home page shelf shows the first book not started in series that have at least one book finished and no books in progress. Enabling this setting will continue series from the furthest completed book instead of the first book not started.",
   "LabelSettingsParseSubtitles": "Analisar subtítulos",
   "LabelSettingsParseSubtitlesHelp": "Extrair subtítulos do nome da pasta do audiobook.<br>Subtítulo deve estar separado por \" - \"<br>ex: \"Título do Livro - Um Subtítulo Aqui\" tem o subtítulo \"Um Subtítulo Aqui\"",
   "LabelSettingsPreferMatchedMetadata": "Preferir metadados consultados",

--- a/client/strings/ru.json
+++ b/client/strings/ru.json
@@ -466,6 +466,8 @@
   "LabelSettingsHideSingleBookSeriesHelp": "Серии, в которых всего одна книга, будут скрыты со страницы серий и полок домашней страницы.",
   "LabelSettingsHomePageBookshelfView": "Вид книжной полки на Домашней странице",
   "LabelSettingsLibraryBookshelfView": "Вид книжной полки в Библиотеке",
+  "LabelSettingsOnlyShowLaterBooksInContinueSeries": "Skip earlier books in Continue Series",
+  "LabelSettingsOnlyShowLaterBooksInContinueSeriesHelp": "The Continue Series home page shelf shows the first book not started in series that have at least one book finished and no books in progress. Enabling this setting will continue series from the furthest completed book instead of the first book not started.",
   "LabelSettingsParseSubtitles": "Разбор подзаголовков",
   "LabelSettingsParseSubtitlesHelp": "Извлечение подзаголовков из имен папок аудиокниг.<br>Подзаголовок должны быть отделен \" - \"<br>например \"Название Книги - Тут Подзаголовок\" подзаголовок будет \"Тут Подзаголовок\"",
   "LabelSettingsPreferMatchedMetadata": "Предпочитать метаданные поиска",

--- a/client/strings/sv.json
+++ b/client/strings/sv.json
@@ -466,6 +466,8 @@
   "LabelSettingsHideSingleBookSeriesHelp": "Serier som har en enda bok kommer att döljas från seriesidan och hyllsidan på startsidan.",
   "LabelSettingsHomePageBookshelfView": "Startsida använd bokhyllvy",
   "LabelSettingsLibraryBookshelfView": "Bibliotek använd bokhyllvy",
+  "LabelSettingsOnlyShowLaterBooksInContinueSeries": "Skip earlier books in Continue Series",
+  "LabelSettingsOnlyShowLaterBooksInContinueSeriesHelp": "The Continue Series home page shelf shows the first book not started in series that have at least one book finished and no books in progress. Enabling this setting will continue series from the furthest completed book instead of the first book not started.",
   "LabelSettingsParseSubtitles": "Analysera undertexter",
   "LabelSettingsParseSubtitlesHelp": "Extrahera undertexter från mappnamn för ljudböcker.<br>Undertext måste vara åtskilda av \" - \"<br>t.ex. \"Boktitel - En undertitel här\" har undertiteln \"En undertitel här\"",
   "LabelSettingsPreferMatchedMetadata": "Föredra matchad metadata",

--- a/client/strings/vi-vn.json
+++ b/client/strings/vi-vn.json
@@ -466,6 +466,8 @@
   "LabelSettingsHideSingleBookSeriesHelp": "Các loạt sách chỉ có một cuốn sách sẽ được ẩn khỏi trang loạt sách và kệ trang chủ.",
   "LabelSettingsHomePageBookshelfView": "Trang chủ sử dụng chế độ xem kệ sách",
   "LabelSettingsLibraryBookshelfView": "Thư viện sử dụng chế độ xem kệ sách",
+  "LabelSettingsOnlyShowLaterBooksInContinueSeries": "Skip earlier books in Continue Series",
+  "LabelSettingsOnlyShowLaterBooksInContinueSeriesHelp": "The Continue Series home page shelf shows the first book not started in series that have at least one book finished and no books in progress. Enabling this setting will continue series from the furthest completed book instead of the first book not started.",
   "LabelSettingsParseSubtitles": "Phân tích phụ đề",
   "LabelSettingsParseSubtitlesHelp": "Trích xuất phụ đề từ tên thư mục sách nói.<br>Phụ đề phải được tách bằng \" - \"<br>i.e. \"Book Title - A Subtitle Here\" có phụ đề \"A Subtitle Here\"",
   "LabelSettingsPreferMatchedMetadata": "Ưu tiên siêu dữ liệu phù hợp",

--- a/client/strings/zh-cn.json
+++ b/client/strings/zh-cn.json
@@ -466,6 +466,8 @@
   "LabelSettingsHideSingleBookSeriesHelp": "只有一本书的系列将从系列页面和主页书架中隐藏.",
   "LabelSettingsHomePageBookshelfView": "首页使用书架视图",
   "LabelSettingsLibraryBookshelfView": "媒体库使用书架视图",
+  "LabelSettingsOnlyShowLaterBooksInContinueSeries": "Skip earlier books in Continue Series",
+  "LabelSettingsOnlyShowLaterBooksInContinueSeriesHelp": "The Continue Series home page shelf shows the first book not started in series that have at least one book finished and no books in progress. Enabling this setting will continue series from the furthest completed book instead of the first book not started.",
   "LabelSettingsParseSubtitles": "解析副标题",
   "LabelSettingsParseSubtitlesHelp": "从有声读物文件夹中提取副标题.<br>副标题必须用 \" - \" 分隔.<br>例: \"书名 - 这里是副标题\" 则显示副标题 \"这里是副标题\"",
   "LabelSettingsPreferMatchedMetadata": "首选匹配的元数据",

--- a/server/models/Library.js
+++ b/server/models/Library.js
@@ -11,6 +11,7 @@ const oldLibrary = require('../objects/Library')
  * @property {string} autoScanCronExpression
  * @property {boolean} audiobooksOnly
  * @property {boolean} hideSingleBookSeries Do not show series that only have 1 book 
+ * @property {boolean} onlyShowLaterBooksInContinueSeries Skip showing books that are earlier than the max sequence read
  * @property {string[]} metadataPrecedence
  */
 

--- a/server/objects/settings/LibrarySettings.js
+++ b/server/objects/settings/LibrarySettings.js
@@ -8,7 +8,8 @@ class LibrarySettings {
     this.skipMatchingMediaWithIsbn = false
     this.autoScanCronExpression = null
     this.audiobooksOnly = false
-    this.hideSingleBookSeries = false // Do not show series that only have 1 book 
+    this.hideSingleBookSeries = false // Do not show series that only have 1 book
+    this.onlyShowLaterBooksInContinueSeries = false // Skip showing books that are earlier than the max sequence read
     this.metadataPrecedence = ['folderStructure', 'audioMetatags', 'nfoFile', 'txtFiles', 'opfFile', 'absMetadata']
     this.podcastSearchRegion = 'us'
 
@@ -25,6 +26,7 @@ class LibrarySettings {
     this.autoScanCronExpression = settings.autoScanCronExpression || null
     this.audiobooksOnly = !!settings.audiobooksOnly
     this.hideSingleBookSeries = !!settings.hideSingleBookSeries
+    this.onlyShowLaterBooksInContinueSeries = !!settings.onlyShowLaterBooksInContinueSeries
     if (settings.metadataPrecedence) {
       this.metadataPrecedence = [...settings.metadataPrecedence]
     } else {
@@ -43,6 +45,7 @@ class LibrarySettings {
       autoScanCronExpression: this.autoScanCronExpression,
       audiobooksOnly: this.audiobooksOnly,
       hideSingleBookSeries: this.hideSingleBookSeries,
+      onlyShowLaterBooksInContinueSeries: this.onlyShowLaterBooksInContinueSeries,
       metadataPrecedence: [...this.metadataPrecedence],
       podcastSearchRegion: this.podcastSearchRegion
     }

--- a/server/utils/queries/libraryFilters.js
+++ b/server/utils/queries/libraryFilters.js
@@ -127,7 +127,7 @@ module.exports = {
    * @returns {object} { libraryItems:LibraryItem[], count:number }
    */
   async getLibraryItemsContinueSeries(library, user, include, limit) {
-    const { libraryItems, count } = await libraryItemsBookFilters.getContinueSeriesLibraryItems(library.id, user, include, limit, 0)
+    const { libraryItems, count } = await libraryItemsBookFilters.getContinueSeriesLibraryItems(library, user, include, limit, 0)
     return {
       libraryItems: libraryItems.map(li => {
         const oldLibraryItem = Database.libraryItemModel.getOldLibraryItem(li).toJSONMinified()

--- a/server/utils/queries/libraryFilters.js
+++ b/server/utils/queries/libraryFilters.js
@@ -75,7 +75,7 @@ module.exports = {
 
   /**
    * Get library items for most recently added shelf
-   * @param {oldLibrary} library 
+   * @param {import('../../objects/Library')} library 
    * @param {oldUser} user 
    * @param {string[]} include 
    * @param {number} limit 
@@ -120,7 +120,7 @@ module.exports = {
 
   /**
    * Get library items for continue series shelf
-   * @param {string} library 
+   * @param {import('../../objects/Library')} library 
    * @param {oldUser} user 
    * @param {string[]} include 
    * @param {number} limit 
@@ -145,7 +145,7 @@ module.exports = {
 
   /**
    * Get library items or podcast episodes for the "Listen Again" and "Read Again" shelf
-   * @param {oldLibrary} library 
+   * @param {import('../../objects/Library')} library 
    * @param {oldUser} user 
    * @param {string[]} include 
    * @param {number} limit 

--- a/server/utils/queries/libraryItemsBookFilters.js
+++ b/server/utils/queries/libraryItemsBookFilters.js
@@ -659,7 +659,7 @@ module.exports = {
       [Sequelize.literal('(SELECT max(mp.updatedAt) FROM bookSeries bs, mediaProgresses mp WHERE mp.mediaItemId = bs.bookId AND mp.userId = :userId AND bs.seriesId = series.id)'), 'recent_progress'],
     ]
     if (library.settings.onlyShowLaterBooksInContinueSeries) {
-      includeAttributes.push([Sequelize.literal('(SELECT CAST(max(bs.sequence) as FLOAT) FROM bookSeries bs, mediaProgresses mp WHERE mp.mediaItemId = bs.bookId AND mp.userId = :userId AND bs.seriesId = series.id)'), 'maxSequence'])
+      includeAttributes.push([Sequelize.literal('(SELECT CAST(max(bs.sequence) as FLOAT) FROM bookSeries bs, mediaProgresses mp WHERE mp.mediaItemId = bs.bookId AND mp.isFinished = 1 AND mp.userId = :userId AND bs.seriesId = series.id)'), 'maxSequence'])
     }
 
     const { rows: series, count } = await Database.seriesModel.findAndCountAll({

--- a/server/utils/queries/libraryItemsBookFilters.js
+++ b/server/utils/queries/libraryItemsBookFilters.js
@@ -633,12 +633,12 @@ module.exports = {
    * 2. Has no books in progress
    * 3. Has at least 1 unfinished book
    * TODO: Reduce queries
-   * @param {string} libraryId 
-   * @param {oldUser} user 
+   * @param {import('../../objects/Library')} library 
+   * @param {import('../../objects/user/User')} user 
    * @param {string[]} include 
    * @param {number} limit 
    * @param {number} offset 
-   * @returns {object} { libraryItems:LibraryItem[], count:number }
+   * @returns {{ libraryItems:import('../../models/LibraryItem')[], count:number }}
    */
   async getContinueSeriesLibraryItems(library, user, include, limit, offset) {
     const libraryId = library.id
@@ -687,7 +687,6 @@ module.exports = {
       },
       replacements: {
         userId: user.id,
-        libraryId: libraryId,
         ...userPermissionBookWhere.replacements
       },
       include: {

--- a/server/utils/queries/libraryItemsBookFilters.js
+++ b/server/utils/queries/libraryItemsBookFilters.js
@@ -739,7 +739,7 @@ module.exports = {
     const libraryItems = series.map(s => {
       if (!s.bookSeries.length) return null // this is only possible if user has restricted books in series
 
-      var bookIndex = 0
+      let bookIndex = 0
       // if the library setting is toggled, only show later entries in series, otherwise skip
       if (library.settings.onlyShowLaterBooksInContinueSeries) {
         bookIndex = s.bookSeries.findIndex(function (b) {


### PR DESCRIPTION
## Issues
Closes https://github.com/advplyr/audiobookshelf/issues/2687 on merge.

## Open questions
* Are there any linting rules I should make sure I follow?
* Did I miss running some script for the other translations?
* Does anyone know of a better name than `onlyShowLaterBooksInContinueSeries` for the setting variable name?
* Does anyone have better copy suggestions for the toggle + info text?

## Pictures
<details>
  <summary>Picture in library, second book read, third up next (first is unread but not next in continue series)</summary>
  <img width="531" alt="image" src="https://github.com/advplyr/audiobookshelf/assets/24991021/6b055588-c7dd-477b-ad8b-961efab4707b">
</details>
<details>
  <summary>Book 2 and 3 read, book 1 still not showing up in Continue Series</summary>
  <img width="632" alt="image" src="https://github.com/advplyr/audiobookshelf/assets/24991021/389f4965-a313-4a70-858d-774d88b1acc6">
</details>
<details>
  <summary>Library settings page</summary>
  <img width="802" alt="image" src="https://github.com/advplyr/audiobookshelf/assets/24991021/ae8a21c8-550b-46b3-b207-a68f7af3d44e">
</details>

