### PR TITLE
Workflow to dispatch an ABS windows event on server release

### DIFF
--- a/.github/workflows/notify-abs-windows.yml
+++ b/.github/workflows/notify-abs-windows.yml
@@ -1,0 +1,17 @@
+name: Dispatch an abs-windows event
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  abs-windows-dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send a remote repository dispatch event
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.ABS_WINDOWS_PAT }}
+          repository: mikiher/audiobookshelf-windows
+          event-type: build-windows

--- a/.github/workflows/notify-abs-windows.yml
+++ b/.github/workflows/notify-abs-windows.yml
@@ -4,6 +4,8 @@ on:
   release:
     types: [published]
   workflow_dispatch:
+  pull_request:
+    types: [opened]
 
 jobs:
   abs-windows-dispatch:

--- a/.github/workflows/notify-abs-windows.yml
+++ b/.github/workflows/notify-abs-windows.yml
@@ -4,8 +4,6 @@ on:
   release:
     types: [published]
   workflow_dispatch:
-  pull_request:
-    types: [opened]
 
 jobs:
   abs-windows-dispatch:


### PR DESCRIPTION
This workflow dispatches an event to the windows repository (mikiher/audiobokshelf-windows) when a new server release is published. 

The event triggers a [workflow](https://github.com/mikiher/audiobookshelf-windows/blob/d187b3de24c2ab7b5e095f131e3d59b66c0ca657/.github/workflows/build-installer.yml#L4) on the windows repository that builds a new windows installer with the latest server release, and creates a draft release for it (this was done manually up until now).

In order for it to work, you'll need to add a secret in the server repository named ABS_WINDOWS_PAT, which will contain the private access token needed to dispatch the event. I sent the token to you in a Discord PM.