### PR TITLE
I18n script runner

### DIFF
--- a/.github/workflows/i18n-auto-branch.yml
+++ b/.github/workflows/i18n-auto-branch.yml
@@ -1,0 +1,65 @@
+name: Automatic update i18n files
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main # Only care about the main branch, don't care about any PRs or forks
+      - master
+    paths:
+      - client/strings/** # Should only check if any strings changed
+
+jobs:
+  update_translations:
+    runs-on: ubuntu-latest
+    steps:
+      # Check out the repository
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # Set up node to run the javascript
+      - name: Set up node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      # The action runs the `copy_keys.js` script, which copies any unused keys
+      # from the English language file to other language files, and orders each
+      # file by key alphabetically.
+      #
+      # The only argument is the `directory`, which is where the i18n files are
+      # stored.
+      - name: Run Update JSON Files action
+        uses: audiobookshelf/audiobookshelf-i18n-updater@v1.1.1
+        with:
+          directory: "client/strings/" # Adjust the directory path as needed
+
+      # Does a git diff to see if any language files were changed from running
+      # the script. This will be false if the local script was already ran
+      # locally so no changes are needed for the language files.
+      - name: Check diff of strings
+        run: |
+          if git diff --exit-code; then
+            echo "CHANGED=false" >>${GITHUB_ENV}
+          else
+            echo "CHANGED=true" >>${GITHUB_ENV}
+          fi
+      # If changes were detected, create a branch with the changes and open
+      # a PR to `main`. This requires changing the Workflow Permissions
+      # to be "read and write" to create the branch and commit, and then
+      # also need to enable "Allow GitHub actions to create and approve PR"
+      # so the PR can actually be made. Also set up secrets for user email
+      # name if anyone cares about that since it's available in git logs anyway.
+      - name: If changes, commit and open PR
+        if: ${{ env.CHANGED == 'true' }}
+        run: |
+          branch_name="update-strings-$(git log --format=%h -n 1)"
+          git config user.email "${{secrets.USER_EMAIL}}"
+          git config user.name "${{secrets.USER_NAME}}"
+          git checkout -b $branch_name
+          git add .
+          git commit -m "chore: Update strings"
+          git push origin $branch_name
+          gh pr create -B main -H $branch_name --title 'Automatic translation updates' --body 'Created by GH Action. Can be ignored if there are other open translation PRs.'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/i18n-manual-branch.yml
+++ b/.github/workflows/i18n-manual-branch.yml
@@ -1,0 +1,59 @@
+name: Automatic update i18n files
+
+on:
+  workflow_dispatch:
+
+jobs:
+  update_translations:
+    runs-on: ubuntu-latest
+    steps:
+      # Check out the repository
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # Set up node to run the javascript
+      - name: Set up node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      # The action runs the `copy_keys.js` script, which copies any unused keys
+      # from the English language file to other language files, and orders each
+      # file by key alphabetically.
+      #
+      # The only argument is the `directory`, which is where the i18n files are
+      # stored.
+      - name: Run Update JSON Files action
+        uses: audiobookshelf/audiobookshelf-i18n-updater@v1.1.1
+        with:
+          directory: "client/strings/" # Adjust the directory path as needed
+
+      # Does a git diff to see if any language files were changed from running
+      # the script. This will be false if the local script was already ran
+      # locally so no changes are needed for the language files.
+      - name: Check diff of strings
+        run: |
+          if git diff --exit-code; then
+            echo "CHANGED=false" >>${GITHUB_ENV}
+          else
+            echo "CHANGED=true" >>${GITHUB_ENV}
+          fi
+      # If changes were detected, create a branch with the changes and open
+      # a PR to `main`. This requires changing the Workflow Permissions
+      # to be "read and write" to create the branch and commit, and then
+      # also need to enable "Allow GitHub actions to create and approve PR"
+      # so the PR can actually be made. Also set up secrets for user email
+      # name if anyone cares about that since it's available in git logs anyway.
+      - name: If changes, commit and open PR
+        if: ${{ env.CHANGED == 'true' }}
+        run: |
+          branch_name="update-strings-$(git log --format=%h -n 1)"
+          git config user.email "${{secrets.USER_EMAIL}}"
+          git config user.name "${{secrets.USER_NAME}}"
+          git checkout -b $branch_name
+          git add .
+          git commit -m "chore: Update strings"
+          git push origin $branch_name
+          gh pr create -B main -H $branch_name --title 'Automatic translation updates' --body 'Created by GH Action. Can be ignored if there are other open translation PRs.'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/i18n-manual-branch.yml
+++ b/.github/workflows/i18n-manual-branch.yml
@@ -1,4 +1,4 @@
-name: Automatic update i18n files
+name: Manual update i18n files
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
This PR includes 2 new workflows:

- `i18n-auto-branch` which automatically runs the key-copying script on pushes to the main/master branch and opens a branch with the updated files if there were any changes
- `i18n-manual-branch` which can be manually triggered

The branch workflows are identical other than the trigger condition to allow for disabling the automatic workflow without removing the ability to run the manual workflow.

These two workflows will need write access to be able to create the branch and PR. These also require defining the USER_EMAIL and USER_NAME secrets for the git initialization. These values don't necessarily need to be secrets, but felt better to do that instead of just including a default value in the action.

These workflows make use of the https://github.com/audiobookshelf/audiobookshelf-i18n-updater GitHub action. The script this action runs ensures a newline at the end of each i18n file so the last line stops showing up as a change when viewing the diff when the number of lines changes in an i18n file.
