### PR TITLE
Change unit tests workflow to include conditional checkout steps

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Checkout (workflow_dispatch)
         uses: actions/checkout@v4
         with:
-          ref: inputs.ref
+          ref: ${{ inputs.ref }}
         if: github.event_name == 'workflow_dispatch'
 
       - name: Set up Node.js

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -11,13 +11,19 @@ on:
 
 jobs:
   run-unit-tests:
+    name: Run Unit Tests
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout code
+      - name: Checkout (push/pull request)
+        uses: actions/checkout@v4
+        if: github.event_name != 'workflow_dispatch'
+
+      - name: Checkout (workflow_dispatch)
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event_name != 'workflow_dispatch' && github.ref_name || inputs.ref}}
+          ref: inputs.ref
+        if: github.event_name == 'workflow_dispatch'
 
       - name: Set up Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
Separates workflow_dispatch and non-workflow_dispatch checkouts into two separate conditional steps.

The initial workflow in PR #2745 was broken when triggered by pull requests.