### PR TITLE
Fix ssrfFilter url

### DIFF
--- a/server/utils/fileUtils.js
+++ b/server/utils/fileUtils.js
@@ -256,8 +256,8 @@ module.exports.downloadFile = (url, filepath, contentTypeFilter = null) => {
       method: 'GET',
       responseType: 'stream',
       timeout: 30000,
-      httpAgent: global.DisableSsrfRequestFilter ? null : ssrfFilter(feedUrl),
-      httpsAgent: global.DisableSsrfRequestFilter ? null : ssrfFilter(feedUrl)
+      httpAgent: global.DisableSsrfRequestFilter ? null : ssrfFilter(url),
+      httpsAgent: global.DisableSsrfRequestFilter ? null : ssrfFilter(url)
     })
       .then((response) => {
         // Validate content type


### PR DESCRIPTION
The recent commit to support disabling the ssrfFilter has broken url loading for non podcasts due to a copy paste error from the podcasts file. This switches the `feedUrl` back to the original `url` and makes image loading, and my kid waiting on a new audiobook, happy.

The original issue likely had a few ways to trigger it but in my scenario it was updating an audiobooks metadata and replacing the image, the error in the logs was:

```
[Server] Unhandled rejection: ReferenceError: feedUrl is not defined, promise: Promise { <rejected> ReferenceError: feedUrl is not defined at /snapshot/audiobookshelf-git/server/utils/fileUtils.js at new Promise (<anonymous>) at Object.downloadFile (/snapshot/audiobookshelf-git/server/utils/fileUtils.js) at /snapshot/audiobookshelf-git/server/utils/fileUtils.js at CoverManager.downloadCoverFromUrl (/snapshot/audiobookshelf-git/server/managers/CoverManager.js) at async ApiRouter.uploadCover (/snapshot/audiobookshelf-git/server/controllers/LibraryItemController.js) at async ApiRouter.updateMedia (/snapshot/audiobookshelf-git/server/controllers/LibraryItemController.js) }
```

After switching to my branch this error no longer occurs and the image is updated correctly.