### PR TITLE
fix scroll to the current chapter fail

### DIFF
--- a/client/components/modals/ChaptersModal.vue
+++ b/client/components/modals/ChaptersModal.vue
@@ -36,7 +36,9 @@ export default {
   },
   watch: {
     value(newVal) {
-      this.$nextTick(this.scrollToChapter)
+      setTimeout(() => {
+        this.$nextTick(this.scrollToChapter)
+      },0);
     }
   },
   computed: {


### PR DESCRIPTION
While using `audiobookshelf` in my environment, I encountered an issue where automatic scrolling to the current chapter wasn't functioning. Upon investigation, I discovered that the value of `document.getElementById(chapter-row-${this.currentChapterId})` within the `scrollToChapter()` method was returning null. After adding a `setTimeout`, I observed that the issue was resolved.

As I'm not well-versed in Vue, this solution may not be optimal.

my environment details:
audiobookshelf: 2.8.0
chrome version: 122.0.6261.112