### PR TITLE
Format the progress info into a table

### DIFF
--- a/client/strings/en-us.json
+++ b/client/strings/en-us.json
@@ -311,6 +311,7 @@
   "LabelFilterByUser": "Filter by User",
   "LabelFindEpisodes": "Find Episodes",
   "LabelFinished": "Finished",
+  "LabelRemaining": "Remaining",
   "LabelFolder": "Folder",
   "LabelFolders": "Folders",
   "LabelFontBold": "Bold",
@@ -851,5 +852,7 @@
   "ToastSortingPrefixesUpdateFailed": "Failed to update sorting prefixes",
   "ToastSortingPrefixesUpdateSuccess": "Sorting prefixes updated ({0} items)",
   "ToastUserDeleteFailed": "Failed to delete user",
-  "ToastUserDeleteSuccess": "User deleted"
+  "ToastUserDeleteSuccess": "User deleted",
+  "ResetProgressQuestion": "Are you sure you want to reset your progress?",
+  "ResetProgressSuccess": "Your progress was reset"
 }

--- a/client/strings/en-us.json
+++ b/client/strings/en-us.json
@@ -311,7 +311,6 @@
   "LabelFilterByUser": "Filter by User",
   "LabelFindEpisodes": "Find Episodes",
   "LabelFinished": "Finished",
-  "LabelRemaining": "Remaining",
   "LabelFolder": "Folder",
   "LabelFolders": "Folders",
   "LabelFontBold": "Bold",
@@ -467,6 +466,7 @@
   "LabelRedo": "Redo",
   "LabelRegion": "Region",
   "LabelReleaseDate": "Release Date",
+  "LabelRemaining": "Remaining",
   "LabelRemoveCover": "Remove cover",
   "LabelRowsPerPage": "Rows per page",
   "LabelSearchTerm": "Search Term",
@@ -772,6 +772,8 @@
   "PlaceholderNewPlaylist": "New playlist name",
   "PlaceholderSearch": "Search..",
   "PlaceholderSearchEpisode": "Search episode..",
+  "ResetProgressQuestion": "Are you sure you want to reset your progress?",
+  "ResetProgressSuccess": "Your progress was reset",
   "ToastAccountUpdateFailed": "Failed to update account",
   "ToastAccountUpdateSuccess": "Account updated",
   "ToastAuthorImageRemoveFailed": "Failed to remove image",
@@ -852,7 +854,5 @@
   "ToastSortingPrefixesUpdateFailed": "Failed to update sorting prefixes",
   "ToastSortingPrefixesUpdateSuccess": "Sorting prefixes updated ({0} items)",
   "ToastUserDeleteFailed": "Failed to delete user",
-  "ToastUserDeleteSuccess": "User deleted",
-  "ResetProgressQuestion": "Are you sure you want to reset your progress?",
-  "ResetProgressSuccess": "Your progress was reset"
+  "ToastUserDeleteSuccess": "User deleted"
 }


### PR DESCRIPTION
This change formats the progress information into a row structure so it is easier to read and is more consistent with the page layout.

I also change the confirmation question to use the internal app dialogue instead of the browser native one.
And moved some of the text to strings resources

All the existing logic for what and when it is shown is the same, it is just come clean up and formatting changes. 

Before Changes
![image](https://github.com/user-attachments/assets/683c357c-74f1-4313-bdf8-0e5df1546224)

After Changes
![image](https://github.com/user-attachments/assets/bbfaba1a-cc6d-4bd0-9d8e-6bc4888e71e6)
