### PR TITLE
persist and show the advanced encoding options

### DIFF
--- a/server/managers/AbMergeManager.js
+++ b/server/managers/AbMergeManager.js
@@ -48,7 +48,8 @@ class AbMergeManager {
       chapters: libraryItem.media.chapters?.map((c) => ({ ...c })),
       coverPath: libraryItem.media.coverPath,
       ffmetadataPath,
-      duration: libraryItem.media.duration
+      duration: libraryItem.media.duration,
+      encodeOptions: options
     }
     const taskDescription = `Encoding audiobook "${libraryItem.media.metadata.title}" into a single m4b file.`
     task.setData('encode-m4b', 'Encoding M4b', taskDescription, false, taskData)


### PR DESCRIPTION
The changes allow two things:

1 - persist the advanced encoding settings so they can used as the default advanced settings
  - Saves the advanced bitrate, channels, codec to local storage
  - Populates the saved values if you select used advanced options

2 - Saves the advanced settings used for an encode task to the task.data so they can be shown in the in progress dialog
  - Saves the passed in advanced encode options in the Task data filed
  - When viewing an in progress encode task it uses these to show what the current encode is using