### PR TITLE
Split the author call in the library stats page to 2 lighter functions

### DIFF
--- a/server/controllers/LibraryController.js
+++ b/server/controllers/LibraryController.js
@@ -610,7 +610,7 @@ class LibraryController {
       const bookStats = await libraryItemsBookFilters.getBookLibraryStats(req.library.id)
       const longestBooks = await libraryItemsBookFilters.getLongestBooks(req.library.id, 10)
 
-      stats.totalAuthors = authors.length
+      stats.totalAuthors = await authorFilters.getAuthorsTotalCount(req.library.id)
       stats.authorsWithCount = authors
       stats.totalGenres = genres.length
       stats.genresWithCount = genres

--- a/server/controllers/LibraryController.js
+++ b/server/controllers/LibraryController.js
@@ -605,7 +605,7 @@ class LibraryController {
     }
 
     if (req.library.isBook) {
-      const authors = await authorFilters.getAuthorsWithCount(req.library.id)
+      const authors = await authorFilters.getAuthorsWithCount(req.library.id, 10)
       const genres = await libraryItemsBookFilters.getGenresWithCount(req.library.id)
       const bookStats = await libraryItemsBookFilters.getBookLibraryStats(req.library.id)
       const longestBooks = await libraryItemsBookFilters.getLongestBooks(req.library.id, 10)

--- a/server/utils/queries/authorFilters.js
+++ b/server/utils/queries/authorFilters.js
@@ -5,7 +5,7 @@ module.exports = {
   /**
    * Get authors total count
    * @param {string} libraryId
-   * @returns {{id:string, name:string, count:number}}
+   * @returns {number} count
    */
   async getAuthorsTotalCount(libraryId) {
     const authorsCount = await Database.authorModel.count({
@@ -19,9 +19,10 @@ module.exports = {
   /**
    * Get authors with count of num books
    * @param {string} libraryId 
+   * @param {number} limit 
    * @returns {{id:string, name:string, count:number}}
    */
-  async getAuthorsWithCount(libraryId) {
+  async getAuthorsWithCount(libraryId, limit) {
     const authors = await Database.bookAuthorModel.findAll({
       include: [{
         model: Database.authorModel,
@@ -37,7 +38,7 @@ module.exports = {
       ],
       group: ['authorId', 'author.id'], // Include 'author.id' to satisfy GROUP BY with JOIN
       order: [[Sequelize.literal('count'), 'DESC']],
-      limit: 10
+      limit: limit
     })
     return authors.map(au => {
       return {


### PR DESCRIPTION
Currently on the library stats page, the function getAuthorsWithCount() is called to get both the top 10 authors by number of books, and also the total number of authors in that library. It does this by querying for all authors and every related book. In a library of 30k authors, this query takes `567038ms`  or around 10 minutes.

This has been split into 2 calls - getAuthorsTotalCount() gets the total number of authors in the library in `1ms` and getAuthorsWithCount() only grabs the top 10 authors by number of books written in `35ms`. These values will vary based n the number of books in the library, but it represents a significant speed increase.

The results displayed on the stats page should be identical after the change.