### PR TITLE
Prevent backup path edits when ENV is set

### DIFF
--- a/client/components/tables/BackupsTable.vue
+++ b/client/components/tables/BackupsTable.vue
@@ -171,7 +171,7 @@ export default {
       this.$axios
         .$get('/api/backups')
         .then((data) => {
-          this.$emit('loaded', data.backupLocation)
+          this.$emit('loaded', data)
           this.setBackups(data.backups || [])
         })
         .catch((error) => {

--- a/client/pages/config/backups.vue
+++ b/client/pages/config/backups.vue
@@ -16,11 +16,11 @@
         </div>
         <div v-else>
           <form class="flex items-center w-full space-x-1" @submit.prevent="saveBackupPath">
-            <ui-text-input v-model="newBackupLocation" :disabled="savingBackupPath" class="w-full max-w-[calc(100%-50px)] text-sm h-8" />
-            <ui-btn small :loading="savingBackupPath" color="success" type="submit" class="h-8">{{ $strings.ButtonSave }}</ui-btn>
+            <ui-text-input v-model="newBackupLocation" :disabled="savingBackupPath || !canEditBackup" class="w-full max-w-[calc(100%-50px)] text-sm h-8" />
+            <ui-btn v-if="canEditBackup" small :loading="savingBackupPath" color="success" type="submit" class="h-8">{{ $strings.ButtonSave }}</ui-btn>
             <ui-btn small :disabled="savingBackupPath" type="button" class="h-8" @click="cancelEditBackupPath">{{ $strings.ButtonCancel }}</ui-btn>
           </form>
-          <p class="text-sm text-warning/80 pt-1">{{ $strings.MessageBackupsLocationEditNote }}</p>
+          <p class="text-sm text-warning/80 pt-1">{{ canEditBackup ? $strings.MessageBackupsLocationEditNote : $strings.MessageBackupsLocationNoEditNote }}</p>
         </div>
       </div>
 
@@ -114,6 +114,10 @@ export default {
     },
     timeFormat() {
       return this.serverSettings.timeFormat
+    },
+    canEditBackup() {
+      // Prevent editing of backup path if an environement variable is set
+      return !this.serverSettings.backupPathEnvSet
     },
     scheduleDescription() {
       if (!this.cronExpression) return ''

--- a/client/pages/config/backups.vue
+++ b/client/pages/config/backups.vue
@@ -92,6 +92,7 @@ export default {
       newServerSettings: {},
       showCronBuilder: false,
       showEditBackupPath: false,
+      backupPathEnvSet: false,
       backupLocation: '',
       newBackupLocation: '',
       savingBackupPath: false
@@ -116,8 +117,8 @@ export default {
       return this.serverSettings.timeFormat
     },
     canEditBackup() {
-      // Prevent editing of backup path if an environement variable is set
-      return !this.serverSettings.backupPathEnvSet
+      // Prevent editing of backup path if an environment variable is set
+      return !this.backupPathEnvSet
     },
     scheduleDescription() {
       if (!this.cronExpression) return ''
@@ -131,9 +132,10 @@ export default {
     }
   },
   methods: {
-    backupsLoaded(backupLocation) {
-      this.backupLocation = backupLocation
-      this.newBackupLocation = backupLocation
+    backupsLoaded(data) {
+      this.backupLocation = data.backupLocation
+      this.newBackupLocation = data.backupLocation
+      this.backupPathEnvSet = data.backupPathEnvSet
     },
     cancelEditBackupPath() {
       this.newBackupLocation = this.backupLocation

--- a/client/strings/en-us.json
+++ b/client/strings/en-us.json
@@ -605,6 +605,7 @@
   "MessageAppriseDescription": "To use this feature you will need to have an instance of <a href=\"https://github.com/caronc/apprise-api\" target=\"_blank\">Apprise API</a> running or an api that will handle those same requests. <br />The Apprise API Url should be the full URL path to send the notification, e.g., if your API instance is served at <code>http://192.168.1.1:8337</code> then you would put <code>http://192.168.1.1:8337/notify</code>.",
   "MessageBackupsDescription": "Backups include users, user progress, library item details, server settings, and images stored in <code>/metadata/items</code> & <code>/metadata/authors</code>. Backups <strong>do not</strong> include any files stored in your library folders.",
   "MessageBackupsLocationEditNote": "Note: Updating the backup location will not move or modify existing backups",
+  "MessageBackupsLocationNoEditNote": "Note: The backup location is set through an environment variable and cannot be changed here.",
   "MessageBackupsLocationPathEmpty": "Backup location path cannot be empty",
   "MessageBatchQuickMatchDescription": "Quick Match will attempt to add missing covers and metadata for the selected items. Enable the options below to allow Quick Match to overwrite existing covers and/or metadata.",
   "MessageBookshelfNoCollections": "You haven't made any collections yet",

--- a/server/controllers/BackupController.js
+++ b/server/controllers/BackupController.js
@@ -10,7 +10,8 @@ class BackupController {
   getAll(req, res) {
     res.json({
       backups: this.backupManager.backups.map((b) => b.toJSON()),
-      backupLocation: this.backupManager.backupPath
+      backupLocation: this.backupManager.backupPath,
+      backupEnvSet: this.backupManager.backupPathEnvSet
     })
   }
 

--- a/server/controllers/BackupController.js
+++ b/server/controllers/BackupController.js
@@ -11,7 +11,7 @@ class BackupController {
     res.json({
       backups: this.backupManager.backups.map((b) => b.toJSON()),
       backupLocation: this.backupManager.backupPath,
-      backupEnvSet: this.backupManager.backupPathEnvSet
+      backupPathEnvSet: this.backupManager.backupPathEnvSet
     })
   }
 

--- a/server/managers/BackupManager.js
+++ b/server/managers/BackupManager.js
@@ -29,6 +29,10 @@ class BackupManager {
     return global.ServerSettings.backupPath
   }
 
+  get backupPathEnvSet() {
+    return global.ServerSettings.backupPathEnvSet
+  }
+
   get backupSchedule() {
     return global.ServerSettings.backupSchedule
   }

--- a/server/managers/BackupManager.js
+++ b/server/managers/BackupManager.js
@@ -30,7 +30,7 @@ class BackupManager {
   }
 
   get backupPathEnvSet() {
-    return global.ServerSettings.backupPathEnvSet
+    return !!process.env.BACKUP_PATH
   }
 
   get backupSchedule() {

--- a/server/objects/settings/ServerSettings.js
+++ b/server/objects/settings/ServerSettings.js
@@ -190,7 +190,7 @@ class ServerSettings {
       this.backupPath = process.env.BACKUP_PATH
     }
 
-    this.backupPathEnvSet = !!settings.process.env.BACKUP_PATH || false
+    this.backupPathEnvSet = !!process.env.BACKUP_PATH || false
   }
 
   toJSON() {

--- a/server/objects/settings/ServerSettings.js
+++ b/server/objects/settings/ServerSettings.js
@@ -26,6 +26,7 @@ class ServerSettings {
     this.rateLimitLoginWindow = 10 * 60 * 1000 // 10 Minutes
 
     // Backups
+    this.backupPathEnvSet = false
     this.backupPath = Path.join(global.MetadataPath, 'backups')
     this.backupSchedule = false // If false then auto-backups are disabled
     this.backupsToKeep = 2
@@ -188,6 +189,8 @@ class ServerSettings {
       Logger.info(`[ServerSettings] Using backup path from environment variable ${process.env.BACKUP_PATH}`)
       this.backupPath = process.env.BACKUP_PATH
     }
+
+    this.backupPathEnvSet = !!settings.process.env.BACKUP_PATH || false
   }
 
   toJSON() {
@@ -206,6 +209,7 @@ class ServerSettings {
       rateLimitLoginRequests: this.rateLimitLoginRequests,
       rateLimitLoginWindow: this.rateLimitLoginWindow,
       backupPath: this.backupPath,
+      backupPathEnvSet: this.backupPathEnvSet,
       backupSchedule: this.backupSchedule,
       backupsToKeep: this.backupsToKeep,
       maxBackupSize: this.maxBackupSize,

--- a/server/objects/settings/ServerSettings.js
+++ b/server/objects/settings/ServerSettings.js
@@ -26,7 +26,6 @@ class ServerSettings {
     this.rateLimitLoginWindow = 10 * 60 * 1000 // 10 Minutes
 
     // Backups
-    this.backupPathEnvSet = false
     this.backupPath = Path.join(global.MetadataPath, 'backups')
     this.backupSchedule = false // If false then auto-backups are disabled
     this.backupsToKeep = 2
@@ -189,8 +188,6 @@ class ServerSettings {
       Logger.info(`[ServerSettings] Using backup path from environment variable ${process.env.BACKUP_PATH}`)
       this.backupPath = process.env.BACKUP_PATH
     }
-
-    this.backupPathEnvSet = !!process.env.BACKUP_PATH || false
   }
 
   toJSON() {
@@ -209,7 +206,6 @@ class ServerSettings {
       rateLimitLoginRequests: this.rateLimitLoginRequests,
       rateLimitLoginWindow: this.rateLimitLoginWindow,
       backupPath: this.backupPath,
-      backupPathEnvSet: this.backupPathEnvSet,
       backupSchedule: this.backupSchedule,
       backupsToKeep: this.backupsToKeep,
       maxBackupSize: this.maxBackupSize,


### PR DESCRIPTION
This PR prevents the backup path from being edited in the web interface if the `BACKUP_PATH` environment variable is set. This is done to help prevent users from thinking their backup settings are not being applied correctly if they are not looking at the debug logs on server start as mentioned here https://github.com/advplyr/audiobookshelf/issues/2973#issuecomment-2179518347.

I changed the response for a `GET` request to `/api/backups` to include an additional value of whether this field can be editable, and set this value in the server settings in the same places where the ENV variable is checked.

Tested with setting and removing the ENV variable to make sure that the field is then editable.

View with environment variable not set:
![backups_no_env](https://github.com/advplyr/audiobookshelf/assets/5686638/534941ca-a30d-4f31-bed3-b8d64172f7ee)

View with environment variable set:
![backups_env](https://github.com/advplyr/audiobookshelf/assets/5686638/debc6bc0-e42b-483b-85d2-273b419d1596)
