### PR TITLE
Add: workflow to close issues on release

### DIFF
--- a/.github/workflows/close-issues-on-release.yml
+++ b/.github/workflows/close-issues-on-release.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Close issues marked as fixed upon a release.
         uses: gcampbell-msft/fixed-pending-release@7fa1b75a0c04bcd4b375110522878e5f6100cff5
         with:
-          label: awaiting-release
+          label: 'awaiting release'
           removeLabel: true
           applyToAll: true
           message: Fixed in [${releaseTag}](${releaseUrl}).

--- a/.github/workflows/close-issues-on-release.yml
+++ b/.github/workflows/close-issues-on-release.yml
@@ -1,0 +1,20 @@
+name: Close fixed issues on release.
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close issues marked as fixed upon a release.
+        uses: gcampbell-msft/fixed-pending-release@7fa1b75a0c04bcd4b375110522878e5f6100cff5
+        with:
+          label: awaiting-release
+          removeLabel: true
+          applyToAll: true
+          message: Fixed in [${releaseTag}](${releaseUrl}).


### PR DESCRIPTION
This PR adds a workflow to automatically do the following to issues with a label of `awaiting release` whenever a release is published:
- Comment that it has been fixed with the current version number
- Close issue (if open)
- Remove `awaiting release` label

This workflow [requires write permissions for issues](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs), which is included in the workflow. The maintainer of the action I am using has not made a new release of the action since merging my PR to it, so I have just pinned the current SHA (not sure when they will get around to that).

I did not see any issues currently labeled as `awaiting release` that need to have the label removed before this workflow is ran. I tested this workflow in a personal repository and it worked well, but you may need to grant the workflow write permissions so it can access the write permissions on the issues (not 100% sure on the scoping there).