### PR TITLE
Book match tab update

### DIFF
--- a/client/components/modals/item/tabs/Match.vue
+++ b/client/components/modals/item/tabs/Match.vue
@@ -40,14 +40,14 @@
             <ui-text-input-with-label v-model="selectedMatch.cover" :disabled="!selectedMatchUsage.cover" readonly :label="$strings.LabelCover" class="flex-grow mx-4" />
           </div>
 
-          <div class="flex py-2">
+          <div class="flex py-2" style="margin-right: 2px">
             <div>
               <p class="text-center text-gray-200">New</p>
               <a :href="selectedMatch.cover" target="_blank" class="bg-primary">
                 <covers-preview-cover :src="selectedMatch.cover" :width="100" :book-cover-aspect-ratio="bookCoverAspectRatio" />
               </a>
             </div>
-            <div v-if="media.coverPath">
+            <div v-if="media.coverPath" style="margin-left: 2px">
               <p class="text-center text-gray-200">Current</p>
               <a :href="$store.getters['globals/getLibraryItemCoverSrc'](libraryItem, null, true)" target="_blank" class="bg-primary">
                 <covers-preview-cover :src="$store.getters['globals/getLibraryItemCoverSrc'](libraryItem, null, true)" :width="100" :book-cover-aspect-ratio="bookCoverAspectRatio" />

--- a/client/components/modals/item/tabs/Match.vue
+++ b/client/components/modals/item/tabs/Match.vue
@@ -40,14 +40,14 @@
             <ui-text-input-with-label v-model="selectedMatch.cover" :disabled="!selectedMatchUsage.cover" readonly :label="$strings.LabelCover" class="flex-grow mx-4" />
           </div>
 
-          <div class="flex py-2" style="margin-right: 2px">
+          <div class="flex py-2">
             <div>
               <p class="text-center text-gray-200">New</p>
               <a :href="selectedMatch.cover" target="_blank" class="bg-primary">
                 <covers-preview-cover :src="selectedMatch.cover" :width="100" :book-cover-aspect-ratio="bookCoverAspectRatio" />
               </a>
             </div>
-            <div v-if="media.coverPath" style="margin-left: 2px">
+            <div v-if="media.coverPath" class="ml-0.5">
               <p class="text-center text-gray-200">Current</p>
               <a :href="$store.getters['globals/getLibraryItemCoverSrc'](libraryItem, null, true)" target="_blank" class="bg-primary">
                 <covers-preview-cover :src="$store.getters['globals/getLibraryItemCoverSrc'](libraryItem, null, true)" :width="100" :book-cover-aspect-ratio="bookCoverAspectRatio" />

--- a/client/components/modals/item/tabs/Match.vue
+++ b/client/components/modals/item/tabs/Match.vue
@@ -32,7 +32,7 @@
         </div>
         <p class="text-xl pl-3">{{ $strings.HeaderUpdateDetails }}</p>
       </div>
-      <ui-checkbox v-model="selectAll" checkbox-bg="bg" @input="selectAllToggled" />
+      <ui-checkbox v-model="selectAll" :label="$strings.LabelSelectAll" checkbox-bg="bg" @input="selectAllToggled" />
       <form @submit.prevent="submitMatchUpdate">
         <div v-if="selectedMatchOrig.cover" class="flex flex-wrap md:flex-nowrap items-center justify-center">
           <div class="flex flex-grow items-center py-2">

--- a/client/strings/bn.json
+++ b/client/strings/bn.json
@@ -439,6 +439,7 @@
   "LabelSearchTitle": "অনুসন্ধান শিরোনাম",
   "LabelSearchTitleOrASIN": "অনুসন্ধান শিরোনাম বা ASIN",
   "LabelSeason": "সেশন",
+  "LabelSelectAll": "Select all",
   "LabelSelectAllEpisodes": "সমস্ত পর্ব নির্বাচন করুন",
   "LabelSelectEpisodesShowing": "দেখানো {0}টি পর্ব নির্বাচন করুন",
   "LabelSelectUsers": "ব্যবহারকারী নির্বাচন করুন",

--- a/client/strings/cs.json
+++ b/client/strings/cs.json
@@ -439,6 +439,7 @@
   "LabelSearchTitle": "Vyhledat název",
   "LabelSearchTitleOrASIN": "Vyhledat název nebo ASIN",
   "LabelSeason": "Sezóna",
+  "LabelSelectAll": "Select all",
   "LabelSelectAllEpisodes": "Vybrat všechny epizody",
   "LabelSelectEpisodesShowing": "Vyberte {0} epizody, které se zobrazují",
   "LabelSelectUsers": "Vybrat uživatele",

--- a/client/strings/da.json
+++ b/client/strings/da.json
@@ -439,6 +439,7 @@
   "LabelSearchTitle": "Søg efter titel",
   "LabelSearchTitleOrASIN": "Søg efter titel eller ASIN",
   "LabelSeason": "Sæson",
+  "LabelSelectAll": "Select all",
   "LabelSelectAllEpisodes": "Vælg alle episoder",
   "LabelSelectEpisodesShowing": "Vælg {0} episoder vist",
   "LabelSelectUsers": "Select users",

--- a/client/strings/de.json
+++ b/client/strings/de.json
@@ -439,6 +439,7 @@
   "LabelSearchTitle": "Titel suchen",
   "LabelSearchTitleOrASIN": "Titel oder ASIN suchen",
   "LabelSeason": "Staffel",
+  "LabelSelectAll": "Select all",
   "LabelSelectAllEpisodes": "Alle Episoden auswählen",
   "LabelSelectEpisodesShowing": "{0} ausgewählte Episoden werden angezeigt",
   "LabelSelectUsers": "Benutzer auswählen",

--- a/client/strings/en-us.json
+++ b/client/strings/en-us.json
@@ -439,6 +439,7 @@
   "LabelSearchTitle": "Search Title",
   "LabelSearchTitleOrASIN": "Search Title or ASIN",
   "LabelSeason": "Season",
+  "LabelSelectAll": "Select all",
   "LabelSelectAllEpisodes": "Select all episodes",
   "LabelSelectEpisodesShowing": "Select {0} episodes showing",
   "LabelSelectUsers": "Select users",

--- a/client/strings/es.json
+++ b/client/strings/es.json
@@ -439,6 +439,7 @@
   "LabelSearchTitle": "Buscar Titulo",
   "LabelSearchTitleOrASIN": "Buscar Título o ASIN",
   "LabelSeason": "Temporada",
+  "LabelSelectAll": "Select all",
   "LabelSelectAllEpisodes": "Seleccionar todos los episodios",
   "LabelSelectEpisodesShowing": "Seleccionar los {0} episodios visibles",
   "LabelSelectUsers": "Seleccionar usuarios",

--- a/client/strings/et.json
+++ b/client/strings/et.json
@@ -439,6 +439,7 @@
   "LabelSearchTitle": "Otsi pealkirja",
   "LabelSearchTitleOrASIN": "Otsi pealkirja või ASIN-i",
   "LabelSeason": "Hooaeg",
+  "LabelSelectAll": "Select all",
   "LabelSelectAllEpisodes": "Vali kõik episoodid",
   "LabelSelectEpisodesShowing": "Valige {0} näidatavat episoodi",
   "LabelSelectUsers": "Valige kasutajad",

--- a/client/strings/fr.json
+++ b/client/strings/fr.json
@@ -439,6 +439,7 @@
   "LabelSearchTitle": "Titre de recherche",
   "LabelSearchTitleOrASIN": "Recherche du titre ou ASIN",
   "LabelSeason": "Saison",
+  "LabelSelectAll": "Select all",
   "LabelSelectAllEpisodes": "Sélectionner tous les épisodes",
   "LabelSelectEpisodesShowing": "Sélectionner {0} episode(s) en cours",
   "LabelSelectUsers": "Sélectionner les utilisateurs",

--- a/client/strings/gu.json
+++ b/client/strings/gu.json
@@ -439,6 +439,7 @@
   "LabelSearchTitle": "Search Title",
   "LabelSearchTitleOrASIN": "Search Title or ASIN",
   "LabelSeason": "Season",
+  "LabelSelectAll": "Select all",
   "LabelSelectAllEpisodes": "Select all episodes",
   "LabelSelectEpisodesShowing": "Select {0} episodes showing",
   "LabelSelectUsers": "Select users",

--- a/client/strings/he.json
+++ b/client/strings/he.json
@@ -439,6 +439,7 @@
   "LabelSearchTitle": "כותרת חיפוש",
   "LabelSearchTitleOrASIN": "כותרת חיפוש או ASIN",
   "LabelSeason": "עונה",
+  "LabelSelectAll": "Select all",
   "LabelSelectAllEpisodes": "בחר את כל הפרקים",
   "LabelSelectEpisodesShowing": "בחר {0} פרקים המוצגים",
   "LabelSelectUsers": "בחר משתמשים",

--- a/client/strings/hi.json
+++ b/client/strings/hi.json
@@ -439,6 +439,7 @@
   "LabelSearchTitle": "Search Title",
   "LabelSearchTitleOrASIN": "Search Title or ASIN",
   "LabelSeason": "Season",
+  "LabelSelectAll": "Select all",
   "LabelSelectAllEpisodes": "Select all episodes",
   "LabelSelectEpisodesShowing": "Select {0} episodes showing",
   "LabelSelectUsers": "Select users",

--- a/client/strings/hr.json
+++ b/client/strings/hr.json
@@ -439,6 +439,7 @@
   "LabelSearchTitle": "Traži naslov",
   "LabelSearchTitleOrASIN": "Traži naslov ili ASIN",
   "LabelSeason": "Sezona",
+  "LabelSelectAll": "Select all",
   "LabelSelectAllEpisodes": "Select all episodes",
   "LabelSelectEpisodesShowing": "Select {0} episodes showing",
   "LabelSelectUsers": "Select users",

--- a/client/strings/hu.json
+++ b/client/strings/hu.json
@@ -439,6 +439,7 @@
   "LabelSearchTitle": "Cím keresése",
   "LabelSearchTitleOrASIN": "Cím vagy ASIN keresése",
   "LabelSeason": "Évad",
+  "LabelSelectAll": "Select all",
   "LabelSelectAllEpisodes": "Összes epizód kiválasztása",
   "LabelSelectEpisodesShowing": "Kiválasztás {0} megjelenített epizód",
   "LabelSelectUsers": "Felhasználók kiválasztása",

--- a/client/strings/it.json
+++ b/client/strings/it.json
@@ -439,6 +439,7 @@
   "LabelSearchTitle": "Cerca Titolo",
   "LabelSearchTitleOrASIN": "Cerca titolo o ASIN",
   "LabelSeason": "Stagione",
+  "LabelSelectAll": "Select all",
   "LabelSelectAllEpisodes": "Seleziona tutti gli Episodi",
   "LabelSelectEpisodesShowing": "Episodi {0} selezionati ",
   "LabelSelectUsers": "Selezione Utenti",

--- a/client/strings/lt.json
+++ b/client/strings/lt.json
@@ -439,6 +439,7 @@
   "LabelSearchTitle": "Ieškoti pavadinimo",
   "LabelSearchTitleOrASIN": "Ieškoti pavadinimo arba ASIN",
   "LabelSeason": "Sezonas",
+  "LabelSelectAll": "Select all",
   "LabelSelectAllEpisodes": "Pažymėti visus epizodus",
   "LabelSelectEpisodesShowing": "Pažymėti {0} rodomus epizodus",
   "LabelSelectUsers": "Select users",

--- a/client/strings/nl.json
+++ b/client/strings/nl.json
@@ -439,6 +439,7 @@
   "LabelSearchTitle": "Zoek titel",
   "LabelSearchTitleOrASIN": "Zoek titel of ASIN",
   "LabelSeason": "Seizoen",
+  "LabelSelectAll": "Select all",
   "LabelSelectAllEpisodes": "Selecteer alle afleveringen",
   "LabelSelectEpisodesShowing": "Selecteer {0} afleveringen laten zien",
   "LabelSelectUsers": "Select users",

--- a/client/strings/no.json
+++ b/client/strings/no.json
@@ -439,6 +439,7 @@
   "LabelSearchTitle": "Søk tittel",
   "LabelSearchTitleOrASIN": "Søk tittel eller ASIN",
   "LabelSeason": "Sesong",
+  "LabelSelectAll": "Select all",
   "LabelSelectAllEpisodes": "Velg alle episoder",
   "LabelSelectEpisodesShowing": "Velg {0} episoder vist",
   "LabelSelectUsers": "Select users",

--- a/client/strings/pl.json
+++ b/client/strings/pl.json
@@ -439,6 +439,7 @@
   "LabelSearchTitle": "Wyszukaj tytuł",
   "LabelSearchTitleOrASIN": "Szukaj tytuł lub ASIN",
   "LabelSeason": "Sezon",
+  "LabelSelectAll": "Select all",
   "LabelSelectAllEpisodes": "Select all episodes",
   "LabelSelectEpisodesShowing": "Select {0} episodes showing",
   "LabelSelectUsers": "Select users",

--- a/client/strings/pt-br.json
+++ b/client/strings/pt-br.json
@@ -439,6 +439,7 @@
   "LabelSearchTitle": "Busca por Título",
   "LabelSearchTitleOrASIN": "Busca por Título ou ASIN",
   "LabelSeason": "Temporada",
+  "LabelSelectAll": "Select all",
   "LabelSelectAllEpisodes": "Selecionar todos os Episódios",
   "LabelSelectEpisodesShowing": "Selecionar os {0} Episódios Visíveis",
   "LabelSelectUsers": "Selecionar usuários",

--- a/client/strings/ru.json
+++ b/client/strings/ru.json
@@ -439,6 +439,7 @@
   "LabelSearchTitle": "Поиск по названию",
   "LabelSearchTitleOrASIN": "Поиск по названию или ASIN",
   "LabelSeason": "Сезон",
+  "LabelSelectAll": "Select all",
   "LabelSelectAllEpisodes": "Выбрать все эпизоды",
   "LabelSelectEpisodesShowing": "Выберите {0} эпизодов для показа",
   "LabelSelectUsers": "Select users",

--- a/client/strings/sv.json
+++ b/client/strings/sv.json
@@ -439,6 +439,7 @@
   "LabelSearchTitle": "Sök titel",
   "LabelSearchTitleOrASIN": "Sök titel eller ASIN",
   "LabelSeason": "Säsong",
+  "LabelSelectAll": "Select all",
   "LabelSelectAllEpisodes": "Välj alla avsnitt",
   "LabelSelectEpisodesShowing": "Välj {0} avsnitt som visas",
   "LabelSelectUsers": "Välj användare",

--- a/client/strings/uk.json
+++ b/client/strings/uk.json
@@ -439,6 +439,7 @@
   "LabelSearchTitle": "Пошук за назвою",
   "LabelSearchTitleOrASIN": "Пошук назви або ASIN",
   "LabelSeason": "Сезон",
+  "LabelSelectAll": "Select all",
   "LabelSelectAllEpisodes": "Вибрати всі серії",
   "LabelSelectEpisodesShowing": "Обрати показані епізоди: {0}",
   "LabelSelectUsers": "Вибрати користувачів",

--- a/client/strings/vi-vn.json
+++ b/client/strings/vi-vn.json
@@ -439,6 +439,7 @@
   "LabelSearchTitle": "Tìm kiếm Tiêu đề",
   "LabelSearchTitleOrASIN": "Tìm kiếm Tiêu đề hoặc ASIN",
   "LabelSeason": "Mùa",
+  "LabelSelectAll": "Select all",
   "LabelSelectAllEpisodes": "Chọn tất cả các tập",
   "LabelSelectEpisodesShowing": "Chọn {0} tập đang hiển thị",
   "LabelSelectUsers": "Chọn người dùng",

--- a/client/strings/zh-cn.json
+++ b/client/strings/zh-cn.json
@@ -439,6 +439,7 @@
   "LabelSearchTitle": "搜索标题",
   "LabelSearchTitleOrASIN": "搜索标题或 ASIN",
   "LabelSeason": "季",
+  "LabelSelectAll": "Select all",
   "LabelSelectAllEpisodes": "选择所有剧集",
   "LabelSelectEpisodesShowing": "选择正在播放的 {0} 剧集",
   "LabelSelectUsers": "选择用户",

--- a/client/strings/zh-tw.json
+++ b/client/strings/zh-tw.json
@@ -439,6 +439,7 @@
   "LabelSearchTitle": "搜尋標題",
   "LabelSearchTitleOrASIN": "搜尋標題或 ASIN",
   "LabelSeason": "季",
+  "LabelSelectAll": "Select all",
   "LabelSelectAllEpisodes": "選擇所有劇集",
   "LabelSelectEpisodesShowing": "選擇正在播放的 {0} 劇集",
   "LabelSelectUsers": "Select users",


### PR DESCRIPTION
This PR fixes https://github.com/advplyr/audiobookshelf/issues/2889.

Adds 4 pixels in between the two cover images, and adds "Select All" translatable text for the top checkbox.

![image](https://github.com/advplyr/audiobookshelf/assets/5686638/2f12f128-522b-465a-abc7-bc663d586575)
