### PR TITLE
Fix permission issues in embed/merge

### DIFF
--- a/server/utils/fileUtils.js
+++ b/server/utils/fileUtils.js
@@ -464,3 +464,46 @@ module.exports.getDirectoriesInPath = async (dirPath, level) => {
     return []
   }
 }
+
+/**
+ * Copies a file from the source path to an existing destination path, preserving the destination's permissions.
+ *
+ * @param {string} srcPath - The path of the source file.
+ * @param {string} destPath - The path of the existing destination file.
+ * @returns {Promise<void>} A promise that resolves when the file has been successfully copied.
+ * @throws {Error} If there is an error reading the source file or writing the destination file.
+ */
+async function copyToExisting(srcPath, destPath) {
+  return new Promise((resolve, reject) => {
+    // Create a readable stream from the source file
+    const readStream = fs.createReadStream(srcPath)
+
+    // Create a writable stream to the destination file
+    const writeStream = fs.createWriteStream(destPath, { flags: 'w' })
+
+    // Pipe the read stream to the write stream
+    readStream.pipe(writeStream)
+
+    // Handle the end of the stream
+    writeStream.on('finish', () => {
+      Logger.debug(`[copyToExisting] Successfully copied file from ${srcPath} to ${destPath}`)
+      resolve()
+    })
+
+    // Handle errors
+    readStream.on('error', (error) => {
+      Logger.error(`[copyToExisting] Error reading from source file ${srcPath}: ${error.message}`)
+      readStream.close()
+      writeStream.close()
+      reject(error)
+    })
+
+    writeStream.on('error', (error) => {
+      Logger.error(`[copyToExisting] Error writing to destination file ${destPath}: ${error.message}`)
+      readStream.close()
+      writeStream.close()
+      reject(error)
+    })
+  })
+}
+module.exports.copyToExisting = copyToExisting


### PR DESCRIPTION
This fixes #3146.

This changes the way the output of the embedding/merging tools is written back to the original directory, so that the permissions of the original audio files are kept intact. 

Before this, we used fs.move(), which moved the ffmpeg output to the original file, effectively replacing the original permissions with whatever permissions the ffmpeg process assigned to its output file. Instead, we now pipe the contents of the ffmpeg output into the original file, so the contents of the original file are replaced but all file attributes (e.g. permissions) remain intact.