### PR TITLE
New share - if existing share, then return the item

### DIFF
--- a/server/controllers/ShareController.js
+++ b/server/controllers/ShareController.js
@@ -272,7 +272,7 @@ class ShareController {
       })
       if (existingMediaItemShare) {
         if (existingMediaItemShare.mediaItemId === mediaItemId) {
-          return res.status(409).send('Item is already shared')
+          return res.status(200).json(existingMediaItemShare.?toJSONForClient())
         } else {
           return res.status(409).send('Slug is already in use')
         }

--- a/server/controllers/ShareController.js
+++ b/server/controllers/ShareController.js
@@ -237,7 +237,41 @@ class ShareController {
     Logger.debug(`[ShareController] Update share playback session ${req.cookies.share_session_id} currentTime: ${playbackSession.currentTime}`)
     res.sendStatus(204)
   }
+  /**
+   * Public route - requires share_session_id cookie
+   * GET: /api/share/mediaitem/:id
+   * get existing share from mediaItemId
+   * 
+   * @param {import('express').Request} req
+   * @param {import('express').Response} res
+   */
+  async getMediaItemShare(req, res) {
+    if (!req.cookies.share_session_id) {
+      return res.status(404).send('Share session not set')
+    }
+    
+    const mediaItemId = req.params.id;
+    
+    if (!mediaItemId || typeof mediaItemId !== 'string') {
+      return res.status(400).send('Missing or invalid media item ID');
+    }
 
+    try {
+      // Check if the media item share exists by mediaItemId
+      const existingMediaItemShare = await Database.mediaItemShareModel.findOne({
+        where: { mediaItemId }
+      });
+
+      if (existingMediaItemShare) {
+        return res.status(200).json(existingMediaItemShare.toJSONForClient());
+      } else {
+        return res.status(404).send('Share not found');
+      }
+    } catch (error) {
+      Logger.error(`[ShareController] Failed to get media item share: ${error.message}`, error);
+      return res.status(500).send('Internal server error');
+    }
+  }
   /**
    * POST: /api/share/mediaitem
    * Create a new media item share

--- a/server/controllers/ShareController.js
+++ b/server/controllers/ShareController.js
@@ -238,10 +238,9 @@ class ShareController {
     res.sendStatus(204)
   }
   /**
-   * Public route
    * GET: /api/share/mediaitem/:id
    * get existing share from mediaItemId
-   *  (or would it be better to return just the slug?)
+   *  (or would it be better to return just the slug instead of whole share object?)
    * 
    * @param {import('express').Request} req
    * @param {import('express').Response} res
@@ -261,6 +260,7 @@ class ShareController {
 
       if (existingMediaItemShare) {
         return res.status(200).json(existingMediaItemShare.toJSONForClient()); // or would it be better to return just the slug?
+      //return res.status(200).json(existingMediaItemShare.slug.toJSONForClient());
       } else {
         return res.status(404).send('Share not found');
       }

--- a/server/controllers/ShareController.js
+++ b/server/controllers/ShareController.js
@@ -238,18 +238,15 @@ class ShareController {
     res.sendStatus(204)
   }
   /**
-   * Public route - requires share_session_id cookie
+   * Public route
    * GET: /api/share/mediaitem/:id
    * get existing share from mediaItemId
+   *  (or would it be better to return just the slug?)
    * 
    * @param {import('express').Request} req
    * @param {import('express').Response} res
    */
   async getMediaItemShare(req, res) {
-    if (!req.cookies.share_session_id) {
-      return res.status(404).send('Share session not set')
-    }
-    
     const mediaItemId = req.params.id;
     
     if (!mediaItemId || typeof mediaItemId !== 'string') {
@@ -263,7 +260,7 @@ class ShareController {
       });
 
       if (existingMediaItemShare) {
-        return res.status(200).json(existingMediaItemShare.toJSONForClient());
+        return res.status(200).json(existingMediaItemShare.toJSONForClient()); // or would it be better to return just the slug?
       } else {
         return res.status(404).send('Share not found');
       }

--- a/server/controllers/ShareController.js
+++ b/server/controllers/ShareController.js
@@ -306,7 +306,7 @@ class ShareController {
       })
       if (existingMediaItemShare) {
         if (existingMediaItemShare.mediaItemId === mediaItemId) {
-          return res.status(200).json(existingMediaItemShare.?toJSONForClient())
+          return res.status(409).send('Item is already shared')
         } else {
           return res.status(409).send('Slug is already in use')
         }


### PR DESCRIPTION
When attempting to create a share, currently request will fail returning “share already exists.” However, it would be more useful if the request returned the existing mediaitem, from which the requester can find the existing slug and use that instead of creating a new share.

Another option would be to create a new GET route that gets the existing share URL/slug by providing libraryitemid as parameter.