### PR TITLE
Replace pkg with @yao-pkg/pkg and target node20

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
     branches-ignore:
-      - 'dependabot/**'  # Don't run dependabot branches, as they are already covered by pull requests
+      - 'dependabot/**' # Don't run dependabot branches, as they are already covered by pull requests
 
 jobs:
   build:
@@ -18,8 +18,8 @@ jobs:
         with:
           node-version: 20
 
-      - name: install pkg
-        run: npm install -g pkg
+      - name: install pkg (using yao-pkg fork for targetting node20)
+        run: npm install -g @yao-pkg/pkg
 
       - name: get client dependencies
         working-directory: client
@@ -33,7 +33,7 @@ jobs:
         run: npm ci --only=production
 
       - name: build binary
-        run: pkg -t node18-linux-x64 -o audiobookshelf .
+        run: pkg -t node20-linux-x64 -o audiobookshelf .
 
       - name: run audiobookshelf
         run: |

--- a/build/linuxpackager
+++ b/build/linuxpackager
@@ -48,7 +48,7 @@ Description: $DESCRIPTION"
 echo "$controlfile" > dist/debian/DEBIAN/control;
 
 # Package debian
-pkg -t node18-linux-x64 -o dist/debian/usr/share/audiobookshelf/audiobookshelf .
+pkg -t node20-linux-x64 -o dist/debian/usr/share/audiobookshelf/audiobookshelf .
 
 fakeroot dpkg-deb -Zxz --build dist/debian
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "start": "node index.js",
     "client": "cd client && npm ci && npm run generate",
     "prod": "npm run client && npm ci && node prod.js",
-    "build-win": "npm run client && pkg -t node18-win-x64 -o ./dist/win/audiobookshelf -C GZip .",
+    "build-win": "npm run client && pkg -t node20-win-x64 -o ./dist/win/audiobookshelf -C GZip .",
     "build-linux": "build/linuxpackager",
     "docker": "docker buildx build --platform linux/amd64,linux/arm64 --push .  -t advplyr/audiobookshelf",
     "docker-amd64-local": "docker buildx build --platform linux/amd64 --load .  -t advplyr/audiobookshelf-amd64-local",

--- a/server/Server.js
+++ b/server/Server.js
@@ -104,6 +104,7 @@ class Server {
    */
   async init() {
     Logger.info('[Server] Init v' + version)
+    Logger.info('[Server] Node.js Version:', process.version)
 
     await this.playbackSessionManager.removeOrphanStreams()
 


### PR DESCRIPTION
This replaces the use of pkg (which packs Node runtime and project code into a single binary) with the @yao-pkg/pkg fork. We do this since pkg is deprecated and in maintenance mode, and doesn't support packing a node20 runtime. Yao-pkg seems to be well maintained and used, and supports node20 targeting.

Changes made:
- Replace node18 pkg targets with node20
- Modify relevant workflows and scripts to install @yao-pkg/pkg instead of pkg
- Log Node version when server goes up for clarity