### PR TITLE
Ensure author and items folder is created before restoring backup

### DIFF
--- a/server/managers/BackupManager.js
+++ b/server/managers/BackupManager.js
@@ -216,7 +216,9 @@ class BackupManager {
     Logger.info(`[BackupManager] Saved backup sqlite file at "${dbPath}"`)
 
     // Extract /metadata/items and /metadata/authors folders
+    await fs.ensureDir(this.ItemsMetadataPath)
     await zip.extract('metadata-items/', this.ItemsMetadataPath)
+    await fs.ensureDir(this.AuthorsMetadataPath)
     await zip.extract('metadata-authors/', this.AuthorsMetadataPath)
     await zip.close()
 


### PR DESCRIPTION
Fixes https://github.com/advplyr/audiobookshelf/issues/2904

If the `metadata-authors/` folder does not contain a directory in it, the extraction will not create the `/metadata/authors` folder, causing a server crash and incomplete restore of the backup.