### PR TITLE
Fix custom metadata provider crash

### DIFF
--- a/server/finders/BookFinder.js
+++ b/server/finders/BookFinder.js
@@ -158,7 +158,7 @@ class BookFinder {
    * @returns {Promise<Object[]>}
    */
   async getCustomProviderResults(title, author, isbn, providerSlug) {
-    const books = await this.customProviderAdapter.search(title, author, providerSlug, 'book')
+    const books = await this.customProviderAdapter.search(title, author, isbn, providerSlug, 'book')
     if (this.verbose) Logger.debug(`Custom provider '${providerSlug}' Search Results: ${books.length || 0}`)
 
     return books


### PR DESCRIPTION
The method `search(title, author, isbn, providerSlug, mediaType)` (`CustomProviderAdapter#17`) expects five arguments but only receives four. This causes a crash because no custom metadata provider `book` (passed as forth argument, not fifth) does exist