### PR TITLE
Time picker cleanup

### DIFF
--- a/client/components/ui/TimePicker.vue
+++ b/client/components/ui/TimePicker.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="relative">
+  <div tabindex="0" @focus="focusDigit('second0')" class="relative">
     <div class="rounded text-gray-200 border w-full px-3 py-2" :class="focusedDigit ? 'bg-primary bg-opacity-50 border-gray-300' : 'bg-primary border-gray-600'" @click="clickInput" v-click-outside="clickOutsideObj">
       <div class="flex items-center">
         <template v-for="(digit, index) in digitDisplay">

--- a/client/components/ui/TimePicker.vue
+++ b/client/components/ui/TimePicker.vue
@@ -1,5 +1,5 @@
 <template>
-  <div tabindex="0" @focus="focusDigit('second0')" class="relative">
+  <div type="text" readonly tabindex="0" @focus="focusDigit('second0')" class="relative">
     <div class="rounded text-gray-200 border w-full px-3 py-2" :class="focusedDigit ? 'bg-primary bg-opacity-50 border-gray-300' : 'bg-primary border-gray-600'" @click="clickInput" v-click-outside="clickOutsideObj">
       <div class="flex items-center">
         <template v-for="(digit, index) in digitDisplay">

--- a/client/components/ui/TimePicker.vue
+++ b/client/components/ui/TimePicker.vue
@@ -1,5 +1,5 @@
 <template>
-  <div type="text" readonly tabindex="0" @focus="focusDigit('second0')" class="relative">
+  <div tabindex="0" @focus="focusDigit('second0')" class="relative">
     <div class="rounded text-gray-200 border w-full px-3 py-2" :class="focusedDigit ? 'bg-primary bg-opacity-50 border-gray-300' : 'bg-primary border-gray-600'" @click="clickInput" v-click-outside="clickOutsideObj">
       <div class="flex items-center">
         <template v-for="(digit, index) in digitDisplay">

--- a/client/components/ui/TimePicker.vue
+++ b/client/components/ui/TimePicker.vue
@@ -174,7 +174,7 @@ export default {
         return this.increaseFocused()
       } else if (evt.key === 'ArrowDown') {
         return this.decreaseFocused()
-      } else if (evt.key === 'Enter' || evt.key === 'Escape') {
+      } else if (evt.key === 'Enter' || evt.key === 'Escape' || evt.key === 'Tab') {
         return this.removeFocus()
       }
 


### PR DESCRIPTION
Fixes https://github.com/advplyr/audiobookshelf/issues/2685

Original behavior was that the TimePicker.vue template was not targetable by a tab. I added a tab target and set the ones place of the seconds to be the default starting point. Currently, users can also tab out of the TimePicker and be focused on two elements, so that is also fixed in this PR.

Original behavior:

https://github.com/advplyr/audiobookshelf/assets/5686638/963ced40-ab9f-46d4-9042-8d1b35d83424


New behavior:

https://github.com/advplyr/audiobookshelf/assets/5686638/b352e903-503e-4715-934c-7ca377c1267d





