### PR TITLE
bug: If !itemProgress unhandled exception syncing user progress

### DIFF
--- a/server/managers/PlaybackSessionManager.js
+++ b/server/managers/PlaybackSessionManager.js
@@ -178,13 +178,15 @@ class PlaybackSessionManager {
     // Update user and emit socket event
     if (result.progressSynced) {
       const itemProgress = user.getMediaProgress(session.libraryItemId, session.episodeId)
-      if (itemProgress) await Database.upsertMediaProgress(itemProgress)
-      SocketAuthority.clientEmitter(user.id, 'user_item_progress_updated', {
-        id: itemProgress.id,
-        sessionId: session.id,
-        deviceDescription: session.deviceDescription,
-        data: itemProgress.toJSON()
-      })
+      if (itemProgress) {
+        await Database.upsertMediaProgress(itemProgress)
+        SocketAuthority.clientEmitter(user.id, 'user_item_progress_updated', {
+          id: itemProgress.id,
+          sessionId: session.id,
+          deviceDescription: session.deviceDescription,
+          data: itemProgress.toJSON()
+        })
+      }
     }
 
     return result


### PR DESCRIPTION
I'm not sure exactly the situation which creates this, but there is an if statement which checks if `itemProgress` -- but then uses it even if not. This caused my server to become useless recently =] Simple fix.