### PR TITLE
Users can edit playlist in UI

### DIFF
--- a/client/components/tables/playlist/ItemTableRow.vue
+++ b/client/components/tables/playlist/ItemTableRow.vue
@@ -38,7 +38,7 @@
         <div v-if="userCanUpdate" class="mx-1" :class="isHovering ? '' : 'ml-6'">
           <ui-icon-btn icon="edit" borderless @click="clickEdit" />
         </div>
-        <div v-if="userCanDelete" class="mx-1">
+        <div class="mx-1" :class="isHovering ? '' : 'ml-6'">
           <ui-icon-btn icon="close" borderless @click="removeClick" />
         </div>
       </div>
@@ -75,8 +75,7 @@ export default {
   },
   computed: {
     translateDistance() {
-      if (!this.userCanUpdate && !this.userCanDelete) return 'translate-x-0'
-      else if (!this.userCanUpdate || !this.userCanDelete) return '-translate-x-12'
+      if (!this.userCanUpdate) return '-translate-x-12'
       return '-translate-x-24'
     },
     libraryItem() {

--- a/client/pages/playlist/_id.vue
+++ b/client/pages/playlist/_id.vue
@@ -19,9 +19,9 @@
               {{ streaming ? $strings.ButtonPlaying : $strings.ButtonPlay }}
             </ui-btn>
 
-            <ui-icon-btn v-if="userCanUpdate" icon="edit" class="mx-0.5" @click="editClick" />
+            <ui-icon-btn icon="edit" class="mx-0.5" @click="editClick" />
 
-            <ui-icon-btn v-if="userCanDelete" icon="delete" class="mx-0.5" @click="removeClick" />
+            <ui-icon-btn icon="delete" class="mx-0.5" @click="removeClick" />
           </div>
 
           <div class="my-8 max-w-2xl">


### PR DESCRIPTION
Fixes: https://github.com/advplyr/audiobookshelf/issues/3016

Do not hide the "edit" or "delete" key on the playlist page even if users do not have "Can Update" permission because they are private structures, so editing does not affect other users.

User without edit permissions view:
![image](https://github.com/advplyr/audiobookshelf/assets/5686638/e1307f29-5f0a-4b8c-95b3-97a8c4e0ef11)
