### PR TITLE
Openapi middleware validation

### DIFF
--- a/docs/controllers/AuthorController.yaml
+++ b/docs/controllers/AuthorController.yaml
@@ -74,17 +74,14 @@ paths:
       description: Get an author by ID. The author's books and series can be included in the response.
       tags:
         - Authors
-      requestBody:
-        required: false
-        description: The author object to create.
-        content:
-          application/json:
-            schema:
-              properties:
-                include:
-                  $ref: '#/components/schemas/authorInclude'
-                library:
-                  $ref: '#/components/schemas/authorLibraryId'
+      parameters:
+        - in: query
+          name: include
+          description: A comma separated list of what to include with the author. The options are `items` and `series`. `series` will only have an effect if `items` is included. For example, the value `items,series` will include both library items and series.
+          allowReserved: true
+          schema:
+            type: string
+          example: 'items,series'
       responses:
         '200':
           description: getAuthorById OK

--- a/docs/controllers/AuthorController.yaml
+++ b/docs/controllers/AuthorController.yaml
@@ -147,10 +147,21 @@ paths:
         required: true
         schema:
           $ref: '../objects/entities/Author.yaml#/components/schemas/authorId'
+      - name: token
+        in: query
+        description: API token
+        schema:
+          type: string
+      - name: ts
+        in: query
+        description: Updated at value
+        schema:
+          type: integer
     get:
       operationId: getAuthorImageById
       summary: Get an author image by author ID
       description: Get an author image by author ID. The image will be returned in the requested format and size.
+      security: [] # No security for getting author image
       tags:
         - Authors
       requestBody:

--- a/docs/controllers/LibraryController.yaml
+++ b/docs/controllers/LibraryController.yaml
@@ -78,10 +78,10 @@ components:
       in: query
       name: desc
       description: Return items in reversed order if true.
-      example: true
+      example: 0
       schema:
-        type: boolean
-        default: false
+        type: integer
+        default: 0
 
   responses:
     library200:
@@ -166,6 +166,7 @@ paths:
           name: include
           schema:
             type: string
+        - $ref: '../schemas.yaml#/components/parameters/minified'
       responses:
         '200':
           $ref: '#/components/responses/library200'
@@ -262,7 +263,6 @@ paths:
           example: 'numBooks'
           schema:
             type: string
-            enum: ['name', 'numBooks', 'totalDuration', 'addedAt', 'lastBookAdded', 'lastBookUpdated']
             default: 'name'
         - $ref: '#/components/parameters/desc'
         - in: query
@@ -386,6 +386,7 @@ paths:
           example: 'rssfeed'
           schema:
             type: string
+        - $ref: '../schemas.yaml#/components/parameters/minified'
       responses:
         '200':
           description: getLibrarySeries OK

--- a/docs/controllers/LibraryController.yaml
+++ b/docs/controllers/LibraryController.yaml
@@ -57,6 +57,32 @@ components:
       description: The fields to include in the response. The only current option is `rssfeed`.
       type: string
       example: 'rssfeed'
+  parameters:
+    limit:
+      in: query
+      name: limit
+      description: The number of items to return. This the size of a single page for the optional `page` query.
+      example: 10
+      schema:
+        type: integer
+        default: 0
+    page:
+      in: query
+      name: page
+      description: The page number (zero indexed) to return. If no limit is specified, then page will have no effect.
+      example: 0
+      schema:
+        type: integer
+        default: 0
+    desc:
+      in: query
+      name: desc
+      description: Return items in reversed order if true.
+      example: true
+      schema:
+        type: boolean
+        default: false
+
   responses:
     library200:
       description: Library found.
@@ -135,6 +161,11 @@ paths:
       description: Get a single library by ID on server.
       tags:
         - Libraries
+      parameters:
+        - in: query
+          name: include
+          schema:
+            type: string
       responses:
         '200':
           $ref: '#/components/responses/library200'
@@ -222,30 +253,38 @@ paths:
       description: Get items in a library by ID on server.
       tags:
         - Libraries
-      requestBody:
-        required: false
-        description: The filters to apply to the requested library items.
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                limit:
-                  $ref: '../schemas.yaml#/components/schemas/limit'
-                page:
-                  $ref: '../schemas.yaml#/components/schemas/page'
-                sort:
-                  $ref: '#/components/schemas/librarySort'
-                desc:
-                  $ref: '../schemas.yaml#/components/schemas/sortDesc'
-                filter:
-                  $ref: '#/components/schemas/libraryFilter'
-                minified:
-                  $ref: '../schemas.yaml#/components/schemas/minified'
-                collapseSeries:
-                  $ref: '#/components/schemas/libraryCollapseSeries'
-                include:
-                  $ref: '#/components/schemas/libraryInclude'
+      parameters:
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/page'
+        - in: query
+          name: sort
+          description: The field to sort by from the request.
+          example: 'numBooks'
+          schema:
+            type: string
+            enum: ['name', 'numBooks', 'totalDuration', 'addedAt', 'lastBookAdded', 'lastBookUpdated']
+            default: 'name'
+        - $ref: '#/components/parameters/desc'
+        - in: query
+          name: filter
+          description: The filter for the library.
+          example: 'media.metadata.title'
+          schema:
+            type: string
+        - in: query
+          name: include
+          description: The fields to include in the response. The only current option is `rssfeed`.
+          allowReserved: true
+          example: 'rssfeed'
+          schema:
+            type: string
+        - $ref: '../schemas.yaml#/components/parameters/minified'
+        - in: query
+          name: collapseSeries
+          description: Whether to collapse series into a single cover
+          schema:
+            type: integer
+            default: 0
       responses:
         '200':
           description: getLibraryItems OK
@@ -323,20 +362,8 @@ paths:
       tags:
         - Libraries
       parameters:
-        - in: query
-          name: limit
-          description: The number of series to return. If 0, all series are returned.
-          example: 10
-          schema:
-            type: integer
-            default: 0
-        - in: query
-          name: page
-          description: The page number (zero indexed) to return. If no limit is specified, then page will have no effect.
-          example: 0
-          schema:
-            type: integer
-            default: 0
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/page'
         - in: query
           name: sort
           description: The field to sort by from the request.
@@ -345,13 +372,7 @@ paths:
             type: string
             enum: ['name', 'numBooks', 'totalDuration', 'addedAt', 'lastBookAdded', 'lastBookUpdated']
             default: 'name'
-        - in: query
-          name: desc
-          description: Return items in reversed order if true.
-          example: true
-          schema:
-            type: boolean
-            default: false
+        - $ref: '#/components/parameters/desc'
         - in: query
           name: filter
           description: The filter for the library.
@@ -361,6 +382,7 @@ paths:
         - in: query
           name: include
           description: The fields to include in the response. The only current option is `rssfeed`.
+          allowReserved: true
           example: 'rssfeed'
           schema:
             type: string
@@ -416,32 +438,32 @@ paths:
       deprecated: true
       tags:
         - Libraries
-      requestBody:
-        required: false
-        description: The filters to apply to the requested library series.
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                limit:
-                  $ref: '../schemas.yaml#/components/schemas/limit'
-                page:
-                  $ref: '../schemas.yaml#/components/schemas/page'
-                sort:
-                  description: The field to sort by from the request.
-                  type: string
-                  enum: ['name', 'numBooks', 'totalDuration', 'addedAt', 'lastBookAdded', 'lastBookUpdated']
-                  example: 'numBooks'
-                  default: 'name'
-                desc:
-                  $ref: '../schemas.yaml#/components/schemas/sortDesc'
-                filter:
-                  $ref: '#/components/schemas/libraryFilter'
-                minified:
-                  $ref: '../schemas.yaml#/components/schemas/minified'
-                include:
-                  $ref: '#/components/schemas/libraryInclude'
+      parameters:
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/page'
+        - in: query
+          name: sort
+          description: The field to sort by from the request.
+          example: 'numBooks'
+          schema:
+            type: string
+            enum: ['name', 'numBooks', 'totalDuration', 'addedAt', 'lastBookAdded', 'lastBookUpdated']
+            default: 'name'
+        - $ref: '#/components/parameters/desc'
+        - in: query
+          name: filter
+          description: The filter for the library.
+          example: 'media.metadata.title'
+          schema:
+            type: string
+        - $ref: '../schemas.yaml#/components/parameters/minified'
+        - in: query
+          name: include
+          description: The fields to include in the response. The only current option is `rssfeed`.
+          allowReserved: true
+          example: 'rssfeed'
+          schema:
+            type: string
       responses:
         '200':
           description: getLibrarySeriesById OK

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -47,25 +47,21 @@
         "operationId": "getAuthorById",
         "summary": "Get an author by ID",
         "description": "Get an author by ID. The author's books and series can be included in the response.",
-        "tags": ["Authors"],
-        "requestBody": {
-          "required": false,
-          "description": "The author object to create.",
-          "content": {
-            "application/json": {
-              "schema": {
-                "properties": {
-                  "include": {
-                    "$ref": "#/components/schemas/authorInclude"
-                  },
-                  "library": {
-                    "$ref": "#/components/schemas/libraryId"
-                  }
-                }
-              }
-            }
+        "tags": [
+          "Authors"
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "include",
+            "description": "A comma separated list of what to include with the author. The options are `items` and `series`. `series` will only have an effect if `items` is included. For example, the value `items,series` will include both library items and series.",
+            "allowReserved": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "items,series"
           }
-        },
+        ],
         "responses": {
           "200": {
             "description": "getAuthorById OK",
@@ -86,7 +82,9 @@
         "operationId": "updateAuthorById",
         "summary": "Update an author by ID",
         "description": "Update an author by ID. The author's name and description can be updated. This endpoint will merge two authors if the new author name matches another author name in the database.",
-        "tags": ["Authors"],
+        "tags": [
+          "Authors"
+        ],
         "requestBody": {
           "description": "The author object to update.",
           "content": {
@@ -140,7 +138,9 @@
         "operationId": "deleteAuthorById",
         "summary": "Delete an author by ID",
         "description": "Delete an author by ID. This will remove the author from all books.",
-        "tags": ["Authors"],
+        "tags": [
+          "Authors"
+        ],
         "responses": {
           "200": {
             "description": "deleteAuthorById OK",
@@ -175,7 +175,9 @@
         "operationId": "getAuthorImageById",
         "summary": "Get an author image by author ID",
         "description": "Get an author image by author ID. The image will be returned in the requested format and size.",
-        "tags": ["Authors"],
+        "tags": [
+          "Authors"
+        ],
         "requestBody": {
           "required": false,
           "description": "The author image to get.",
@@ -233,7 +235,9 @@
         "operationId": "addAuthorImageById",
         "summary": "Add an author image to the server",
         "description": "Add an author image to the server. The image will be downloaded from the provided URL and stored on the server.",
-        "tags": ["Authors"],
+        "tags": [
+          "Authors"
+        ],
         "requestBody": {
           "required": true,
           "description": "The author image to add by URL.",
@@ -266,7 +270,9 @@
         "operationId": "updateAuthorImageById",
         "summary": "Update an author image by author ID",
         "description": "Update an author image by author ID. The image will be resized if the width, height, or format is provided.",
-        "tags": ["Authors"],
+        "tags": [
+          "Authors"
+        ],
         "requestBody": {
           "description": "The author image to update.",
           "content": {
@@ -311,7 +317,9 @@
         "operationId": "deleteAuthorImageById",
         "summary": "Delete an author image by author ID",
         "description": "Delete an author image by author ID. This will remove the image from the server and the database.",
-        "tags": ["Authors"],
+        "tags": [
+          "Authors"
+        ],
         "responses": {
           "200": {
             "description": "deleteAuthorImageById OK"
@@ -338,7 +346,9 @@
         "operationId": "matchAuthorById",
         "summary": "Match the author against Audible using quick match",
         "description": "Match the author against Audible using quick match. Quick match updates the author's description and image (if no image already existed) with information from audible. Either `asin` or `q` must be provided, with `asin` taking priority if both are provided.",
-        "tags": ["Authors"],
+        "tags": [
+          "Authors"
+        ],
         "requestBody": {
           "required": true,
           "description": "The author object to match against an online provider.",
@@ -385,166 +395,6 @@
         }
       }
     },
-    "/api/libraries": {
-      "get": {
-        "operationId": "getLibraries",
-        "summary": "Get all libraries on server",
-        "description": "Get all libraries on server.",
-        "tags": ["Libraries"],
-        "responses": {
-          "200": {
-            "description": "getLibraries OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/library"
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "post": {
-        "operationId": "createLibrary",
-        "summary": "Create a new library on server",
-        "description": "Create a new library on server.",
-        "tags": ["Libraries"],
-        "requestBody": {
-          "description": "The library object to create.",
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": ["name", "folders"],
-                "properties": {
-                  "name": {
-                    "$ref": "#/components/schemas/libraryName"
-                  },
-                  "folders": {
-                    "$ref": "#/components/schemas/libraryFolders"
-                  },
-                  "displayOrder": {
-                    "$ref": "#/components/schemas/libraryDisplayOrder"
-                  },
-                  "icon": {
-                    "$ref": "#/components/schemas/libraryIcon"
-                  },
-                  "mediaType": {
-                    "$ref": "#/components/schemas/libraryMediaType"
-                  },
-                  "provider": {
-                    "$ref": "#/components/schemas/libraryProvider"
-                  },
-                  "settings": {
-                    "$ref": "#/components/schemas/librarySettings"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "$ref": "#/components/responses/library200"
-          },
-          "404": {
-            "$ref": "#/components/responses/library404"
-          }
-        }
-      }
-    },
-    "/api/libraries/{id}": {
-      "parameters": [
-        {
-          "name": "id",
-          "in": "path",
-          "description": "The ID of the library.",
-          "required": true,
-          "schema": {
-            "$ref": "#/components/schemas/libraryId"
-          }
-        }
-      ],
-      "get": {
-        "operationId": "getLibraryById",
-        "summary": "Get a single library by ID on server",
-        "description": "Get a single library by ID on server.",
-        "tags": ["Libraries"],
-        "responses": {
-          "200": {
-            "$ref": "#/components/responses/library200"
-          },
-          "404": {
-            "$ref": "#/components/responses/library404"
-          }
-        }
-      },
-      "patch": {
-        "operationId": "updateLibraryById",
-        "summary": "Update a single library by ID on server",
-        "description": "Update a single library by ID on server.",
-        "tags": ["Libraries"],
-        "requestBody": {
-          "required": true,
-          "description": "The library object to update.",
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "name": {
-                    "$ref": "#/components/schemas/libraryName"
-                  },
-                  "folders": {
-                    "$ref": "#/components/schemas/libraryFolders"
-                  },
-                  "displayOrder": {
-                    "$ref": "#/components/schemas/libraryDisplayOrder"
-                  },
-                  "icon": {
-                    "$ref": "#/components/schemas/libraryIcon"
-                  },
-                  "mediaType": {
-                    "$ref": "#/components/schemas/libraryMediaType"
-                  },
-                  "provider": {
-                    "$ref": "#/components/schemas/libraryProvider"
-                  },
-                  "settings": {
-                    "$ref": "#/components/schemas/librarySettings"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "$ref": "#/components/responses/library200"
-          },
-          "404": {
-            "$ref": "#/components/responses/library404"
-          }
-        }
-      },
-      "delete": {
-        "operationId": "deleteLibraryById",
-        "summary": "Delete a single library by ID on server",
-        "description": "Delete a single library by ID on server and return the deleted object.",
-        "tags": ["Libraries"],
-        "responses": {
-          "200": {
-            "$ref": "#/components/responses/library200"
-          },
-          "404": {
-            "$ref": "#/components/responses/library404"
-          }
-        }
-      }
-    },
     "/api/libraries/{id}/authors": {
       "parameters": [
         {
@@ -561,7 +411,9 @@
         "operationId": "getLibraryAuthors",
         "summary": "Get all authors in a library",
         "description": "Get all authors in a library by ID on server.",
-        "tags": ["Libraries"],
+        "tags": [
+          "Libraries"
+        ],
         "responses": {
           "200": {
             "description": "getLibraryAuthors OK",
@@ -575,277 +427,6 @@
                       "items": {
                         "$ref": "#/components/schemas/authorExpanded"
                       }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "$ref": "#/components/responses/library404"
-          }
-        }
-      }
-    },
-    "/api/libraries/{id}/items": {
-      "parameters": [
-        {
-          "name": "id",
-          "in": "path",
-          "description": "The ID of the library.",
-          "required": true,
-          "schema": {
-            "$ref": "#/components/schemas/libraryId"
-          }
-        }
-      ],
-      "get": {
-        "operationId": "getLibraryItems",
-        "summary": "Get items in a library",
-        "description": "Get items in a library by ID on server.",
-        "tags": ["Libraries"],
-        "requestBody": {
-          "required": false,
-          "description": "The filters to apply to the requested library items.",
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "limit": {
-                    "$ref": "#/components/schemas/limit"
-                  },
-                  "page": {
-                    "$ref": "#/components/schemas/page"
-                  },
-                  "sort": {
-                    "$ref": "#/components/schemas/librarySort"
-                  },
-                  "desc": {
-                    "$ref": "#/components/schemas/sortDesc"
-                  },
-                  "filter": {
-                    "$ref": "#/components/schemas/libraryFilter"
-                  },
-                  "minified": {
-                    "$ref": "#/components/schemas/minified"
-                  },
-                  "collapseSeries": {
-                    "$ref": "#/components/schemas/libraryCollapseSeries"
-                  },
-                  "include": {
-                    "$ref": "#/components/schemas/libraryInclude"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "getLibraryItems OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "results": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/components/schemas/libraryItemBase"
-                      }
-                    },
-                    "total": {
-                      "$ref": "#/components/schemas/total"
-                    },
-                    "limit": {
-                      "$ref": "#/components/schemas/limit"
-                    },
-                    "page": {
-                      "$ref": "#/components/schemas/page"
-                    },
-                    "sortBy": {
-                      "$ref": "#/components/schemas/sortBy"
-                    },
-                    "sortDesc": {
-                      "$ref": "#/components/schemas/sortDesc"
-                    },
-                    "filterBy": {
-                      "$ref": "#/components/schemas/filterBy"
-                    },
-                    "mediaType": {
-                      "$ref": "#/components/schemas/mediaType"
-                    },
-                    "minified": {
-                      "$ref": "#/components/schemas/minified"
-                    },
-                    "collapseSeries": {
-                      "$ref": "#/components/schemas/collapseSeries"
-                    },
-                    "include": {
-                      "$ref": "#/components/schemas/libraryInclude"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "$ref": "#/components/responses/library404"
-          }
-        }
-      }
-    },
-    "/api/libraries/{id}/issues": {
-      "parameters": [
-        {
-          "name": "id",
-          "in": "path",
-          "description": "The ID of the library.",
-          "required": true,
-          "schema": {
-            "$ref": "#/components/schemas/libraryId"
-          }
-        }
-      ],
-      "delete": {
-        "operationId": "deleteLibraryIssues",
-        "summary": "Delete items with issues in a library.",
-        "description": "Delete all items with issues in a library by library ID on the server. This only removes the items from the ABS database and does not delete media files.",
-        "tags": ["Libraries"],
-        "responses": {
-          "200": {
-            "description": "deleteLibraryIssues OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string",
-                  "example": "Issues deleted."
-                }
-              }
-            }
-          },
-          "404": {
-            "$ref": "#/components/responses/library404"
-          }
-        }
-      }
-    },
-    "/api/libraries/{id}/series": {
-      "parameters": [
-        {
-          "name": "id",
-          "in": "path",
-          "description": "The ID of the library.",
-          "required": true,
-          "schema": {
-            "$ref": "#/components/schemas/libraryId"
-          }
-        }
-      ],
-      "get": {
-        "operationId": "getLibrarySeries",
-        "summary": "Get library series",
-        "description": "Get series in a library. Filtering and sorting can be applied.",
-        "tags": ["Libraries"],
-        "parameters": [
-          {
-            "in": "query",
-            "name": "limit",
-            "description": "The number of series to return. If 0, all series are returned.",
-            "example": 10,
-            "schema": {
-              "type": "integer",
-              "default": 0
-            }
-          },
-          {
-            "in": "query",
-            "name": "page",
-            "description": "The page number (zero indexed) to return. If no limit is specified, then page will have no effect.",
-            "example": 0,
-            "schema": {
-              "type": "integer",
-              "default": 0
-            }
-          },
-          {
-            "in": "query",
-            "name": "sort",
-            "description": "The field to sort by from the request.",
-            "example": "numBooks",
-            "schema": {
-              "type": "string",
-              "enum": ["name", "numBooks", "totalDuration", "addedAt", "lastBookAdded", "lastBookUpdated"],
-              "default": "name"
-            }
-          },
-          {
-            "in": "query",
-            "name": "desc",
-            "description": "Return items in reversed order if true.",
-            "example": true,
-            "schema": {
-              "type": "boolean",
-              "default": false
-            }
-          },
-          {
-            "in": "query",
-            "name": "filter",
-            "description": "The filter for the library.",
-            "example": "media.metadata.title",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "include",
-            "description": "The fields to include in the response. The only current option is `rssfeed`.",
-            "example": "rssfeed",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "getLibrarySeries OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "results": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/components/schemas/seriesBooks"
-                      }
-                    },
-                    "total": {
-                      "$ref": "#/components/schemas/total"
-                    },
-                    "limit": {
-                      "$ref": "#/components/schemas/limit"
-                    },
-                    "page": {
-                      "$ref": "#/components/schemas/page"
-                    },
-                    "sortBy": {
-                      "$ref": "#/components/schemas/sortBy"
-                    },
-                    "sortDesc": {
-                      "$ref": "#/components/schemas/sortDesc"
-                    },
-                    "filterBy": {
-                      "$ref": "#/components/schemas/filterBy"
-                    },
-                    "minified": {
-                      "$ref": "#/components/schemas/minified"
-                    },
-                    "include": {
-                      "$ref": "#/components/schemas/libraryInclude"
                     }
                   }
                 }
@@ -884,7 +465,9 @@
         "summary": "Get single series in library",
         "description": "Get a single series in a library by ID on server. This endpoint is deprecated and `/api/series/{id}` should be used instead.",
         "deprecated": true,
-        "tags": ["Libraries"],
+        "tags": [
+          "Libraries"
+        ],
         "requestBody": {
           "required": false,
           "description": "The filters to apply to the requested library series.",
@@ -902,7 +485,14 @@
                   "sort": {
                     "description": "The field to sort by from the request.",
                     "type": "string",
-                    "enum": ["name", "numBooks", "totalDuration", "addedAt", "lastBookAdded", "lastBookUpdated"],
+                    "enum": [
+                      "name",
+                      "numBooks",
+                      "totalDuration",
+                      "addedAt",
+                      "lastBookAdded",
+                      "lastBookUpdated"
+                    ],
                     "example": "numBooks",
                     "default": "name"
                   },
@@ -954,7 +544,9 @@
       ],
       "get": {
         "operationId": "getSeries",
-        "tags": ["Series"],
+        "tags": [
+          "Series"
+        ],
         "summary": "Get series",
         "description": "Get a series by ID.",
         "requestBody": {
@@ -969,7 +561,12 @@
                     "type": "string",
                     "description": "A comma separated list of what to include with the series.",
                     "example": "progress,rssfeed",
-                    "enum": ["progress", "rssfeed", "progress,rssfeed", "rssfeed,progress"]
+                    "enum": [
+                      "progress",
+                      "rssfeed",
+                      "progress,rssfeed",
+                      "rssfeed,progress"
+                    ]
                   }
                 }
               }
@@ -994,7 +591,9 @@
       },
       "patch": {
         "operationId": "updateSeries",
-        "tags": ["Series"],
+        "tags": [
+          "Series"
+        ],
         "summary": "Update series",
         "description": "Update a series by ID.",
         "requestBody": {
@@ -1045,17 +644,6 @@
       "authorId": {
         "type": "string",
         "description": "The ID of the author.",
-        "format": "uuid",
-        "example": "e4bb1afb-4a4f-4dd6-8be0-e615d233185b"
-      },
-      "authorInclude": {
-        "description": "A comma separated list of what to include with the author. The options are `items` and `series`. `series` will only have an effect if `items` is included. For example, the value `items,series` will include both library items and series.",
-        "type": "string",
-        "example": "items"
-      },
-      "libraryId": {
-        "type": "string",
-        "description": "The ID of the library.",
         "format": "uuid",
         "example": "e4bb1afb-4a4f-4dd6-8be0-e615d233185b"
       },
@@ -1111,6 +699,12 @@
         "format": "[0-9]*",
         "example": "649644248522215260"
       },
+      "libraryId": {
+        "type": "string",
+        "description": "The ID of the library.",
+        "format": "uuid",
+        "example": "e4bb1afb-4a4f-4dd6-8be0-e615d233185b"
+      },
       "folderId": {
         "type": "string",
         "description": "The ID of the folder.",
@@ -1120,7 +714,10 @@
       "mediaType": {
         "type": "string",
         "description": "The type of media, will be book or podcast.",
-        "enum": ["book", "podcast"]
+        "enum": [
+          "book",
+          "podcast"
+        ]
       },
       "libraryItemBase": {
         "type": "object",
@@ -1205,7 +802,11 @@
             "items": {
               "type": "string"
             },
-            "example": ["Fantasy", "Sci-Fi", "Nonfiction: History"]
+            "example": [
+              "Fantasy",
+              "Sci-Fi",
+              "Nonfiction: History"
+            ]
           },
           "publishedYear": {
             "description": "The year the book was published. Will be null if unknown.",
@@ -1303,7 +904,10 @@
         "items": {
           "type": "string"
         },
-        "example": ["To Be Read", "Genre: Nonfiction"]
+        "example": [
+          "To Be Read",
+          "Genre: Nonfiction"
+        ]
       },
       "durationSec": {
         "description": "The total length (in seconds) of the item or file.",
@@ -1513,172 +1117,6 @@
         "example": "us",
         "default": "us"
       },
-      "libraryName": {
-        "description": "The name of the library.",
-        "type": "string",
-        "example": "My Audiobooks"
-      },
-      "folder": {
-        "type": "object",
-        "description": "Folder used in library",
-        "properties": {
-          "id": {
-            "$ref": "#/components/schemas/folderId"
-          },
-          "fullPath": {
-            "description": "The path on the server for the folder. (Read Only)",
-            "type": "string",
-            "example": "/podcasts"
-          },
-          "libraryId": {
-            "$ref": "#/components/schemas/libraryId"
-          },
-          "addedAt": {
-            "$ref": "#/components/schemas/addedAt"
-          }
-        }
-      },
-      "librarySettings": {
-        "description": "The settings for the library.",
-        "type": "object",
-        "properties": {
-          "coverAspectRatio": {
-            "description": "Whether the library should use square book covers. Must be 0 (for false) or 1 (for true).",
-            "type": "integer",
-            "example": 1
-          },
-          "disableWatcher": {
-            "description": "Whether to disable the folder watcher for the library.",
-            "type": "boolean",
-            "example": false
-          },
-          "skipMatchingMediaWithAsin": {
-            "description": "Whether to skip matching books that already have an ASIN.",
-            "type": "boolean",
-            "example": false
-          },
-          "skipMatchingMediaWithIsbn": {
-            "description": "Whether to skip matching books that already have an ISBN.",
-            "type": "boolean",
-            "example": false
-          },
-          "autoScanCronExpression": {
-            "description": "The cron expression for when to automatically scan the library folders. If null, automatic scanning will be disabled.",
-            "type": "string",
-            "nullable": true,
-            "example": "0 0 0 * * *"
-          },
-          "audiobooksOnly": {
-            "description": "Whether the library should ignore ebook files and only allow ebook files to be supplementary.",
-            "type": "boolean",
-            "example": false
-          },
-          "hideSingleBookSeries": {
-            "description": "Whether to hide series with only one book.",
-            "type": "boolean",
-            "example": false
-          },
-          "onlyShowLaterBooksInContinueSeries": {
-            "description": "Whether to only show books in a series after the highest series sequence.",
-            "type": "boolean",
-            "example": false
-          },
-          "metadataPrecedence": {
-            "description": "The precedence of metadata sources. See Metadata Providers for a list of possible providers.",
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "example": ["folderStructure", "audioMetatags", "nfoFile", "txtFiles", "opfFile", "absMetadata"]
-          },
-          "podcastSearchRegion": {
-            "description": "The region to use when searching for podcasts.",
-            "type": "string",
-            "example": "us"
-          }
-        }
-      },
-      "createdAt": {
-        "type": "integer",
-        "description": "The time (in ms since POSIX epoch) when was created.",
-        "example": 1633522963509
-      },
-      "library": {
-        "description": "A library object which includes either books or podcasts.",
-        "type": "object",
-        "properties": {
-          "id": {
-            "$ref": "#/components/schemas/libraryId"
-          },
-          "name": {
-            "$ref": "#/components/schemas/libraryName"
-          },
-          "folders": {
-            "description": "The folders that belong to the library.",
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/folder"
-            }
-          },
-          "displayOrder": {
-            "description": "Display position of the library in the list of libraries. Must be >= 1.",
-            "type": "integer",
-            "example": 1
-          },
-          "icon": {
-            "description": "The selected icon for the library. See Library Icons for a list of possible icons.",
-            "type": "string",
-            "example": "audiobookshelf"
-          },
-          "mediaType": {
-            "description": "The type of media that the library contains. Will be `book` or `podcast`. (Read Only)",
-            "type": "string",
-            "example": "book"
-          },
-          "provider": {
-            "description": "Preferred metadata provider for the library. See Metadata Providers for a list of possible providers.",
-            "type": "string",
-            "example": "audible"
-          },
-          "settings": {
-            "$ref": "#/components/schemas/librarySettings"
-          },
-          "createdAt": {
-            "$ref": "#/components/schemas/createdAt"
-          },
-          "lastUpdate": {
-            "$ref": "#/components/schemas/updatedAt"
-          }
-        }
-      },
-      "libraryFolders": {
-        "description": "The folders of the library. Only specify the fullPath.",
-        "type": "array",
-        "items": {
-          "$ref": "#/components/schemas/folder"
-        }
-      },
-      "libraryDisplayOrder": {
-        "description": "The display order of the library. Must be >= 1.",
-        "type": "integer",
-        "minimum": 1,
-        "example": 1
-      },
-      "libraryIcon": {
-        "description": "The icon of the library. See Library Icons for a list of possible icons.",
-        "type": "string",
-        "example": "audiobookshelf"
-      },
-      "libraryMediaType": {
-        "description": "The type of media that the library contains. Must be `book` or `podcast`.",
-        "type": "string",
-        "example": "book"
-      },
-      "libraryProvider": {
-        "description": "Preferred metadata provider for the library. See Metadata Providers for a list of possible providers.",
-        "type": "string",
-        "example": "audible"
-      },
       "authorExpanded": {
         "type": "object",
         "description": "The author schema with the total number of books in the library.",
@@ -1710,11 +1148,6 @@
         "example": 1,
         "default": 0
       },
-      "librarySort": {
-        "description": "The sort order of the library. For example, to sort by title use 'sort=media.metadata.title'.",
-        "type": "string",
-        "example": "media.metadata.title"
-      },
       "sortDesc": {
         "description": "Return items in reversed order if true.",
         "type": "boolean",
@@ -1732,91 +1165,10 @@
         "example": true,
         "default": false
       },
-      "libraryCollapseSeries": {
-        "description": "Whether to collapse series.",
-        "type": "boolean",
-        "example": true,
-        "default": false
-      },
       "libraryInclude": {
         "description": "The fields to include in the response. The only current option is `rssfeed`.",
         "type": "string",
         "example": "rssfeed"
-      },
-      "total": {
-        "description": "The total number of items in the response.",
-        "type": "integer",
-        "example": 100
-      },
-      "sortBy": {
-        "type": "string",
-        "description": "The field to sort by from the request.",
-        "example": "media.metadata.title"
-      },
-      "filterBy": {
-        "type": "string",
-        "description": "The field to filter by from the request. TODO",
-        "example": "media.metadata.title"
-      },
-      "collapseSeries": {
-        "type": "boolean",
-        "description": "Whether collapse series was set in the request.",
-        "example": true
-      },
-      "sequence": {
-        "description": "The position in the series the book is.",
-        "type": "string",
-        "nullable": true
-      },
-      "libraryItemSequence": {
-        "type": "object",
-        "description": "A single item on the server, like a book or podcast. Includes series sequence information.",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/libraryItemBase"
-          },
-          {
-            "$ref": "#/components/schemas/sequence"
-          }
-        ]
-      },
-      "seriesBooks": {
-        "type": "object",
-        "description": "A series object which includes the name and books in the series.",
-        "properties": {
-          "id": {
-            "$ref": "#/components/schemas/seriesId"
-          },
-          "name": {
-            "$ref": "#/components/schemas/seriesName"
-          },
-          "addedAt": {
-            "$ref": "#/components/schemas/addedAt"
-          },
-          "nameIgnorePrefix": {
-            "description": "The name of the series with any prefix moved to the end.",
-            "type": "string"
-          },
-          "nameIgnorePrefixSort": {
-            "description": "The name of the series with any prefix removed.",
-            "type": "string"
-          },
-          "type": {
-            "description": "Will always be `series`.",
-            "type": "string"
-          },
-          "books": {
-            "description": "The library items that contain the books in the series. A sequence attribute that denotes the position in the series the book is in, is tacked on.",
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/libraryItemSequence"
-            }
-          },
-          "totalDuration": {
-            "description": "The combined duration (in seconds) of all books in the series.",
-            "type": "number"
-          }
-        }
       },
       "seriesDescription": {
         "description": "A description for the series. Will be null if there is none.",
@@ -1900,16 +1252,6 @@
             "schema": {
               "type": "string",
               "example": "Author not found."
-            }
-          }
-        }
-      },
-      "library200": {
-        "description": "Library found.",
-        "content": {
-          "application/json": {
-            "schema": {
-              "$ref": "#/components/schemas/library"
             }
           }
         }

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -499,6 +499,9 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "$ref": "#/components/parameters/minified"
           }
         ],
         "responses": {
@@ -654,14 +657,6 @@
             "example": "numBooks",
             "schema": {
               "type": "string",
-              "enum": [
-                "name",
-                "numBooks",
-                "totalDuration",
-                "addedAt",
-                "lastBookAdded",
-                "lastBookUpdated"
-              ],
               "default": "name"
             }
           },
@@ -857,6 +852,9 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "$ref": "#/components/parameters/minified"
           }
         ],
         "responses": {
@@ -2007,6 +2005,16 @@
       }
     },
     "parameters": {
+      "minified": {
+        "in": "query",
+        "name": "minified",
+        "description": "Return minified items if true",
+        "schema": {
+          "type": "integer",
+          "minimum": 0,
+          "example": 1
+        }
+      },
       "limit": {
         "in": "query",
         "name": "limit",
@@ -2031,20 +2039,10 @@
         "in": "query",
         "name": "desc",
         "description": "Return items in reversed order if true.",
-        "example": true,
-        "schema": {
-          "type": "boolean",
-          "default": false
-        }
-      },
-      "minified": {
-        "in": "query",
-        "name": "minified",
-        "description": "Return minified items if true",
+        "example": 0,
         "schema": {
           "type": "integer",
-          "minimum": 0,
-          "example": 1
+          "default": 0
         }
       }
     }

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -169,12 +169,29 @@
           "schema": {
             "$ref": "#/components/schemas/authorId"
           }
+        },
+        {
+          "name": "token",
+          "in": "query",
+          "description": "API token",
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "ts",
+          "in": "query",
+          "description": "Updated at value",
+          "schema": {
+            "type": "integer"
+          }
         }
       ],
       "get": {
         "operationId": "getAuthorImageById",
         "summary": "Get an author image by author ID",
         "description": "Get an author image by author ID. The image will be returned in the requested format and size.",
+        "security": [],
         "tags": [
           "Authors"
         ],

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -395,6 +395,179 @@
         }
       }
     },
+    "/api/libraries": {
+      "get": {
+        "operationId": "getLibraries",
+        "summary": "Get all libraries on server",
+        "description": "Get all libraries on server.",
+        "tags": [
+          "Libraries"
+        ],
+        "responses": {
+          "200": {
+            "description": "getLibraries OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/library"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "createLibrary",
+        "summary": "Create a new library on server",
+        "description": "Create a new library on server.",
+        "tags": [
+          "Libraries"
+        ],
+        "requestBody": {
+          "description": "The library object to create.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "name",
+                  "folders"
+                ],
+                "properties": {
+                  "name": {
+                    "$ref": "#/components/schemas/libraryName"
+                  },
+                  "folders": {
+                    "$ref": "#/components/schemas/libraryFolders"
+                  },
+                  "displayOrder": {
+                    "$ref": "#/components/schemas/libraryDisplayOrder"
+                  },
+                  "icon": {
+                    "$ref": "#/components/schemas/libraryIcon"
+                  },
+                  "mediaType": {
+                    "$ref": "#/components/schemas/libraryMediaType"
+                  },
+                  "provider": {
+                    "$ref": "#/components/schemas/libraryProvider"
+                  },
+                  "settings": {
+                    "$ref": "#/components/schemas/librarySettings"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/library200"
+          },
+          "404": {
+            "$ref": "#/components/responses/library404"
+          }
+        }
+      }
+    },
+    "/api/libraries/{id}": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "description": "The ID of the library.",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/libraryId"
+          }
+        }
+      ],
+      "get": {
+        "operationId": "getLibraryById",
+        "summary": "Get a single library by ID on server",
+        "description": "Get a single library by ID on server.",
+        "tags": [
+          "Libraries"
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/library200"
+          },
+          "404": {
+            "$ref": "#/components/responses/library404"
+          }
+        }
+      },
+      "patch": {
+        "operationId": "updateLibraryById",
+        "summary": "Update a single library by ID on server",
+        "description": "Update a single library by ID on server.",
+        "tags": [
+          "Libraries"
+        ],
+        "requestBody": {
+          "required": true,
+          "description": "The library object to update.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "$ref": "#/components/schemas/libraryName"
+                  },
+                  "folders": {
+                    "$ref": "#/components/schemas/libraryFolders"
+                  },
+                  "displayOrder": {
+                    "$ref": "#/components/schemas/libraryDisplayOrder"
+                  },
+                  "icon": {
+                    "$ref": "#/components/schemas/libraryIcon"
+                  },
+                  "mediaType": {
+                    "$ref": "#/components/schemas/libraryMediaType"
+                  },
+                  "provider": {
+                    "$ref": "#/components/schemas/libraryProvider"
+                  },
+                  "settings": {
+                    "$ref": "#/components/schemas/librarySettings"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/library200"
+          },
+          "404": {
+            "$ref": "#/components/responses/library404"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "deleteLibraryById",
+        "summary": "Delete a single library by ID on server",
+        "description": "Delete a single library by ID on server and return the deleted object.",
+        "tags": [
+          "Libraries"
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/library200"
+          },
+          "404": {
+            "$ref": "#/components/responses/library404"
+          }
+        }
+      }
+    },
     "/api/libraries/{id}/authors": {
       "parameters": [
         {
@@ -427,6 +600,290 @@
                       "items": {
                         "$ref": "#/components/schemas/authorExpanded"
                       }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "$ref": "#/components/responses/library404"
+          }
+        }
+      }
+    },
+    "/api/libraries/{id}/items": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "description": "The ID of the library.",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/libraryId"
+          }
+        }
+      ],
+      "get": {
+        "operationId": "getLibraryItems",
+        "summary": "Get items in a library",
+        "description": "Get items in a library by ID on server.",
+        "tags": [
+          "Libraries"
+        ],
+        "requestBody": {
+          "required": false,
+          "description": "The filters to apply to the requested library items.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "limit": {
+                    "$ref": "#/components/schemas/limit"
+                  },
+                  "page": {
+                    "$ref": "#/components/schemas/page"
+                  },
+                  "sort": {
+                    "$ref": "#/components/schemas/librarySort"
+                  },
+                  "desc": {
+                    "$ref": "#/components/schemas/sortDesc"
+                  },
+                  "filter": {
+                    "$ref": "#/components/schemas/libraryFilter"
+                  },
+                  "minified": {
+                    "$ref": "#/components/schemas/minified"
+                  },
+                  "collapseSeries": {
+                    "$ref": "#/components/schemas/libraryCollapseSeries"
+                  },
+                  "include": {
+                    "$ref": "#/components/schemas/libraryInclude"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "getLibraryItems OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "results": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/libraryItemBase"
+                      }
+                    },
+                    "total": {
+                      "$ref": "#/components/schemas/total"
+                    },
+                    "limit": {
+                      "$ref": "#/components/schemas/limit"
+                    },
+                    "page": {
+                      "$ref": "#/components/schemas/page"
+                    },
+                    "sortBy": {
+                      "$ref": "#/components/schemas/sortBy"
+                    },
+                    "sortDesc": {
+                      "$ref": "#/components/schemas/sortDesc"
+                    },
+                    "filterBy": {
+                      "$ref": "#/components/schemas/filterBy"
+                    },
+                    "mediaType": {
+                      "$ref": "#/components/schemas/mediaType"
+                    },
+                    "minified": {
+                      "$ref": "#/components/schemas/minified"
+                    },
+                    "collapseSeries": {
+                      "$ref": "#/components/schemas/collapseSeries"
+                    },
+                    "include": {
+                      "$ref": "#/components/schemas/libraryInclude"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "$ref": "#/components/responses/library404"
+          }
+        }
+      }
+    },
+    "/api/libraries/{id}/issues": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "description": "The ID of the library.",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/libraryId"
+          }
+        }
+      ],
+      "delete": {
+        "operationId": "deleteLibraryIssues",
+        "summary": "Delete items with issues in a library.",
+        "description": "Delete all items with issues in a library by library ID on the server. This only removes the items from the ABS database and does not delete media files.",
+        "tags": [
+          "Libraries"
+        ],
+        "responses": {
+          "200": {
+            "description": "deleteLibraryIssues OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "example": "Issues deleted."
+                }
+              }
+            }
+          },
+          "404": {
+            "$ref": "#/components/responses/library404"
+          }
+        }
+      }
+    },
+    "/api/libraries/{id}/series": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "description": "The ID of the library.",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/libraryId"
+          }
+        }
+      ],
+      "get": {
+        "operationId": "getLibrarySeries",
+        "summary": "Get library series",
+        "description": "Get series in a library. Filtering and sorting can be applied.",
+        "tags": [
+          "Libraries"
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "limit",
+            "description": "The number of series to return. If 0, all series are returned.",
+            "example": 10,
+            "schema": {
+              "type": "integer",
+              "default": 0
+            }
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "description": "The page number (zero indexed) to return. If no limit is specified, then page will have no effect.",
+            "example": 0,
+            "schema": {
+              "type": "integer",
+              "default": 0
+            }
+          },
+          {
+            "in": "query",
+            "name": "sort",
+            "description": "The field to sort by from the request.",
+            "example": "numBooks",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "name",
+                "numBooks",
+                "totalDuration",
+                "addedAt",
+                "lastBookAdded",
+                "lastBookUpdated"
+              ],
+              "default": "name"
+            }
+          },
+          {
+            "in": "query",
+            "name": "desc",
+            "description": "Return items in reversed order if true.",
+            "example": true,
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "in": "query",
+            "name": "filter",
+            "description": "The filter for the library.",
+            "example": "media.metadata.title",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "include",
+            "description": "The fields to include in the response. The only current option is `rssfeed`.",
+            "example": "rssfeed",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "getLibrarySeries OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "results": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/seriesBooks"
+                      }
+                    },
+                    "total": {
+                      "$ref": "#/components/schemas/total"
+                    },
+                    "limit": {
+                      "$ref": "#/components/schemas/limit"
+                    },
+                    "page": {
+                      "$ref": "#/components/schemas/page"
+                    },
+                    "sortBy": {
+                      "$ref": "#/components/schemas/sortBy"
+                    },
+                    "sortDesc": {
+                      "$ref": "#/components/schemas/sortDesc"
+                    },
+                    "filterBy": {
+                      "$ref": "#/components/schemas/filterBy"
+                    },
+                    "minified": {
+                      "$ref": "#/components/schemas/minified"
+                    },
+                    "include": {
+                      "$ref": "#/components/schemas/libraryInclude"
                     }
                   }
                 }
@@ -1117,6 +1574,179 @@
         "example": "us",
         "default": "us"
       },
+      "libraryName": {
+        "description": "The name of the library.",
+        "type": "string",
+        "example": "My Audiobooks"
+      },
+      "folder": {
+        "type": "object",
+        "description": "Folder used in library",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/folderId"
+          },
+          "fullPath": {
+            "description": "The path on the server for the folder. (Read Only)",
+            "type": "string",
+            "example": "/podcasts"
+          },
+          "libraryId": {
+            "$ref": "#/components/schemas/libraryId"
+          },
+          "addedAt": {
+            "$ref": "#/components/schemas/addedAt"
+          }
+        }
+      },
+      "librarySettings": {
+        "description": "The settings for the library.",
+        "type": "object",
+        "properties": {
+          "coverAspectRatio": {
+            "description": "Whether the library should use square book covers. Must be 0 (for false) or 1 (for true).",
+            "type": "integer",
+            "example": 1
+          },
+          "disableWatcher": {
+            "description": "Whether to disable the folder watcher for the library.",
+            "type": "boolean",
+            "example": false
+          },
+          "skipMatchingMediaWithAsin": {
+            "description": "Whether to skip matching books that already have an ASIN.",
+            "type": "boolean",
+            "example": false
+          },
+          "skipMatchingMediaWithIsbn": {
+            "description": "Whether to skip matching books that already have an ISBN.",
+            "type": "boolean",
+            "example": false
+          },
+          "autoScanCronExpression": {
+            "description": "The cron expression for when to automatically scan the library folders. If null, automatic scanning will be disabled.",
+            "type": "string",
+            "nullable": true,
+            "example": "0 0 0 * * *"
+          },
+          "audiobooksOnly": {
+            "description": "Whether the library should ignore ebook files and only allow ebook files to be supplementary.",
+            "type": "boolean",
+            "example": false
+          },
+          "hideSingleBookSeries": {
+            "description": "Whether to hide series with only one book.",
+            "type": "boolean",
+            "example": false
+          },
+          "onlyShowLaterBooksInContinueSeries": {
+            "description": "Whether to only show books in a series after the highest series sequence.",
+            "type": "boolean",
+            "example": false
+          },
+          "metadataPrecedence": {
+            "description": "The precedence of metadata sources. See Metadata Providers for a list of possible providers.",
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "example": [
+              "folderStructure",
+              "audioMetatags",
+              "nfoFile",
+              "txtFiles",
+              "opfFile",
+              "absMetadata"
+            ]
+          },
+          "podcastSearchRegion": {
+            "description": "The region to use when searching for podcasts.",
+            "type": "string",
+            "example": "us"
+          }
+        }
+      },
+      "createdAt": {
+        "type": "integer",
+        "description": "The time (in ms since POSIX epoch) when was created.",
+        "example": 1633522963509
+      },
+      "library": {
+        "description": "A library object which includes either books or podcasts.",
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/libraryId"
+          },
+          "name": {
+            "$ref": "#/components/schemas/libraryName"
+          },
+          "folders": {
+            "description": "The folders that belong to the library.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/folder"
+            }
+          },
+          "displayOrder": {
+            "description": "Display position of the library in the list of libraries. Must be >= 1.",
+            "type": "integer",
+            "example": 1
+          },
+          "icon": {
+            "description": "The selected icon for the library. See Library Icons for a list of possible icons.",
+            "type": "string",
+            "example": "audiobookshelf"
+          },
+          "mediaType": {
+            "description": "The type of media that the library contains. Will be `book` or `podcast`. (Read Only)",
+            "type": "string",
+            "example": "book"
+          },
+          "provider": {
+            "description": "Preferred metadata provider for the library. See Metadata Providers for a list of possible providers.",
+            "type": "string",
+            "example": "audible"
+          },
+          "settings": {
+            "$ref": "#/components/schemas/librarySettings"
+          },
+          "createdAt": {
+            "$ref": "#/components/schemas/createdAt"
+          },
+          "lastUpdate": {
+            "$ref": "#/components/schemas/updatedAt"
+          }
+        }
+      },
+      "libraryFolders": {
+        "description": "The folders of the library. Only specify the fullPath.",
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/folder"
+        }
+      },
+      "libraryDisplayOrder": {
+        "description": "The display order of the library. Must be >= 1.",
+        "type": "integer",
+        "minimum": 1,
+        "example": 1
+      },
+      "libraryIcon": {
+        "description": "The icon of the library. See Library Icons for a list of possible icons.",
+        "type": "string",
+        "example": "audiobookshelf"
+      },
+      "libraryMediaType": {
+        "description": "The type of media that the library contains. Must be `book` or `podcast`.",
+        "type": "string",
+        "example": "book"
+      },
+      "libraryProvider": {
+        "description": "Preferred metadata provider for the library. See Metadata Providers for a list of possible providers.",
+        "type": "string",
+        "example": "audible"
+      },
       "authorExpanded": {
         "type": "object",
         "description": "The author schema with the total number of books in the library.",
@@ -1148,6 +1778,11 @@
         "example": 1,
         "default": 0
       },
+      "librarySort": {
+        "description": "The sort order of the library. For example, to sort by title use 'sort=media.metadata.title'.",
+        "type": "string",
+        "example": "media.metadata.title"
+      },
       "sortDesc": {
         "description": "Return items in reversed order if true.",
         "type": "boolean",
@@ -1165,10 +1800,91 @@
         "example": true,
         "default": false
       },
+      "libraryCollapseSeries": {
+        "description": "Whether to collapse series.",
+        "type": "boolean",
+        "example": true,
+        "default": false
+      },
       "libraryInclude": {
         "description": "The fields to include in the response. The only current option is `rssfeed`.",
         "type": "string",
         "example": "rssfeed"
+      },
+      "total": {
+        "description": "The total number of items in the response.",
+        "type": "integer",
+        "example": 100
+      },
+      "sortBy": {
+        "type": "string",
+        "description": "The field to sort by from the request.",
+        "example": "media.metadata.title"
+      },
+      "filterBy": {
+        "type": "string",
+        "description": "The field to filter by from the request. TODO",
+        "example": "media.metadata.title"
+      },
+      "collapseSeries": {
+        "type": "boolean",
+        "description": "Whether collapse series was set in the request.",
+        "example": true
+      },
+      "sequence": {
+        "description": "The position in the series the book is.",
+        "type": "string",
+        "nullable": true
+      },
+      "libraryItemSequence": {
+        "type": "object",
+        "description": "A single item on the server, like a book or podcast. Includes series sequence information.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/libraryItemBase"
+          },
+          {
+            "$ref": "#/components/schemas/sequence"
+          }
+        ]
+      },
+      "seriesBooks": {
+        "type": "object",
+        "description": "A series object which includes the name and books in the series.",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/seriesId"
+          },
+          "name": {
+            "$ref": "#/components/schemas/seriesName"
+          },
+          "addedAt": {
+            "$ref": "#/components/schemas/addedAt"
+          },
+          "nameIgnorePrefix": {
+            "description": "The name of the series with any prefix moved to the end.",
+            "type": "string"
+          },
+          "nameIgnorePrefixSort": {
+            "description": "The name of the series with any prefix removed.",
+            "type": "string"
+          },
+          "type": {
+            "description": "Will always be `series`.",
+            "type": "string"
+          },
+          "books": {
+            "description": "The library items that contain the books in the series. A sequence attribute that denotes the position in the series the book is in, is tacked on.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/libraryItemSequence"
+            }
+          },
+          "totalDuration": {
+            "description": "The combined duration (in seconds) of all books in the series.",
+            "type": "number"
+          }
+        }
       },
       "seriesDescription": {
         "description": "A description for the series. Will be null if there is none.",
@@ -1252,6 +1968,16 @@
             "schema": {
               "type": "string",
               "example": "Author not found."
+            }
+          }
+        }
+      },
+      "library200": {
+        "description": "Library found.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/library"
             }
           }
         }

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -492,6 +492,15 @@
         "tags": [
           "Libraries"
         ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "include",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "$ref": "#/components/responses/library200"
@@ -631,43 +640,66 @@
         "tags": [
           "Libraries"
         ],
-        "requestBody": {
-          "required": false,
-          "description": "The filters to apply to the requested library items.",
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "limit": {
-                    "$ref": "#/components/schemas/limit"
-                  },
-                  "page": {
-                    "$ref": "#/components/schemas/page"
-                  },
-                  "sort": {
-                    "$ref": "#/components/schemas/librarySort"
-                  },
-                  "desc": {
-                    "$ref": "#/components/schemas/sortDesc"
-                  },
-                  "filter": {
-                    "$ref": "#/components/schemas/libraryFilter"
-                  },
-                  "minified": {
-                    "$ref": "#/components/schemas/minified"
-                  },
-                  "collapseSeries": {
-                    "$ref": "#/components/schemas/libraryCollapseSeries"
-                  },
-                  "include": {
-                    "$ref": "#/components/schemas/libraryInclude"
-                  }
-                }
-              }
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/limit"
+          },
+          {
+            "$ref": "#/components/parameters/page"
+          },
+          {
+            "in": "query",
+            "name": "sort",
+            "description": "The field to sort by from the request.",
+            "example": "numBooks",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "name",
+                "numBooks",
+                "totalDuration",
+                "addedAt",
+                "lastBookAdded",
+                "lastBookUpdated"
+              ],
+              "default": "name"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/desc"
+          },
+          {
+            "in": "query",
+            "name": "filter",
+            "description": "The filter for the library.",
+            "example": "media.metadata.title",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "include",
+            "description": "The fields to include in the response. The only current option is `rssfeed`.",
+            "allowReserved": true,
+            "example": "rssfeed",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/minified"
+          },
+          {
+            "in": "query",
+            "name": "collapseSeries",
+            "description": "Whether to collapse series into a single cover",
+            "schema": {
+              "type": "integer",
+              "default": 0
             }
           }
-        },
+        ],
         "responses": {
           "200": {
             "description": "getLibraryItems OK",
@@ -781,24 +813,10 @@
         ],
         "parameters": [
           {
-            "in": "query",
-            "name": "limit",
-            "description": "The number of series to return. If 0, all series are returned.",
-            "example": 10,
-            "schema": {
-              "type": "integer",
-              "default": 0
-            }
+            "$ref": "#/components/parameters/limit"
           },
           {
-            "in": "query",
-            "name": "page",
-            "description": "The page number (zero indexed) to return. If no limit is specified, then page will have no effect.",
-            "example": 0,
-            "schema": {
-              "type": "integer",
-              "default": 0
-            }
+            "$ref": "#/components/parameters/page"
           },
           {
             "in": "query",
@@ -819,14 +837,7 @@
             }
           },
           {
-            "in": "query",
-            "name": "desc",
-            "description": "Return items in reversed order if true.",
-            "example": true,
-            "schema": {
-              "type": "boolean",
-              "default": false
-            }
+            "$ref": "#/components/parameters/desc"
           },
           {
             "in": "query",
@@ -841,6 +852,7 @@
             "in": "query",
             "name": "include",
             "description": "The fields to include in the response. The only current option is `rssfeed`.",
+            "allowReserved": true,
             "example": "rssfeed",
             "schema": {
               "type": "string"
@@ -925,51 +937,57 @@
         "tags": [
           "Libraries"
         ],
-        "requestBody": {
-          "required": false,
-          "description": "The filters to apply to the requested library series.",
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "limit": {
-                    "$ref": "#/components/schemas/limit"
-                  },
-                  "page": {
-                    "$ref": "#/components/schemas/page"
-                  },
-                  "sort": {
-                    "description": "The field to sort by from the request.",
-                    "type": "string",
-                    "enum": [
-                      "name",
-                      "numBooks",
-                      "totalDuration",
-                      "addedAt",
-                      "lastBookAdded",
-                      "lastBookUpdated"
-                    ],
-                    "example": "numBooks",
-                    "default": "name"
-                  },
-                  "desc": {
-                    "$ref": "#/components/schemas/sortDesc"
-                  },
-                  "filter": {
-                    "$ref": "#/components/schemas/libraryFilter"
-                  },
-                  "minified": {
-                    "$ref": "#/components/schemas/minified"
-                  },
-                  "include": {
-                    "$ref": "#/components/schemas/libraryInclude"
-                  }
-                }
-              }
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/limit"
+          },
+          {
+            "$ref": "#/components/parameters/page"
+          },
+          {
+            "in": "query",
+            "name": "sort",
+            "description": "The field to sort by from the request.",
+            "example": "numBooks",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "name",
+                "numBooks",
+                "totalDuration",
+                "addedAt",
+                "lastBookAdded",
+                "lastBookUpdated"
+              ],
+              "default": "name"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/desc"
+          },
+          {
+            "in": "query",
+            "name": "filter",
+            "description": "The filter for the library.",
+            "example": "media.metadata.title",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/minified"
+          },
+          {
+            "in": "query",
+            "name": "include",
+            "description": "The fields to include in the response. The only current option is `rssfeed`.",
+            "allowReserved": true,
+            "example": "rssfeed",
+            "schema": {
+              "type": "string"
             }
           }
-        },
+        ],
         "responses": {
           "200": {
             "description": "getLibrarySeriesById OK",
@@ -1766,6 +1784,11 @@
           }
         ]
       },
+      "total": {
+        "description": "The total number of items in the response.",
+        "type": "integer",
+        "example": 100
+      },
       "limit": {
         "description": "The number of items to return. If 0, no items are returned.",
         "type": "integer",
@@ -1778,20 +1801,19 @@
         "example": 1,
         "default": 0
       },
-      "librarySort": {
-        "description": "The sort order of the library. For example, to sort by title use 'sort=media.metadata.title'.",
+      "sortBy": {
         "type": "string",
+        "description": "The field to sort by from the request.",
         "example": "media.metadata.title"
       },
       "sortDesc": {
-        "description": "Return items in reversed order if true.",
+        "description": "Whether to sort in descending order.",
         "type": "boolean",
-        "example": true,
-        "default": false
+        "example": true
       },
-      "libraryFilter": {
-        "description": "The filter for the library.",
+      "filterBy": {
         "type": "string",
+        "description": "The field to filter by from the request. TODO",
         "example": "media.metadata.title"
       },
       "minified": {
@@ -1800,36 +1822,15 @@
         "example": true,
         "default": false
       },
-      "libraryCollapseSeries": {
-        "description": "Whether to collapse series.",
+      "collapseSeries": {
         "type": "boolean",
-        "example": true,
-        "default": false
+        "description": "Whether collapse series was set in the request.",
+        "example": true
       },
       "libraryInclude": {
         "description": "The fields to include in the response. The only current option is `rssfeed`.",
         "type": "string",
         "example": "rssfeed"
-      },
-      "total": {
-        "description": "The total number of items in the response.",
-        "type": "integer",
-        "example": 100
-      },
-      "sortBy": {
-        "type": "string",
-        "description": "The field to sort by from the request.",
-        "example": "media.metadata.title"
-      },
-      "filterBy": {
-        "type": "string",
-        "description": "The field to filter by from the request. TODO",
-        "example": "media.metadata.title"
-      },
-      "collapseSeries": {
-        "type": "boolean",
-        "description": "Whether collapse series was set in the request.",
-        "example": true
       },
       "sequence": {
         "description": "The position in the series the book is.",
@@ -2002,6 +2003,48 @@
               "example": "Series not found."
             }
           }
+        }
+      }
+    },
+    "parameters": {
+      "limit": {
+        "in": "query",
+        "name": "limit",
+        "description": "The number of items to return. This the size of a single page for the optional `page` query.",
+        "example": 10,
+        "schema": {
+          "type": "integer",
+          "default": 0
+        }
+      },
+      "page": {
+        "in": "query",
+        "name": "page",
+        "description": "The page number (zero indexed) to return. If no limit is specified, then page will have no effect.",
+        "example": 0,
+        "schema": {
+          "type": "integer",
+          "default": 0
+        }
+      },
+      "desc": {
+        "in": "query",
+        "name": "desc",
+        "description": "Return items in reversed order if true.",
+        "example": true,
+        "schema": {
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "minified": {
+        "in": "query",
+        "name": "minified",
+        "description": "Return minified items if true",
+        "schema": {
+          "type": "integer",
+          "minimum": 0,
+          "example": 1
         }
       }
     }

--- a/docs/schemas.yaml
+++ b/docs/schemas.yaml
@@ -60,3 +60,12 @@ components:
       type: string
       example: 'us'
       default: 'us'
+  parameters:
+    minified:
+      in: query
+      name: minified
+      description: Return minified items if true
+      schema:
+        type: integer
+        minimum: 0
+        example: 1

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "axios": "^0.27.2",
         "cookie-parser": "^1.4.6",
         "express": "^4.17.1",
+        "express-openapi-validator": "^5.2.0",
         "express-session": "^1.17.3",
         "graceful-fs": "^4.2.10",
         "htmlparser2": "^8.0.1",
@@ -50,6 +51,38 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@apidevtools/json-schema-ref-parser": {
+      "version": "11.6.4",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-11.6.4.tgz",
+      "integrity": "sha512-9K6xOqeevacvweLGik6LnZCb1fBtCOSIWQs8d096XGeqoLKC33UVMGz9+77Gw44KvbH4pKcQPWo4ZpxkXYj05w==",
+      "dependencies": {
+        "@jsdevtools/ono": "^7.1.3",
+        "@types/json-schema": "^7.0.15",
+        "js-yaml": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/philsturgeon"
+      }
+    },
+    "node_modules/@apidevtools/json-schema-ref-parser/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+    },
+    "node_modules/@apidevtools/json-schema-ref-parser/node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -568,6 +601,11 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@jsdevtools/ono": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
+      "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg=="
+    },
     "node_modules/@mapbox/node-pre-gyp": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.10.tgz",
@@ -735,6 +773,23 @@
         "node": ">= 6"
       }
     },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.5",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.5.tgz",
+      "integrity": "sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg==",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/cookie": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
@@ -756,15 +811,89 @@
         "@types/ms": "*"
       }
     },
+    "node_modules/@types/express": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.21.tgz",
+      "integrity": "sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.33",
+        "@types/qs": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "4.19.3",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.3.tgz",
+      "integrity": "sha512-KOzM7MhcBFlmnlr/fzISFF5vGWVSvN6fTd4T+ExOt08bA/dA5kpSzY52nMsI1KDFmUREpJelPYyuslLRSjjgCg==",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.4.tgz",
+      "integrity": "sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA=="
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="
+    },
+    "node_modules/@types/mime": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
+      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w=="
+    },
     "node_modules/@types/ms": {
       "version": "0.7.31",
       "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
       "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA=="
     },
+    "node_modules/@types/multer": {
+      "version": "1.4.11",
+      "resolved": "https://registry.npmjs.org/@types/multer/-/multer-1.4.11.tgz",
+      "integrity": "sha512-svK240gr6LVWvv3YGyhLlA+6LRRWA4mnGIU7RcNmgjBYFl6665wcXrRfxGp5tEPVHUNm5FMcmq7too9bxCwX/w==",
+      "dependencies": {
+        "@types/express": "*"
+      }
+    },
     "node_modules/@types/node": {
       "version": "18.11.18",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.18.tgz",
       "integrity": "sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA=="
+    },
+    "node_modules/@types/qs": {
+      "version": "6.9.15",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.15.tgz",
+      "integrity": "sha512-uXHQKES6DQKKCLh441Xv/dwxOq1TVS3JPUMlEqoEglvlhR6Mxnlew/Xq/LRVHpLyk7iK3zODe1qYHIMltO7XGg=="
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ=="
+    },
+    "node_modules/@types/send": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.4.tgz",
+      "integrity": "sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==",
+      "dependencies": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "1.15.7",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.7.tgz",
+      "integrity": "sha512-W8Ym+h8nhuRwaKPaDw34QUkwsGi6Rc4yYqvKFo5rm2FUEhCFbzVWrxXUxuKK8TASjWsysJY0nsmNCGhCOIsrOw==",
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/node": "*",
+        "@types/send": "*"
+      }
     },
     "node_modules/@types/validator": {
       "version": "13.7.17",
@@ -870,6 +999,50 @@
         "node": ">=8"
       }
     },
+    "node_modules/ajv": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.16.0.tgz",
+      "integrity": "sha512-F0twR8U1ZU67JIEtekUcLkXkoO5mMMmgGD8sK/xUFzJ805jxHQl92hImFAqqXMyMYjSPOyUPAwHYhB72g5sTXw==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.4.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-draft-04": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
+      "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
+      "peerDependencies": {
+        "ajv": "^8.5.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/ansi-colors": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
@@ -914,6 +1087,11 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/append-field": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
+      "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw=="
     },
     "node_modules/append-transform": {
       "version": "2.0.0",
@@ -1095,6 +1273,22 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -1385,6 +1579,52 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
     },
+    "node_modules/concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "engines": [
+        "node >= 0.8"
+      ],
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "node_modules/concat-stream/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+    },
+    "node_modules/concat-stream/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/concat-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "node_modules/concat-stream/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/console-control-strings": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
@@ -1402,9 +1642,9 @@
       }
     },
     "node_modules/content-type": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
       "engines": {
         "node": ">= 0.6"
       }
@@ -1447,6 +1687,11 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
     },
     "node_modules/cors": {
       "version": "2.8.5",
@@ -1851,6 +2096,42 @@
         "node": ">= 0.10.0"
       }
     },
+    "node_modules/express-openapi-validator": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/express-openapi-validator/-/express-openapi-validator-5.2.0.tgz",
+      "integrity": "sha512-7YMLsnC9MfeCa/nb2YnAxxRKGzkZ6GucjCcZc+IZU6AHq0TZ3vLOGhXT+uqMV3QiCJWy0XdzQtrUBwGD8eBEaQ==",
+      "dependencies": {
+        "@apidevtools/json-schema-ref-parser": "^11.6.2",
+        "@types/multer": "^1.4.11",
+        "ajv": "^8.14.0",
+        "ajv-draft-04": "^1.0.0",
+        "ajv-formats": "^2.1.1",
+        "content-type": "^1.0.5",
+        "json-schema-traverse": "^1.0.0",
+        "lodash.clonedeep": "^4.5.0",
+        "lodash.get": "^4.4.2",
+        "media-typer": "^1.1.0",
+        "multer": "^1.4.5-lts.1",
+        "ono": "^7.1.3",
+        "path-to-regexp": "^6.2.2"
+      },
+      "peerDependencies": {
+        "express": "*"
+      }
+    },
+    "node_modules/express-openapi-validator/node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/express-openapi-validator/node_modules/path-to-regexp": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.2.tgz",
+      "integrity": "sha512-GQX3SSMokngb36+whdpRXE+3f9V8UzyAorlYvOGx87ufGHehNTn5lCxrKtLyZ4Yl/wEKnNnr98ZzOwwDZV5ogw=="
+    },
     "node_modules/express-session": {
       "version": "1.17.3",
       "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.17.3.tgz",
@@ -1876,6 +2157,11 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "node_modules/fill-range": {
       "version": "7.0.1",
@@ -2772,6 +3058,11 @@
         "node": ">=4"
       }
     },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -2877,6 +3168,11 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
+    "node_modules/lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ=="
+    },
     "node_modules/lodash.flattendeep": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
@@ -2886,8 +3182,7 @@
     "node_modules/lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
-      "dev": true
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ=="
     },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
@@ -3070,6 +3365,14 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/minipass": {
@@ -3454,6 +3757,34 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+    },
+    "node_modules/multer": {
+      "version": "1.4.5-lts.1",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-1.4.5-lts.1.tgz",
+      "integrity": "sha512-ywPWvcDMeH+z9gQq5qYHCCy+ethsk4goepZ45GLD63fOu0YcNecQxi64nDs3qluZB+murG3/D4dJ7+dGctcCQQ==",
+      "dependencies": {
+        "append-field": "^1.0.0",
+        "busboy": "^1.0.0",
+        "concat-stream": "^1.5.2",
+        "mkdirp": "^0.5.4",
+        "object-assign": "^4.1.1",
+        "type-is": "^1.6.4",
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/multer/node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
     },
     "node_modules/nanoid": {
       "version": "3.3.3",
@@ -3882,6 +4213,14 @@
         "wrappy": "1"
       }
     },
+    "node_modules/ono": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/ono/-/ono-7.1.3.tgz",
+      "integrity": "sha512-9jnfVriq7uJM4o5ganUY54ntUm+5EK21EGaQ5NWnkWg3zz5ywbbonlBguRcnmF1/HDiIe3zxNxXcO1YPBmPcQQ==",
+      "dependencies": {
+        "@jsdevtools/ono": "7.1.3"
+      }
+    },
     "node_modules/openid-client": {
       "version": "5.6.1",
       "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-5.6.1.tgz",
@@ -4121,6 +4460,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+    },
     "node_modules/process-on-spawn": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/process-on-spawn/-/process-on-spawn-1.0.0.tgz",
@@ -4169,6 +4513,14 @@
       "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
       "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==",
       "dev": true
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/qs": {
       "version": "6.11.0",
@@ -4265,6 +4617,14 @@
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4872,6 +5232,14 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -5056,6 +5424,11 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
+    },
     "node_modules/typedarray-to-buffer": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
@@ -5136,6 +5509,14 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dependencies": {
+        "punycode": "^2.1.0"
       }
     },
     "node_modules/util-deprecate": {
@@ -5304,6 +5685,14 @@
       "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "engines": {
+        "node": ">=0.4"
       }
     },
     "node_modules/y18n": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
       },
       "devDependencies": {
         "chai": "^4.3.10",
+        "express-openapi-validator": "^5.2.0",
         "mocha": "^10.2.0",
         "nodemon": "^2.0.20",
         "nyc": "^15.1.0",
@@ -50,6 +51,41 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@apidevtools/json-schema-ref-parser": {
+      "version": "11.6.4",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-11.6.4.tgz",
+      "integrity": "sha512-9K6xOqeevacvweLGik6LnZCb1fBtCOSIWQs8d096XGeqoLKC33UVMGz9+77Gw44KvbH4pKcQPWo4ZpxkXYj05w==",
+      "dev": true,
+      "dependencies": {
+        "@jsdevtools/ono": "^7.1.3",
+        "@types/json-schema": "^7.0.15",
+        "js-yaml": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/philsturgeon"
+      }
+    },
+    "node_modules/@apidevtools/json-schema-ref-parser/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
+    },
+    "node_modules/@apidevtools/json-schema-ref-parser/node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -568,6 +604,12 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@jsdevtools/ono": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
+      "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
+      "dev": true
+    },
     "node_modules/@mapbox/node-pre-gyp": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.10.tgz",
@@ -735,6 +777,25 @@
         "node": ">= 6"
       }
     },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.5",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.5.tgz",
+      "integrity": "sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg==",
+      "dev": true,
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/cookie": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
@@ -756,15 +817,99 @@
         "@types/ms": "*"
       }
     },
+    "node_modules/@types/express": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.21.tgz",
+      "integrity": "sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.33",
+        "@types/qs": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "4.19.3",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.3.tgz",
+      "integrity": "sha512-KOzM7MhcBFlmnlr/fzISFF5vGWVSvN6fTd4T+ExOt08bA/dA5kpSzY52nMsI1KDFmUREpJelPYyuslLRSjjgCg==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.4.tgz",
+      "integrity": "sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==",
+      "dev": true
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true
+    },
+    "node_modules/@types/mime": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
+      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
+      "dev": true
+    },
     "node_modules/@types/ms": {
       "version": "0.7.31",
       "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
       "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA=="
     },
+    "node_modules/@types/multer": {
+      "version": "1.4.11",
+      "resolved": "https://registry.npmjs.org/@types/multer/-/multer-1.4.11.tgz",
+      "integrity": "sha512-svK240gr6LVWvv3YGyhLlA+6LRRWA4mnGIU7RcNmgjBYFl6665wcXrRfxGp5tEPVHUNm5FMcmq7too9bxCwX/w==",
+      "dev": true,
+      "dependencies": {
+        "@types/express": "*"
+      }
+    },
     "node_modules/@types/node": {
       "version": "18.11.18",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.18.tgz",
       "integrity": "sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA=="
+    },
+    "node_modules/@types/qs": {
+      "version": "6.9.15",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.15.tgz",
+      "integrity": "sha512-uXHQKES6DQKKCLh441Xv/dwxOq1TVS3JPUMlEqoEglvlhR6Mxnlew/Xq/LRVHpLyk7iK3zODe1qYHIMltO7XGg==",
+      "dev": true
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "dev": true
+    },
+    "node_modules/@types/send": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.4.tgz",
+      "integrity": "sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==",
+      "dev": true,
+      "dependencies": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "1.15.7",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.7.tgz",
+      "integrity": "sha512-W8Ym+h8nhuRwaKPaDw34QUkwsGi6Rc4yYqvKFo5rm2FUEhCFbzVWrxXUxuKK8TASjWsysJY0nsmNCGhCOIsrOw==",
+      "dev": true,
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/node": "*",
+        "@types/send": "*"
+      }
     },
     "node_modules/@types/validator": {
       "version": "13.7.17",
@@ -870,6 +1015,53 @@
         "node": ">=8"
       }
     },
+    "node_modules/ajv": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.16.0.tgz",
+      "integrity": "sha512-F0twR8U1ZU67JIEtekUcLkXkoO5mMMmgGD8sK/xUFzJ805jxHQl92hImFAqqXMyMYjSPOyUPAwHYhB72g5sTXw==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.4.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-draft-04": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
+      "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
+      "dev": true,
+      "peerDependencies": {
+        "ajv": "^8.5.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "dev": true,
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/ansi-colors": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
@@ -914,6 +1106,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/append-field": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
+      "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==",
+      "dev": true
     },
     "node_modules/append-transform": {
       "version": "2.0.0",
@@ -1095,6 +1293,24 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dev": true,
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -1385,6 +1601,57 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
     },
+    "node_modules/concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "dev": true,
+      "engines": [
+        "node >= 0.8"
+      ],
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "node_modules/concat-stream/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true
+    },
+    "node_modules/concat-stream/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/concat-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
+    },
+    "node_modules/concat-stream/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/console-control-strings": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
@@ -1402,9 +1669,9 @@
       }
     },
     "node_modules/content-type": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
       "engines": {
         "node": ">= 0.6"
       }
@@ -1447,6 +1714,12 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "dev": true
     },
     "node_modules/cors": {
       "version": "2.8.5",
@@ -1851,6 +2124,45 @@
         "node": ">= 0.10.0"
       }
     },
+    "node_modules/express-openapi-validator": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/express-openapi-validator/-/express-openapi-validator-5.2.0.tgz",
+      "integrity": "sha512-7YMLsnC9MfeCa/nb2YnAxxRKGzkZ6GucjCcZc+IZU6AHq0TZ3vLOGhXT+uqMV3QiCJWy0XdzQtrUBwGD8eBEaQ==",
+      "dev": true,
+      "dependencies": {
+        "@apidevtools/json-schema-ref-parser": "^11.6.2",
+        "@types/multer": "^1.4.11",
+        "ajv": "^8.14.0",
+        "ajv-draft-04": "^1.0.0",
+        "ajv-formats": "^2.1.1",
+        "content-type": "^1.0.5",
+        "json-schema-traverse": "^1.0.0",
+        "lodash.clonedeep": "^4.5.0",
+        "lodash.get": "^4.4.2",
+        "media-typer": "^1.1.0",
+        "multer": "^1.4.5-lts.1",
+        "ono": "^7.1.3",
+        "path-to-regexp": "^6.2.2"
+      },
+      "peerDependencies": {
+        "express": "*"
+      }
+    },
+    "node_modules/express-openapi-validator/node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/express-openapi-validator/node_modules/path-to-regexp": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.2.tgz",
+      "integrity": "sha512-GQX3SSMokngb36+whdpRXE+3f9V8UzyAorlYvOGx87ufGHehNTn5lCxrKtLyZ4Yl/wEKnNnr98ZzOwwDZV5ogw==",
+      "dev": true
+    },
     "node_modules/express-session": {
       "version": "1.17.3",
       "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.17.3.tgz",
@@ -1876,6 +2188,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
     },
     "node_modules/fill-range": {
       "version": "7.0.1",
@@ -2772,6 +3090,12 @@
         "node": ">=4"
       }
     },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true
+    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -2876,6 +3200,12 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
+    "node_modules/lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
+      "dev": true
     },
     "node_modules/lodash.flattendeep": {
       "version": "4.4.0",
@@ -3070,6 +3400,15 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/minipass": {
@@ -3454,6 +3793,36 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+    },
+    "node_modules/multer": {
+      "version": "1.4.5-lts.1",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-1.4.5-lts.1.tgz",
+      "integrity": "sha512-ywPWvcDMeH+z9gQq5qYHCCy+ethsk4goepZ45GLD63fOu0YcNecQxi64nDs3qluZB+murG3/D4dJ7+dGctcCQQ==",
+      "dev": true,
+      "dependencies": {
+        "append-field": "^1.0.0",
+        "busboy": "^1.0.0",
+        "concat-stream": "^1.5.2",
+        "mkdirp": "^0.5.4",
+        "object-assign": "^4.1.1",
+        "type-is": "^1.6.4",
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/multer/node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
     },
     "node_modules/nanoid": {
       "version": "3.3.3",
@@ -3882,6 +4251,15 @@
         "wrappy": "1"
       }
     },
+    "node_modules/ono": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/ono/-/ono-7.1.3.tgz",
+      "integrity": "sha512-9jnfVriq7uJM4o5ganUY54ntUm+5EK21EGaQ5NWnkWg3zz5ywbbonlBguRcnmF1/HDiIe3zxNxXcO1YPBmPcQQ==",
+      "dev": true,
+      "dependencies": {
+        "@jsdevtools/ono": "7.1.3"
+      }
+    },
     "node_modules/openid-client": {
       "version": "5.6.1",
       "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-5.6.1.tgz",
@@ -4121,6 +4499,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true
+    },
     "node_modules/process-on-spawn": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/process-on-spawn/-/process-on-spawn-1.0.0.tgz",
@@ -4169,6 +4553,15 @@
       "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
       "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==",
       "dev": true
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/qs": {
       "version": "6.11.0",
@@ -4264,6 +4657,15 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -4872,6 +5274,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -5056,6 +5467,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "dev": true
+    },
     "node_modules/typedarray-to-buffer": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
@@ -5136,6 +5553,15 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "dependencies": {
+        "punycode": "^2.1.0"
       }
     },
     "node_modules/util-deprecate": {
@@ -5304,6 +5730,15 @@
       "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4"
       }
     },
     "node_modules/y18n": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "axios": "^0.27.2",
         "cookie-parser": "^1.4.6",
         "express": "^4.17.1",
-        "express-openapi-validator": "^5.2.0",
         "express-session": "^1.17.3",
         "graceful-fs": "^4.2.10",
         "htmlparser2": "^8.0.1",
@@ -51,38 +50,6 @@
       },
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@apidevtools/json-schema-ref-parser": {
-      "version": "11.6.4",
-      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-11.6.4.tgz",
-      "integrity": "sha512-9K6xOqeevacvweLGik6LnZCb1fBtCOSIWQs8d096XGeqoLKC33UVMGz9+77Gw44KvbH4pKcQPWo4ZpxkXYj05w==",
-      "dependencies": {
-        "@jsdevtools/ono": "^7.1.3",
-        "@types/json-schema": "^7.0.15",
-        "js-yaml": "^4.1.0"
-      },
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/philsturgeon"
-      }
-    },
-    "node_modules/@apidevtools/json-schema-ref-parser/node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
-    },
-    "node_modules/@apidevtools/json-schema-ref-parser/node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -601,11 +568,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@jsdevtools/ono": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
-      "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg=="
-    },
     "node_modules/@mapbox/node-pre-gyp": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.10.tgz",
@@ -773,23 +735,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/@types/body-parser": {
-      "version": "1.19.5",
-      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.5.tgz",
-      "integrity": "sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg==",
-      "dependencies": {
-        "@types/connect": "*",
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/connect": {
-      "version": "3.4.38",
-      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
-      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/cookie": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
@@ -811,89 +756,15 @@
         "@types/ms": "*"
       }
     },
-    "node_modules/@types/express": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.21.tgz",
-      "integrity": "sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==",
-      "dependencies": {
-        "@types/body-parser": "*",
-        "@types/express-serve-static-core": "^4.17.33",
-        "@types/qs": "*",
-        "@types/serve-static": "*"
-      }
-    },
-    "node_modules/@types/express-serve-static-core": {
-      "version": "4.19.3",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.3.tgz",
-      "integrity": "sha512-KOzM7MhcBFlmnlr/fzISFF5vGWVSvN6fTd4T+ExOt08bA/dA5kpSzY52nMsI1KDFmUREpJelPYyuslLRSjjgCg==",
-      "dependencies": {
-        "@types/node": "*",
-        "@types/qs": "*",
-        "@types/range-parser": "*",
-        "@types/send": "*"
-      }
-    },
-    "node_modules/@types/http-errors": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.4.tgz",
-      "integrity": "sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA=="
-    },
-    "node_modules/@types/json-schema": {
-      "version": "7.0.15",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
-      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="
-    },
-    "node_modules/@types/mime": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
-      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w=="
-    },
     "node_modules/@types/ms": {
       "version": "0.7.31",
       "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
       "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA=="
     },
-    "node_modules/@types/multer": {
-      "version": "1.4.11",
-      "resolved": "https://registry.npmjs.org/@types/multer/-/multer-1.4.11.tgz",
-      "integrity": "sha512-svK240gr6LVWvv3YGyhLlA+6LRRWA4mnGIU7RcNmgjBYFl6665wcXrRfxGp5tEPVHUNm5FMcmq7too9bxCwX/w==",
-      "dependencies": {
-        "@types/express": "*"
-      }
-    },
     "node_modules/@types/node": {
       "version": "18.11.18",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.18.tgz",
       "integrity": "sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA=="
-    },
-    "node_modules/@types/qs": {
-      "version": "6.9.15",
-      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.15.tgz",
-      "integrity": "sha512-uXHQKES6DQKKCLh441Xv/dwxOq1TVS3JPUMlEqoEglvlhR6Mxnlew/Xq/LRVHpLyk7iK3zODe1qYHIMltO7XGg=="
-    },
-    "node_modules/@types/range-parser": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
-      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ=="
-    },
-    "node_modules/@types/send": {
-      "version": "0.17.4",
-      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.4.tgz",
-      "integrity": "sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==",
-      "dependencies": {
-        "@types/mime": "^1",
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/serve-static": {
-      "version": "1.15.7",
-      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.7.tgz",
-      "integrity": "sha512-W8Ym+h8nhuRwaKPaDw34QUkwsGi6Rc4yYqvKFo5rm2FUEhCFbzVWrxXUxuKK8TASjWsysJY0nsmNCGhCOIsrOw==",
-      "dependencies": {
-        "@types/http-errors": "*",
-        "@types/node": "*",
-        "@types/send": "*"
-      }
     },
     "node_modules/@types/validator": {
       "version": "13.7.17",
@@ -999,50 +870,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/ajv": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.16.0.tgz",
-      "integrity": "sha512-F0twR8U1ZU67JIEtekUcLkXkoO5mMMmgGD8sK/xUFzJ805jxHQl92hImFAqqXMyMYjSPOyUPAwHYhB72g5sTXw==",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.4.1"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/ajv-draft-04": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
-      "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
-      "peerDependencies": {
-        "ajv": "^8.5.0"
-      },
-      "peerDependenciesMeta": {
-        "ajv": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/ajv-formats": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
-      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
-      "dependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "ajv": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/ansi-colors": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
@@ -1087,11 +914,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/append-field": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
-      "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw=="
     },
     "node_modules/append-transform": {
       "version": "2.0.0",
@@ -1273,22 +1095,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
-    },
-    "node_modules/buffer-from": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
-    },
-    "node_modules/busboy": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
-      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
-      "dependencies": {
-        "streamsearch": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=10.16.0"
-      }
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -1579,52 +1385,6 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
     },
-    "node_modules/concat-stream": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
-      "engines": [
-        "node >= 0.8"
-      ],
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
-        "typedarray": "^0.0.6"
-      }
-    },
-    "node_modules/concat-stream/node_modules/isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
-    },
-    "node_modules/concat-stream/node_modules/readable-stream": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/concat-stream/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-    },
-    "node_modules/concat-stream/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
     "node_modules/console-control-strings": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
@@ -1642,9 +1402,9 @@
       }
     },
     "node_modules/content-type": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
-      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
       "engines": {
         "node": ">= 0.6"
       }
@@ -1687,11 +1447,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
-    },
-    "node_modules/core-util-is": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
     },
     "node_modules/cors": {
       "version": "2.8.5",
@@ -2096,42 +1851,6 @@
         "node": ">= 0.10.0"
       }
     },
-    "node_modules/express-openapi-validator": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/express-openapi-validator/-/express-openapi-validator-5.2.0.tgz",
-      "integrity": "sha512-7YMLsnC9MfeCa/nb2YnAxxRKGzkZ6GucjCcZc+IZU6AHq0TZ3vLOGhXT+uqMV3QiCJWy0XdzQtrUBwGD8eBEaQ==",
-      "dependencies": {
-        "@apidevtools/json-schema-ref-parser": "^11.6.2",
-        "@types/multer": "^1.4.11",
-        "ajv": "^8.14.0",
-        "ajv-draft-04": "^1.0.0",
-        "ajv-formats": "^2.1.1",
-        "content-type": "^1.0.5",
-        "json-schema-traverse": "^1.0.0",
-        "lodash.clonedeep": "^4.5.0",
-        "lodash.get": "^4.4.2",
-        "media-typer": "^1.1.0",
-        "multer": "^1.4.5-lts.1",
-        "ono": "^7.1.3",
-        "path-to-regexp": "^6.2.2"
-      },
-      "peerDependencies": {
-        "express": "*"
-      }
-    },
-    "node_modules/express-openapi-validator/node_modules/media-typer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
-      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/express-openapi-validator/node_modules/path-to-regexp": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.2.tgz",
-      "integrity": "sha512-GQX3SSMokngb36+whdpRXE+3f9V8UzyAorlYvOGx87ufGHehNTn5lCxrKtLyZ4Yl/wEKnNnr98ZzOwwDZV5ogw=="
-    },
     "node_modules/express-session": {
       "version": "1.17.3",
       "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.17.3.tgz",
@@ -2157,11 +1876,6 @@
       "engines": {
         "node": ">= 0.6"
       }
-    },
-    "node_modules/fast-deep-equal": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "node_modules/fill-range": {
       "version": "7.0.1",
@@ -3058,11 +2772,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
-    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -3168,11 +2877,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
-    "node_modules/lodash.clonedeep": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ=="
-    },
     "node_modules/lodash.flattendeep": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
@@ -3182,7 +2886,8 @@
     "node_modules/lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ=="
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+      "dev": true
     },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
@@ -3365,14 +3070,6 @@
       },
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/minimist": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/minipass": {
@@ -3757,34 +3454,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
-    },
-    "node_modules/multer": {
-      "version": "1.4.5-lts.1",
-      "resolved": "https://registry.npmjs.org/multer/-/multer-1.4.5-lts.1.tgz",
-      "integrity": "sha512-ywPWvcDMeH+z9gQq5qYHCCy+ethsk4goepZ45GLD63fOu0YcNecQxi64nDs3qluZB+murG3/D4dJ7+dGctcCQQ==",
-      "dependencies": {
-        "append-field": "^1.0.0",
-        "busboy": "^1.0.0",
-        "concat-stream": "^1.5.2",
-        "mkdirp": "^0.5.4",
-        "object-assign": "^4.1.1",
-        "type-is": "^1.6.4",
-        "xtend": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
-    "node_modules/multer/node_modules/mkdirp": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "dependencies": {
-        "minimist": "^1.2.6"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      }
     },
     "node_modules/nanoid": {
       "version": "3.3.3",
@@ -4213,14 +3882,6 @@
         "wrappy": "1"
       }
     },
-    "node_modules/ono": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/ono/-/ono-7.1.3.tgz",
-      "integrity": "sha512-9jnfVriq7uJM4o5ganUY54ntUm+5EK21EGaQ5NWnkWg3zz5ywbbonlBguRcnmF1/HDiIe3zxNxXcO1YPBmPcQQ==",
-      "dependencies": {
-        "@jsdevtools/ono": "7.1.3"
-      }
-    },
     "node_modules/openid-client": {
       "version": "5.6.1",
       "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-5.6.1.tgz",
@@ -4460,11 +4121,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
-    },
     "node_modules/process-on-spawn": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/process-on-spawn/-/process-on-spawn-1.0.0.tgz",
@@ -4513,14 +4169,6 @@
       "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
       "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==",
       "dev": true
-    },
-    "node_modules/punycode": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
-      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/qs": {
       "version": "6.11.0",
@@ -4617,14 +4265,6 @@
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/require-from-string": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5232,14 +4872,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/streamsearch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
-      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -5424,11 +5056,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/typedarray": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
-    },
     "node_modules/typedarray-to-buffer": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
@@ -5509,14 +5136,6 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
-      }
-    },
-    "node_modules/uri-js": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
-      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "dependencies": {
-        "punycode": "^2.1.0"
       }
     },
     "node_modules/util-deprecate": {
@@ -5685,14 +5304,6 @@
       "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
       "engines": {
         "node": ">=4.0"
-      }
-    },
-    "node_modules/xtend": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-      "engines": {
-        "node": ">=0.4"
       }
     },
     "node_modules/y18n": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "axios": "^0.27.2",
     "cookie-parser": "^1.4.6",
     "express": "^4.17.1",
-    "express-openapi-validator": "^5.2.0",
     "express-session": "^1.17.3",
     "graceful-fs": "^4.2.10",
     "htmlparser2": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
   },
   "devDependencies": {
     "chai": "^4.3.10",
+    "express-openapi-validator": "^5.2.0",
     "mocha": "^10.2.0",
     "nodemon": "^2.0.20",
     "nyc": "^15.1.0",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "axios": "^0.27.2",
     "cookie-parser": "^1.4.6",
     "express": "^4.17.1",
+    "express-openapi-validator": "^5.2.0",
     "express-session": "^1.17.3",
     "graceful-fs": "^4.2.10",
     "htmlparser2": "^8.0.1",

--- a/server/Server.js
+++ b/server/Server.js
@@ -206,7 +206,7 @@ class Server {
 
     // Install the OpenApiValidator middleware
     if (Logger.isDev) {
-      const apiSpec = Path.join(__dirname, 'openapi.json')
+      const apiSpec = Path.join(__dirname, '..', 'docs', 'openapi.json')
       app.use(
         OpenApiValidator.middleware({
           apiSpec: apiSpec,

--- a/server/Server.js
+++ b/server/Server.js
@@ -205,30 +205,32 @@ class Server {
     })
 
     // Install the OpenApiValidator middleware
-    const apiSpec = Path.join(__dirname, 'openapi.json')
-    app.use(
-      OpenApiValidator.middleware({
-        apiSpec: apiSpec,
-        validateRequests: true,
-        validateResponses: {
-          onError: (error, body, req) => {
-            console.log(`Response body fails validation: `, error)
-            console.log(`Emitted from:`, req.originalUrl)
-            console.debug(body)
-          }
-        },
-        formats: [
-          // Define custom format types for OpenAPI spec
-          {
-            name: 'uuid',
-            type: 'string',
-            validate: (v) => /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/.test(v.toString())
-          }
-        ],
-        unknownFormats: ['li_[a-z0-9]{18}', '[0-9]*'],
-        ignoreUndocumented: true
-      })
-    )
+    if (Logger.isDev) {
+      const apiSpec = Path.join(__dirname, 'openapi.json')
+      app.use(
+        OpenApiValidator.middleware({
+          apiSpec: apiSpec,
+          validateRequests: true,
+          validateResponses: {
+            onError: (error, body, req) => {
+              console.log(`Response body fails validation: `, error)
+              console.log(`Emitted from:`, req.originalUrl)
+              console.debug(body)
+            }
+          },
+          formats: [
+            // Define custom format types for OpenAPI spec
+            {
+              name: 'uuid',
+              type: 'string',
+              validate: (v) => /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/.test(v.toString())
+            }
+          ],
+          unknownFormats: ['li_[a-z0-9]{18}', '[0-9]*'],
+          ignoreUndocumented: true
+        })
+      )
+    }
 
     // parse cookies in requests
     app.use(cookieParser())

--- a/server/Server.js
+++ b/server/Server.js
@@ -204,8 +204,13 @@ class Server {
       next()
     })
 
-    // Install the OpenApiValidator middleware
+    // Install the OpenApiValidator middleware if using a dev environment
     if (Logger.isDev) {
+      // If you do not want to use this, you can comment out the entire section
+      // or only certain parts.
+      //
+      // The default value of `validateResponses` is false, so it can be safely commented
+      // out if the validation is causing problems.
       const apiSpec = Path.join(__dirname, '..', 'docs', 'openapi.json')
       app.use(
         OpenApiValidator.middleware({

--- a/server/Server.js
+++ b/server/Server.js
@@ -217,6 +217,15 @@ class Server {
             console.debug(body)
           }
         },
+        formats: [
+          // Define custom format types for OpenAPI spec
+          {
+            name: 'uuid',
+            type: 'string',
+            validate: (v) => /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/.test(v.toString())
+          }
+        ],
+        unknownFormats: ['li_[a-z0-9]{18}', '[0-9]*'],
         ignoreUndocumented: true
       })
     )

--- a/server/Server.js
+++ b/server/Server.js
@@ -1,6 +1,7 @@
 const Path = require('path')
 const Sequelize = require('sequelize')
 const express = require('express')
+const OpenApiValidator = require('express-openapi-validator')
 const http = require('http')
 const util = require('util')
 const fs = require('./libs/fsExtra')
@@ -202,6 +203,23 @@ class Server {
 
       next()
     })
+
+    // Install the OpenApiValidator middleware
+    const apiSpec = Path.join(__dirname, 'openapi.json')
+    app.use(
+      OpenApiValidator.middleware({
+        apiSpec: apiSpec,
+        validateRequests: true,
+        validateResponses: {
+          onError: (error, body, req) => {
+            console.log(`Response body fails validation: `, error)
+            console.log(`Emitted from:`, req.originalUrl)
+            console.debug(body)
+          }
+        },
+        ignoreUndocumented: true
+      })
+    )
 
     // parse cookies in requests
     app.use(cookieParser())


### PR DESCRIPTION
This PR adds `openapi-openapi-validator` to compare API requests and responses against the OpenAPI specification located in `docs`. I am only adding this as a dev dependency because if the request/response does not match the spec, the web client may render incorrectly (I ran into issues with the "edit library item" modal sometimes presenting a blank tab when the spec was not met).

An example of errors given to help identify how a request or response does not match the spec:
![Screenshot from 2024-06-21 14-52-02](https://github.com/advplyr/audiobookshelf/assets/5686638/90addac2-803b-459d-9d3a-193978d060ee)

This PR also updates some of the `requestBody` to `parameters` and creates some generic `parameter`s in response to changes made in https://github.com/advplyr/audiobookshelf/commit/d6438590d7010e9e9f512ecfdbf4cd7f0d149407