### PR TITLE
On item pages, fetch the item's library data to the store if it's not available

### DIFF
--- a/client/pages/author/_id.vue
+++ b/client/pages/author/_id.vue
@@ -56,8 +56,8 @@ export default {
       return redirect(`/library/${store.state.libraries.currentLibraryId}/authors`)
     }
 
-    if (query.library) {
-      store.commit('libraries/setCurrentLibrary', query.library)
+    if (store.state.libraries.currentLibraryId !== author.libraryId || !store.state.libraries.filterData) {
+      await store.dispatch('libraries/fetch', author.libraryId)
     }
 
     return {

--- a/client/pages/item/_id/index.vue
+++ b/client/pages/item/_id/index.vue
@@ -794,10 +794,6 @@ export default {
     this.episodeDownloadsQueued = this.libraryItem.episodeDownloadsQueued || []
     this.episodesDownloading = this.libraryItem.episodesDownloading || []
 
-    // use this items library id as the current
-    if (this.libraryId) {
-      this.$store.commit('libraries/setCurrentLibrary', this.libraryId)
-    }
     this.$eventBus.$on(`${this.libraryItem.id}_updated`, this.libraryItemUpdated)
     this.$root.socket.on('item_updated', this.libraryItemUpdated)
     this.$root.socket.on('rss_feed_open', this.rssFeedOpen)

--- a/client/pages/item/_id/index.vue
+++ b/client/pages/item/_id/index.vue
@@ -168,6 +168,9 @@ export default {
       console.error('No item...', params.id)
       return redirect('/')
     }
+    if (store.state.libraries.currentLibraryId !== item.libraryId || !store.state.libraries.filterData) {
+      await store.dispatch('libraries/fetch', item.libraryId)
+    }
     return {
       libraryItem: item,
       rssFeed: item.rssFeed || null,

--- a/client/pages/library/_library/podcast/download-queue.vue
+++ b/client/pages/library/_library/podcast/download-queue.vue
@@ -54,11 +54,19 @@
 
 <script>
 export default {
-  async asyncData({ params, redirect }) {
-    if (!params.library) {
-      console.error('No library...', params.library)
-      return redirect('/')
+  async asyncData({ params, redirect, store }) {
+    var libraryId = params.library
+    var libraryData = await store.dispatch('libraries/fetch', libraryId)
+    if (!libraryData) {
+      return redirect('/oops?message=Library not found')
     }
+
+    // Redirect book libraries
+    const library = libraryData.library
+    if (library.mediaType === 'book') {
+      return redirect(`/library/${libraryId}`)
+    }
+
     return {
       libraryId: params.library
     }
@@ -124,10 +132,6 @@ export default {
     }
   },
   mounted() {
-    if (this.libraryId) {
-      this.$store.commit('libraries/setCurrentLibrary', this.libraryId)
-    }
-
     this.loadInitialDownloadQueue()
   },
   beforeDestroy() {

--- a/client/store/libraries.js
+++ b/client/store/libraries.js
@@ -166,22 +166,6 @@ export const actions = {
         commit('set', [])
       })
     return true
-  },
-  loadLibraryFilterData({ state, commit, rootState }) {
-    if (!rootState.user || !rootState.user.user) {
-      console.error('libraries/loadLibraryFilterData - User not set')
-      return false
-    }
-
-    this.$axios
-      .$get(`/api/libraries/${state.currentLibraryId}/filterdata`)
-      .then((data) => {
-        commit('setLibraryFilterData', data)
-      })
-      .catch((error) => {
-        console.error('Failed', error)
-        commit('setLibraryFilterData', null)
-      })
   }
 }
 


### PR DESCRIPTION
This fixes #3209 

The fix fixes the problem by making sure filterData is available in the store when the item page is loaded.

There might be some refactoring needed in libraries.js to make sure that dependent state variables are updated together. Currently for example, it is possible to change the currentLibraryId without trigerring a library fetch, which leaves the libraries state in an incosistent state (filterData is not updated, for example). Let me know what you think.