### PR TITLE
Fix library files inconsistencies

### DIFF
--- a/server/Logger.js
+++ b/server/Logger.js
@@ -93,7 +93,7 @@ class Logger {
 
     // Save log to file
     if (level >= this.logLevel) {
-      await this.logManager.logToFile(logObj)
+      await this.logManager?.logToFile(logObj)
     }
   }
 

--- a/server/models/LibraryItem.js
+++ b/server/models/LibraryItem.js
@@ -1,4 +1,4 @@
-const { DataTypes, Model, WhereOptions } = require('sequelize')
+const { DataTypes, Model } = require('sequelize')
 const Logger = require('../Logger')
 const oldLibraryItem = require('../objects/LibraryItem')
 const libraryFilters = require('../utils/queries/libraryFilters')
@@ -116,7 +116,7 @@ class LibraryItem extends Model {
 
   /**
    * Currently unused because this is too slow and uses too much mem
-   * @param {[WhereOptions]} where
+   * @param {import('sequelize').WhereOptions} [where]
    * @returns {Array<objects.LibraryItem>} old library items
    */
   static async getAllOldLibraryItems(where = null) {
@@ -773,12 +773,14 @@ class LibraryItem extends Model {
 
   /**
    * 
-   * @param {WhereOptions} where 
+   * @param {import('sequelize').WhereOptions} where 
+   * @param {import('sequelize').BindOrReplacements} replacements
    * @returns {Object} oldLibraryItem
    */
-  static async findOneOld(where) {
+  static async findOneOld(where, replacements = {}) {
     const libraryItem = await this.findOne({
       where,
+      replacements,
       include: [
         {
           model: this.sequelize.models.book,

--- a/server/scanner/LibraryItemScanData.js
+++ b/server/scanner/LibraryItemScanData.js
@@ -4,6 +4,12 @@ const LibraryItem = require('../models/LibraryItem')
 const globals = require('../utils/globals')
 
 class LibraryItemScanData {
+  /**
+   * @typedef LibraryFileModifiedObject
+   * @property {LibraryItem.LibraryFileObject} old
+   * @property {LibraryItem.LibraryFileObject} new
+   */
+
   constructor(data) {
     /** @type {string} */
     this.libraryFolderId = data.libraryFolderId
@@ -39,7 +45,7 @@ class LibraryItemScanData {
     this.libraryFilesRemoved = []
     /** @type {LibraryItem.LibraryFileObject[]} */
     this.libraryFilesAdded = []
-    /** @type {LibraryItem.LibraryFileObject[]} */
+    /** @type {LibraryFileModifiedObject[]} */
     this.libraryFilesModified = []
   }
 
@@ -77,9 +83,9 @@ class LibraryItemScanData {
     return (this.audioLibraryFilesRemoved.length + this.audioLibraryFilesAdded.length + this.audioLibraryFilesModified.length) > 0
   }
 
-  /** @type {LibraryItem.LibraryFileObject[]} */
+  /** @type {LibraryFileModifiedObject[]} */
   get audioLibraryFilesModified() {
-    return this.libraryFilesModified.filter(lf => globals.SupportedAudioTypes.includes(lf.metadata.ext?.slice(1).toLowerCase() || ''))
+    return this.libraryFilesModified.filter(lf => globals.SupportedAudioTypes.includes(lf.old.metadata.ext?.slice(1).toLowerCase() || ''))
   }
 
   /** @type {LibraryItem.LibraryFileObject[]} */
@@ -97,12 +103,42 @@ class LibraryItemScanData {
     return this.libraryFiles.filter(lf => globals.SupportedAudioTypes.includes(lf.metadata.ext?.slice(1).toLowerCase() || ''))
   }
 
+  /** @type {LibraryFileModifiedObject[]} */
+  get imageLibraryFilesModified() {
+    return this.libraryFilesModified.filter(lf => globals.SupportedImageTypes.includes(lf.old.metadata.ext?.slice(1).toLowerCase() || ''))
+  }
+
+  /** @type {LibraryItem.LibraryFileObject[]} */
+  get imageLibraryFilesRemoved() {
+    return this.libraryFilesRemoved.filter(lf => globals.SupportedImageTypes.includes(lf.metadata.ext?.slice(1).toLowerCase() || ''))
+  }
+
+  /** @type {LibraryItem.LibraryFileObject[]} */
+  get imageLibraryFilesAdded() {
+    return this.libraryFilesAdded.filter(lf => globals.SupportedImageTypes.includes(lf.metadata.ext?.slice(1).toLowerCase() || ''))
+  }
+
   /** @type {LibraryItem.LibraryFileObject[]} */
   get imageLibraryFiles() {
     return this.libraryFiles.filter(lf => globals.SupportedImageTypes.includes(lf.metadata.ext?.slice(1).toLowerCase() || ''))
   }
 
-  /** @type {import('../objects/files/LibraryFile')[]} */
+  /** @type {LibraryFileModifiedObject[]} */
+  get ebookLibraryFilesModified() {
+    return this.libraryFilesModified.filter(lf => globals.SupportedEbookTypes.includes(lf.old.metadata.ext?.slice(1).toLowerCase() || ''))
+  }
+
+  /** @type {LibraryItem.LibraryFileObject[]} */
+  get ebookLibraryFilesRemoved() {
+    return this.libraryFilesRemoved.filter(lf => globals.SupportedEbookTypes.includes(lf.metadata.ext?.slice(1).toLowerCase() || ''))
+  }
+
+  /** @type {LibraryItem.LibraryFileObject[]} */
+  get ebookLibraryFilesAdded() {
+    return this.libraryFilesAdded.filter(lf => globals.SupportedEbookTypes.includes(lf.metadata.ext?.slice(1).toLowerCase() || ''))
+  }
+
+  /** @type {LibraryItem.LibraryFileObject[]} */
   get ebookLibraryFiles() {
     return this.libraryFiles.filter(lf => globals.SupportedEbookTypes.includes(lf.metadata.ext?.slice(1).toLowerCase() || ''))
   }
@@ -153,7 +189,7 @@ class LibraryItemScanData {
         existingLibraryItem[key] = this[key]
         this.hasChanges = true
 
-        if (key === 'relPath') {
+        if (key === 'relPath' || key === 'path') {
           this.hasPathChange = true
         }
       }
@@ -202,8 +238,9 @@ class LibraryItemScanData {
         this.hasChanges = true
       } else {
         libraryFilesAdded = libraryFilesAdded.filter(lf => lf !== matchingLibraryFile)
+        let existingLibraryFileBefore = structuredClone(existingLibraryFile)
         if (this.compareUpdateLibraryFile(existingLibraryItem.path, existingLibraryFile, matchingLibraryFile, libraryScan)) {
-          this.libraryFilesModified.push(existingLibraryFile)
+          this.libraryFilesModified.push({old: existingLibraryFileBefore, new: existingLibraryFile})
           this.hasChanges = true
         }
       }

--- a/server/scanner/LibraryItemScanner.js
+++ b/server/scanner/LibraryItemScanner.js
@@ -21,10 +21,10 @@ class LibraryItemScanner {
    * Scan single library item
    * 
    * @param {string} libraryItemId 
-   * @param {{relPath:string, path:string}} [renamedPaths] used by watcher when item folder was renamed
+   * @param {{relPath:string, path:string}} [updateLibraryItemDetails] used by watcher when item folder was renamed
    * @returns {number} ScanResult
    */
-  async scanLibraryItem(libraryItemId, renamedPaths = null) {
+  async scanLibraryItem(libraryItemId, updateLibraryItemDetails = null) {
     // TODO: Add task manager
     const libraryItem = await Database.libraryItemModel.findByPk(libraryItemId)
     if (!libraryItem) {
@@ -32,11 +32,12 @@ class LibraryItemScanner {
       return ScanResult.NOTHING
     }
 
+    const libraryFolderId = updateLibraryItemDetails?.libraryFolderId || libraryItem.libraryFolderId
     const library = await Database.libraryModel.findByPk(libraryItem.libraryId, {
       include: {
         model: Database.libraryFolderModel,
         where: {
-          id: libraryItem.libraryFolderId
+          id: libraryFolderId
         }
       }
     })
@@ -51,9 +52,9 @@ class LibraryItemScanner {
 
     const scanLogger = new ScanLogger()
     scanLogger.verbose = true
-    scanLogger.setData('libraryItem', renamedPaths?.relPath || libraryItem.relPath)
+    scanLogger.setData('libraryItem', updateLibraryItemDetails?.relPath || libraryItem.relPath)
 
-    const libraryItemPath = renamedPaths?.path || fileUtils.filePathToPOSIX(libraryItem.path)
+    const libraryItemPath = updateLibraryItemDetails?.path || fileUtils.filePathToPOSIX(libraryItem.path)
     const folder = library.libraryFolders[0]
     const libraryItemScanData = await this.getLibraryItemScanData(libraryItemPath, library, folder, false)
 

--- a/server/scanner/LibraryItemScanner.js
+++ b/server/scanner/LibraryItemScanner.js
@@ -56,7 +56,7 @@ class LibraryItemScanner {
 
     const libraryItemPath = updateLibraryItemDetails?.path || fileUtils.filePathToPOSIX(libraryItem.path)
     const folder = library.libraryFolders[0]
-    const libraryItemScanData = await this.getLibraryItemScanData(libraryItemPath, library, folder, false)
+    const libraryItemScanData = await this.getLibraryItemScanData(libraryItemPath, library, folder, updateLibraryItemDetails?.isFile || false)
 
     let libraryItemDataUpdated = await libraryItemScanData.checkLibraryItemData(libraryItem, scanLogger)
 

--- a/server/scanner/LibraryScanner.js
+++ b/server/scanner/LibraryScanner.js
@@ -525,7 +525,7 @@ class LibraryScanner {
         path: potentialChildDirs
       })
 
-      let renamedPaths = {}
+      let updatedLibraryItemDetails = {}
       if (!existingLibraryItem) {
         const dirIno = await fileUtils.getIno(fullPath)
         existingLibraryItem = await Database.libraryItemModel.findOneOld({
@@ -536,8 +536,9 @@ class LibraryScanner {
           // Update library item paths for scan
           existingLibraryItem.path = fullPath
           existingLibraryItem.relPath = itemDir
-          renamedPaths.path = fullPath
-          renamedPaths.relPath = itemDir
+          updatedLibraryItemDetails.path = fullPath
+          updatedLibraryItemDetails.relPath = itemDir
+          updatedLibraryItemDetails.libraryFolderId = folder.id
         }
       }
       if (existingLibraryItem) {
@@ -557,7 +558,7 @@ class LibraryScanner {
 
         // Scan library item for updates
         Logger.debug(`[LibraryScanner] Folder update for relative path "${itemDir}" is in library item "${existingLibraryItem.media.metadata.title}" - scan for updates`)
-        itemGroupingResults[itemDir] = await LibraryItemScanner.scanLibraryItem(existingLibraryItem.id, renamedPaths)
+        itemGroupingResults[itemDir] = await LibraryItemScanner.scanLibraryItem(existingLibraryItem.id, updatedLibraryItemDetails)
         continue
       } else if (library.settings.audiobooksOnly && !hasAudioFiles(fileUpdateGroup, itemDir)) {
         Logger.debug(`[LibraryScanner] Folder update for relative path "${itemDir}" has no audio files`)

--- a/server/scanner/LibraryScanner.js
+++ b/server/scanner/LibraryScanner.js
@@ -154,7 +154,11 @@ class LibraryScanner {
       let libraryItemData = libraryItemDataFound.find(lid => lid.path === existingLibraryItem.path)
       if (!libraryItemData) {
         // Fallback to finding matching library item with matching inode value
-        libraryItemData = libraryItemDataFound.find(lid => lid.ino === existingLibraryItem.ino)
+        libraryItemData = libraryItemDataFound.find(lid =>
+          ItemToItemInoMatch(lid, existingLibraryItem) || 
+          ItemToFileInoMatch(lid, existingLibraryItem) || 
+          ItemToFileInoMatch(existingLibraryItem, lid)
+          )
         if (libraryItemData) {
           libraryScan.addLog(LogLevel.INFO, `Library item with path "${existingLibraryItem.path}" was not found, but library item inode "${existingLibraryItem.ino}" was found at path "${libraryItemData.path}"`)
         }
@@ -522,23 +526,25 @@ class LibraryScanner {
 
       // Check if book dir group is already an item
       let existingLibraryItem = await Database.libraryItemModel.findOneOld({
+        libraryId: library.id,
         path: potentialChildDirs
       })
 
       let updatedLibraryItemDetails = {}
       if (!existingLibraryItem) {
-        const dirIno = await fileUtils.getIno(fullPath)
-        existingLibraryItem = await Database.libraryItemModel.findOneOld({
-          ino: dirIno
-        })
+        const isSingleMedia = isSingleMediaFile(fileUpdateGroup, itemDir)
+        existingLibraryItem = 
+          await findLibraryItemByItemToItemInoMatch(library.id, fullPath) || 
+          await findLibraryItemByItemToFileInoMatch(library.id, fullPath, isSingleMedia) ||
+          await findLibraryItemByFileToItemInoMatch(library.id, fullPath, isSingleMedia, fileUpdateGroup[itemDir])
         if (existingLibraryItem) {
-          Logger.debug(`[LibraryScanner] scanFolderUpdates: Library item found by inode value=${dirIno}. "${existingLibraryItem.relPath} => ${itemDir}"`)
           // Update library item paths for scan
           existingLibraryItem.path = fullPath
           existingLibraryItem.relPath = itemDir
           updatedLibraryItemDetails.path = fullPath
           updatedLibraryItemDetails.relPath = itemDir
           updatedLibraryItemDetails.libraryFolderId = folder.id
+          updatedLibraryItemDetails.isFile = isSingleMedia
         }
       }
       if (existingLibraryItem) {
@@ -555,7 +561,6 @@ class LibraryScanner {
             continue
           }
         }
-
         // Scan library item for updates
         Logger.debug(`[LibraryScanner] Folder update for relative path "${itemDir}" is in library item "${existingLibraryItem.media.metadata.title}" - scan for updates`)
         itemGroupingResults[itemDir] = await LibraryItemScanner.scanLibraryItem(existingLibraryItem.id, updatedLibraryItemDetails)
@@ -595,6 +600,14 @@ class LibraryScanner {
 }
 module.exports = new LibraryScanner()
 
+function ItemToFileInoMatch(libraryItem1, libraryItem2) {
+  return libraryItem1.isFile && libraryItem2.libraryFiles.some(lf => lf.ino === libraryItem1.ino)
+}
+
+function ItemToItemInoMatch(libraryItem1, libraryItem2) {
+  return libraryItem1.ino === libraryItem2.ino
+}
+
 function hasAudioFiles(fileUpdateGroup, itemDir) {
   return isSingleMediaFile(fileUpdateGroup, itemDir) ?
     scanUtils.checkFilepathIsAudioFile(fileUpdateGroup[itemDir]) :
@@ -603,4 +616,52 @@ function hasAudioFiles(fileUpdateGroup, itemDir) {
 
 function isSingleMediaFile(fileUpdateGroup, itemDir) {
   return itemDir === fileUpdateGroup[itemDir]
+}
+
+async function findLibraryItemByItemToItemInoMatch(libraryId, fullPath) {
+  const ino = await fileUtils.getIno(fullPath)
+  if (!ino) return null
+  const existingLibraryItem = await Database.libraryItemModel.findOneOld({
+    libraryId: libraryId,
+    ino: ino
+  })
+  if (existingLibraryItem)
+    Logger.debug(`[LibraryScanner] Found library item with matching inode "${ino}" at path "${existingLibraryItem.path}"`)
+  return existingLibraryItem
+}
+
+async function findLibraryItemByItemToFileInoMatch(libraryId, fullPath, isSingleMedia) {  
+  if (!isSingleMedia) return null
+  // check if it was moved from another folder by comparing the ino to the library files
+  const ino = await fileUtils.getIno(fullPath)
+  if (!ino) return null
+  const existingLibraryItem = await Database.libraryItemModel.findOneOld({
+    libraryId: libraryId,
+    libraryFiles: {
+      [ sequelize.Op.substring ]: ino
+    }
+  })
+  if (existingLibraryItem)
+    Logger.debug(`[LibraryScanner] Found library item with a library file matching inode "${ino}" at path "${existingLibraryItem.path}"`)
+  return existingLibraryItem
+}
+
+async function findLibraryItemByFileToItemInoMatch(libraryId, fullPath, isSingleMedia, itemFiles) {
+  if (isSingleMedia) return null
+  // check if it was moved from the root folder by comparing the ino to the ino of the scanned files
+  let itemFileInos = []
+  for (const itemFile of itemFiles) {
+    const ino = await fileUtils.getIno(Path.posix.join(fullPath, itemFile))
+    if (ino) itemFileInos.push(ino)
+  }
+  if (!itemFileInos.length) return null
+  const existingLibraryItem = await Database.libraryItemModel.findOneOld({
+    libraryId: libraryId,
+    ino: {
+      [ sequelize.Op.in ] : itemFileInos
+    }
+  })
+  if (existingLibraryItem)
+    Logger.debug(`[LibraryScanner] Found library item with inode matching one of "${itemFileInos.join(',')}" at path "${existingLibraryItem.path}"`)
+  return existingLibraryItem
 }


### PR DESCRIPTION
Fixes #2686 

After some further investigation, it looks like the code already covers Audio files media updates for modified files, so what I ended up doing was the following:
- Refactored library files properties in LibraryItemScanData
- Used the refactored properties above in BookScanner and PodcastScanner to update media with modified ebook/cover library files
- Fixed another related bug in which libraryFolderId in LibraryItem was also not properly updated when books were moved between different library folders within the same library

To test this, I did a lot of moving of directries between different folders (with audio/ebooks/covers) in the same library ) with watcher on and off (and running library scans when watcher was off). Now everything seems to be working without crashes or errors, and the database records look fine after each move. I'd like to write unit tests, but the code is so complicated that I need to wrap my head around how to do it properly.

Also, I still need to write a db migration script to fix existing corrup records, but I think it's important to check in the logic fixes first because of the nasty crashes and corruptions the current code can potentially create.

