### PR TITLE
Add user agent string to feed requests

### DIFF
--- a/server/utils/ffmpegHelpers.js
+++ b/server/utils/ffmpegHelpers.js
@@ -7,7 +7,7 @@ const { filePathToPOSIX } = require('./fileUtils')
 
 function escapeSingleQuotes(path) {
   // return path.replace(/'/g, '\'\\\'\'')
-  return filePathToPOSIX(path).replace(/ /g, '\\ ').replace(/'/g, '\\\'')
+  return filePathToPOSIX(path).replace(/ /g, '\\ ').replace(/'/g, "\\'")
 }
 
 // Returns first track start time
@@ -19,7 +19,7 @@ async function writeConcatFile(tracks, outputPath, startTime = 0) {
   // Find first track greater than startTime
   if (startTime > 0) {
     var currTrackEnd = 0
-    var startingTrack = tracks.find(t => {
+    var startingTrack = tracks.find((t) => {
       currTrackEnd += t.duration
       return startTime < currTrackEnd
     })
@@ -29,8 +29,8 @@ async function writeConcatFile(tracks, outputPath, startTime = 0) {
     }
   }
 
-  var tracksToInclude = tracks.filter(t => t.index >= trackToStartWithIndex)
-  var trackPaths = tracksToInclude.map(t => {
+  var tracksToInclude = tracks.filter((t) => t.index >= trackToStartWithIndex)
+  var trackPaths = tracksToInclude.map((t) => {
     var line = 'file ' + escapeSingleQuotes(t.metadata.path) + '\n' + `duration ${t.duration}`
     return line
   })
@@ -99,6 +99,9 @@ module.exports.downloadPodcastEpisode = (podcastEpisodeDownload) => {
       url: podcastEpisodeDownload.url,
       method: 'GET',
       responseType: 'stream',
+      headers: {
+        'User-Agent': 'audiobookshelf (+https://audiobookshelf.org; like iTMS)'
+      },
       timeout: 30000
     }).catch((error) => {
       Logger.error(`[ffmpegHelpers] Failed to download podcast episode with url "${podcastEpisodeDownload.url}"`, error)
@@ -108,35 +111,31 @@ module.exports.downloadPodcastEpisode = (podcastEpisodeDownload) => {
 
     const ffmpeg = Ffmpeg(response.data)
     ffmpeg.addOption('-loglevel debug') // Debug logs printed on error
-    ffmpeg.outputOptions(
-      '-c:a', 'copy',
-      '-map', '0:a',
-      '-metadata', 'podcast=1'
-    )
+    ffmpeg.outputOptions('-c:a', 'copy', '-map', '0:a', '-metadata', 'podcast=1')
 
     const podcastMetadata = podcastEpisodeDownload.libraryItem.media.metadata
     const podcastEpisode = podcastEpisodeDownload.podcastEpisode
     const finalSizeInBytes = Number(podcastEpisode.enclosure?.length || 0)
 
     const taggings = {
-      'album': podcastMetadata.title,
+      album: podcastMetadata.title,
       'album-sort': podcastMetadata.title,
-      'artist': podcastMetadata.author,
+      artist: podcastMetadata.author,
       'artist-sort': podcastMetadata.author,
-      'comment': podcastEpisode.description,
-      'subtitle': podcastEpisode.subtitle,
-      'disc': podcastEpisode.season,
-      'genre': podcastMetadata.genres.length ? podcastMetadata.genres.join(';') : null,
-      'language': podcastMetadata.language,
-      'MVNM': podcastMetadata.title,
-      'MVIN': podcastEpisode.episode,
-      'track': podcastEpisode.episode,
+      comment: podcastEpisode.description,
+      subtitle: podcastEpisode.subtitle,
+      disc: podcastEpisode.season,
+      genre: podcastMetadata.genres.length ? podcastMetadata.genres.join(';') : null,
+      language: podcastMetadata.language,
+      MVNM: podcastMetadata.title,
+      MVIN: podcastEpisode.episode,
+      track: podcastEpisode.episode,
       'series-part': podcastEpisode.episode,
-      'title': podcastEpisode.title,
+      title: podcastEpisode.title,
       'title-sort': podcastEpisode.title,
-      'year': podcastEpisode.pubYear,
-      'date': podcastEpisode.pubDate,
-      'releasedate': podcastEpisode.pubDate,
+      year: podcastEpisode.pubYear,
+      date: podcastEpisode.pubDate,
+      releasedate: podcastEpisode.pubDate,
       'itunes-id': podcastMetadata.itunesId,
       'podcast-type': podcastMetadata.type,
       'episode-type': podcastMetadata.episodeType

--- a/server/utils/fileUtils.js
+++ b/server/utils/fileUtils.js
@@ -255,6 +255,9 @@ module.exports.downloadFile = (url, filepath, contentTypeFilter = null) => {
       url,
       method: 'GET',
       responseType: 'stream',
+      headers: {
+        'User-Agent': 'audiobookshelf (+https://audiobookshelf.org)'
+      },
       timeout: 30000,
       httpAgent: global.DisableSsrfRequestFilter ? null : ssrfFilter(url),
       httpsAgent: global.DisableSsrfRequestFilter ? null : ssrfFilter(url)

--- a/server/utils/podcastUtils.js
+++ b/server/utils/podcastUtils.js
@@ -235,7 +235,7 @@ module.exports.getPodcastFeed = (feedUrl, excludeEpisodeMetadata = false) => {
     responseType: 'arraybuffer',
     headers: {
       Accept: 'application/rss+xml, application/xhtml+xml, application/xml, */*;q=0.8',
-      'User-Agent': 'audiobookshelf (+https://github.com/advplyr/audiobookshelf; like iTMS)'
+      'User-Agent': 'audiobookshelf (+https://audiobookshelf.org; like iTMS)'
     },
     httpAgent: global.DisableSsrfRequestFilter ? null : ssrfFilter(feedUrl),
     httpsAgent: global.DisableSsrfRequestFilter ? null : ssrfFilter(feedUrl)

--- a/server/utils/podcastUtils.js
+++ b/server/utils/podcastUtils.js
@@ -233,7 +233,10 @@ module.exports.getPodcastFeed = (feedUrl, excludeEpisodeMetadata = false) => {
     method: 'GET',
     timeout: 12000,
     responseType: 'arraybuffer',
-    headers: { Accept: 'application/rss+xml, application/xhtml+xml, application/xml, */*;q=0.8' },
+    headers: {
+      Accept: 'application/rss+xml, application/xhtml+xml, application/xml, */*;q=0.8',
+      'User-Agent': 'audiobookshelf (+https://github.com/advplyr/audiobookshelf; like iTMS)'
+    },
     httpAgent: global.DisableSsrfRequestFilter ? null : ssrfFilter(feedUrl),
     httpsAgent: global.DisableSsrfRequestFilter ? null : ssrfFilter(feedUrl)
   })


### PR DESCRIPTION
Hey folks, I work on Pinecast (https://pinecast.com). We recently had a customer write in that their audiobookshelf server stopped updating feeds from us. It turns out that we'd seen a huge uptick in requests from the default Axios user agent string, which caused requests with that user agent to get served a captcha. My suspicion is that companies have started scraping more aggressively.

Podcast apps have (by and large) done a good job of providing descriptive `User-Agent` headers. Identifying your app allows podcasters to get informed analytics data and helps hosting companies like mine to identify and fix problems more easily.

---

In this PR, I'm adding the `user-agent` HTTP request header. I've chosen a value that is fairly straightforward: the name of the project, a link to the project, and `like iTMS` to indicate that the client should be treated similarly to Apple's podcast crawler. I do not have strong feelings about this UA string, but I'll suggest that if you decide to go with something else, you avoid adding a version number. There's a balance between user privacy (less information) and transparency (more descriptive information) and compatibility (more information that looks like another user agent).

This PR does not update the client calls to download media. I am not too familiar with the project and do not want to regress any features. However, I strongly suspect this function will need a similar update:

https://github.com/advplyr/audiobookshelf/blob/master/server/utils/fileUtils.js#L254

I'm glad to make that change as well, if you think it's appropriate.