### PR TITLE
bug: if oldLibraryItem is null things crash

### DIFF
--- a/server/scanner/LibraryScanner.js
+++ b/server/scanner/LibraryScanner.js
@@ -176,9 +176,11 @@ class LibraryScanner {
 
             // TODO: Temporary while using old model to socket emit
             const oldLibraryItem = await Database.libraryItemModel.getOldById(existingLibraryItem.id)
-            oldLibraryItem.isMissing = true
-            oldLibraryItem.updatedAt = Date.now()
-            oldLibraryItemsUpdated.push(oldLibraryItem)
+            if (oldLibraryItem) {
+              oldLibraryItem.isMissing = true
+              oldLibraryItem.updatedAt = Date.now()
+              oldLibraryItemsUpdated.push(oldLibraryItem)
+            }
           }
         }
       } else {


### PR DESCRIPTION
I'm not sure how it got into this state, but once in the state it keeps crashing. Might be because I have multiple instances running against the same sqlite database so two concurrent were scanning at the same time?