### PR TITLE
Tweaks to custom metadata provider schema

### DIFF
--- a/custom-metadata-provider-specification.yaml
+++ b/custom-metadata-provider-specification.yaml
@@ -1,15 +1,16 @@
 openapi: 3.0.0
-servers: 
+
+servers:
   - url: https://example.com
-    description: Local server 
+    description: Local server
+
 info:
-  license: 
+  title: Custom Metadata Provider
+  version: 0.1.0
+  license:
     name: MIT
     url: https://opensource.org/licenses/MIT
 
-    
-  title: Custom Metadata Provider
-  version: 0.1.0
 security:
   - api_key: []
 
@@ -19,8 +20,9 @@ paths:
       description: Search for books
       operationId: search
       summary: Search for books
-      security: 
-        -  api_key: []
+      security:
+        - api_key: []
+
       parameters:
         - name: query
           in: query
@@ -32,6 +34,7 @@ paths:
           required: false
           schema:
             type: string
+
       responses:
         "200":
           description: OK
@@ -72,9 +75,17 @@ paths:
                   error:
                     type: string
 components:
+  securitySchemes:
+    api_key:
+      type: apiKey
+      name: AUTHORIZATION
+      in: header
+
   schemas:
     BookMetadata:
       type: object
+      required:
+        - title
       properties:
         title:
           type: string
@@ -110,26 +121,20 @@ components:
         series:
           type: array
           items:
-            type: object
-            properties:
-              series:
-                type: string
-                required: true
-              sequence:
-                type: number
-                format: int64
+            $ref: "#/components/schemas/SeriesMetadata"
         language:
           type: string
         duration:
-          type: number
+          type: integer
           format: int64
           description: Duration in seconds
-      required: 
-        -  title
-  securitySchemes:
-    api_key:
-      type: apiKey
-      name: AUTHORIZATION
-      in: header
-        
-          
+
+    SeriesMetadata:
+      type: object
+      required:
+        - series
+      properties:
+        series:
+          type: string
+        sequence:
+          type: string


### PR DESCRIPTION
When developing my [custom metadata provider](https://github.com/ahobsonsayers/abs-tract), I noticed a couple of issues with the provider schema that I thought I would fix. I also did a bit of minor tidy up (I hope this is ok, If not let me know and I will revert!)

Schema changes:
- `duration` type should be an integer not a number
- I have split out `SeriesMetadata` to its own component, as this will generate its own type for those who use generators with the schema, instead of nested anonymous objects.
- `series` under SeriesMetadata being required was specified in the incorrect way using `required: <bool>` instead of `required: <property array>`
- `sequence` under SeriesMetadata should not be a number, it should be a string to allow for sequences like `0.5`, `1-3` and `1,3,5`

Let me know if there is any changes you would like me to make!