### PR TITLE
Fix: Filter undefined entries from loadExtensions array

### DIFF
--- a/.devcontainer/dev.js
+++ b/.devcontainer/dev.js
@@ -5,6 +5,5 @@ module.exports.config = {
   ConfigPath: Path.resolve('config'),
   MetadataPath: Path.resolve('metadata'),
   FFmpegPath: '/usr/bin/ffmpeg',
-  FFProbePath: '/usr/bin/ffprobe',
-  SkipBinariesCheck: true
+  FFProbePath: '/usr/bin/ffprobe'
 }

--- a/index.js
+++ b/index.js
@@ -9,7 +9,6 @@ if (isDev) {
   if (devEnv.MetadataPath) process.env.METADATA_PATH = devEnv.MetadataPath
   if (devEnv.FFmpegPath) process.env.FFMPEG_PATH = devEnv.FFmpegPath
   if (devEnv.FFProbePath) process.env.FFPROBE_PATH = devEnv.FFProbePath
-  if (devEnv.SkipBinariesCheck) process.env.SKIP_BINARIES_CHECK = '1'
   if (devEnv.BackupPath) process.env.BACKUP_PATH = devEnv.BackupPath
   process.env.SOURCE = 'local'
   process.env.ROUTER_BASE_PATH = devEnv.RouterBasePath || ''

--- a/server/Database.js
+++ b/server/Database.js
@@ -228,6 +228,8 @@ class Database {
     const db = await this.sequelize.dialect.connectionManager.getConnection()
     if (typeof db?.loadExtension !== 'function') throw new Error('Failed to get db connection for loading extensions')
 
+    extensions = extensions.filter(ext => ext !== undefined)
+
     for (const ext of extensions) {
       Logger.info(`[Database] Loading extension ${ext}`)
       await new Promise((resolve, reject) => {

--- a/server/Database.js
+++ b/server/Database.js
@@ -228,8 +228,6 @@ class Database {
     const db = await this.sequelize.dialect.connectionManager.getConnection()
     if (typeof db?.loadExtension !== 'function') throw new Error('Failed to get db connection for loading extensions')
 
-    extensions = extensions.filter(ext => ext !== undefined)
-
     for (const ext of extensions) {
       Logger.info(`[Database] Loading extension ${ext}`)
       await new Promise((resolve, reject) => {

--- a/server/managers/BinaryManager.js
+++ b/server/managers/BinaryManager.js
@@ -273,12 +273,6 @@ class BinaryManager {
   }
 
   async init() {
-    // Optional skip binaries check
-    if (process.env.SKIP_BINARIES_CHECK === '1') {
-      Logger.info('[BinaryManager] Skipping check for binaries')
-      return
-    }
-
     if (this.initialized) return
 
     const missingBinaries = await this.findRequiredBinaries()


### PR DESCRIPTION
This PR fixes an issue introduced in #3199, where the server would crash on startup if `SQLEAN_UNICODE_PATH` was not set. 

As I'm not sure if `loadExtensions` will be used in other locations in the future, I figured filtering out `undefined` entries within the function might be preferable to to simply checking for a valid `SQLEAN_UNICODE_PATH` value before calling it.