### PR TITLE
Add ultrawide support for home page

### DIFF
--- a/client/components/app/BookShelfCategorized.vue
+++ b/client/components/app/BookShelfCategorized.vue
@@ -170,7 +170,7 @@ export default {
       // Sets the limit for the number of items to be displayed based on the viewport width.
       const viewportWidth = window.innerWidth
       let limit
-      if (viewportWidth >= 3240 && viewportWidth <= 3440) {
+      if (viewportWidth >= 3240) {
         limit = 15
       } else if (viewportWidth >= 2880 && viewportWidth < 3240) {
         limit = 12

--- a/client/components/app/BookShelfCategorized.vue
+++ b/client/components/app/BookShelfCategorized.vue
@@ -167,8 +167,19 @@ export default {
       this.loaded = true
     },
     async fetchCategories() {
+      // Sets the limit for the number of items to be displayed based on the viewport width.
+      const viewportWidth = window.innerWidth
+      let limit
+      if (viewportWidth >= 3240 && viewportWidth <= 3440) {
+        limit = 15
+      } else if (viewportWidth >= 2880 && viewportWidth < 3240) {
+        limit = 12
+      }
+
+      const limitQuery = limit ? `&limit=${limit}` : ''
+
       const categories = await this.$axios
-        .$get(`/api/libraries/${this.currentLibraryId}/personalized?include=rssfeed,numEpisodesIncomplete,share`)
+        .$get(`/api/libraries/${this.currentLibraryId}/personalized?include=rssfeed,numEpisodesIncomplete,share${limitQuery}`)
         .then((data) => {
           return data
         })


### PR DESCRIPTION
This adds a simple viewport condition when fetching the personalized shelve data for the home page, so screens with larger aspect ratios, such as 21:9, don't have space on the right side.

This resolves #2518 

