### PR TITLE
Separator between multiple series

### DIFF
--- a/client/pages/item/_id/index.vue
+++ b/client/pages/item/_id/index.vue
@@ -34,7 +34,10 @@
 
               <p v-if="bookSubtitle" class="text-gray-200 text-xl md:text-2xl">{{ bookSubtitle }}</p>
 
-              <nuxt-link v-for="_series in seriesList" :key="_series.id" :to="`/library/${libraryId}/series/${_series.id}`" class="hover:underline font-sans text-gray-300 text-lg leading-7"> {{ _series.text }}</nuxt-link>
+              <nuxt-link v-for="(_series, index) in seriesList" :key="_series.id" :to="`/library/${libraryId}/series/${_series.id}`" class="hover:underline font-sans text-gray-300 text-lg leading-7">
+                {{ _series.text
+                }}<span v-if="index < seriesList.length - 1">, </span>
+              </nuxt-link>
 
               <template v-if="!isVideo">
                 <p v-if="isPodcast" class="mb-2 mt-0.5 text-gray-200 text-lg md:text-xl">by {{ podcastAuthor || 'Unknown' }}</p>

--- a/client/pages/item/_id/index.vue
+++ b/client/pages/item/_id/index.vue
@@ -34,10 +34,10 @@
 
               <p v-if="bookSubtitle" class="text-gray-200 text-xl md:text-2xl">{{ bookSubtitle }}</p>
 
-              <nuxt-link v-for="(_series, index) in seriesList" :key="_series.id" :to="`/library/${libraryId}/series/${_series.id}`" class="hover:underline font-sans text-gray-300 text-lg leading-7">
-                {{ _series.text
-                }}<span v-if="index < seriesList.length - 1">, </span>
-              </nuxt-link>
+              <template v-for="(_series, index) in seriesList">
+                <nuxt-link :key="_series.id" :to="`/library/${libraryId}/series/${_series.id}`" class="hover:underline font-sans text-gray-300 text-lg leading-7">{{ _series.text }}</nuxt-link
+                ><span :key="index" v-if="index < seriesList.length - 1">, </span>
+              </template>
 
               <template v-if="!isVideo">
                 <p v-if="isPodcast" class="mb-2 mt-0.5 text-gray-200 text-lg md:text-xl">by {{ podcastAuthor || 'Unknown' }}</p>


### PR DESCRIPTION
If a book is part of multiple series, this patch adds a separator between the series on the library item details page. With no separator, it is not immediately clear that they are separate series.

![Screenshot from 2024-04-04 21-52-11](https://github.com/advplyr/audiobookshelf/assets/1008395/098bae90-cd92-48c3-961d-ecce04271fbd)
