### PR TITLE
Add comma as a separator for genre tags in AudioFileScanner

### DIFF
--- a/server/scanner/AudioFileScanner.js
+++ b/server/scanner/AudioFileScanner.js
@@ -529,7 +529,7 @@ class AudioFileScanner {
    */
   parseGenresString(genreTag) {
     if (!genreTag?.length) return []
-    const separators = ['/', '//', ';']
+    const separators = ['/', '//', ';', ',']
     for (let i = 0; i < separators.length; i++) {
       if (genreTag.includes(separators[i])) {
         return genreTag


### PR DESCRIPTION
Fixes #3127.

This just adds comma as a valid separator for the genres tag.