### PR TITLE
Make OPML import non-blocking

### DIFF
--- a/server/managers/PodcastManager.js
+++ b/server/managers/PodcastManager.js
@@ -354,9 +354,7 @@ class PodcastManager {
     var extractedFeeds = opmlParser.parse(opmlText)
     if (!extractedFeeds || !extractedFeeds.length) {
       Logger.error('[PodcastManager] getOPMLFeeds: No RSS feeds found in OPML')
-      return {
-        error: 'No RSS feeds found in OPML'
-      }
+      throw new Error('No RSS feeds found in OPML')
     }
 
     var rssFeedData = []
@@ -367,6 +365,11 @@ class PodcastManager {
         feedData.metadata.feedUrl = feed.feedUrl
         rssFeedData.push(feedData)
       }
+    }
+
+    if (!rssFeedData.length) {
+      Logger.error('[PodcastManager] getOPMLFeeds: No valid RSS feeds found in OPML')
+      throw new Error('No valid RSS feeds found in OPML')
     }
 
     return {

--- a/server/utils/podcastUtils.js
+++ b/server/utils/podcastUtils.js
@@ -231,7 +231,7 @@ module.exports.getPodcastFeed = (feedUrl, excludeEpisodeMetadata = false) => {
   return axios({
     url: feedUrl,
     method: 'GET',
-    timeout: 12000,
+    timeout: 5000,
     responseType: 'arraybuffer',
     headers: {
       Accept: 'application/rss+xml, application/xhtml+xml, application/xml, */*;q=0.8',
@@ -266,7 +266,7 @@ module.exports.getPodcastFeed = (feedUrl, excludeEpisodeMetadata = false) => {
       return payload.podcast
     })
     .catch((error) => {
-      Logger.error('[podcastUtils] getPodcastFeed Error', error)
+      Logger.error('[podcastUtils] getPodcastFeed Error:', error.message)
       return null
     })
 }


### PR DESCRIPTION
This fixes #3118.

In this bug, an OPML import took a long time to handle on the server, due to the large number of feeds, the connection timed out, and Axios.post() failed with an error.

This PR fixes this by changing the OPML import flow as follows:
1. When calling /podcasts/opml, the client starts listening for an `opml_feeds` socket event
2. On the server, /podcasts/opml now starts the OPML import asynchronously and returns immediately **(note: this breaks the current behavior of the API)**
3. When the server finishes importing the OPML, it emits an `opml_feeds` event with the OPML feeds
4. The client intercepts the event, and continues to show the OPML feeds modal as before.

I know we talked about adding a task so it shows in the appbar, and skipping the confirmation modal:
- I think it may be better to keep the current flow, which seems synchronous to the user although it's now not, and perhaps start to emit progress events, so the user doesn't think the request is stuck.
- I think the confirmation modal is useful. We should probably add the ability to select which feeds to add to the library.

Also changed a couple of minor implementation details:
- Changed the timout in `podcastUtils.getPodcastFeed()` to 5000 (12000 seemed excessive)
- Now throwing an error if no valid RSS feeds remain after running getPodcastFeed on the feeds extracted from the OPML (there seems no point in showing an empty feeds modal)

