### PR TITLE
Temporariliy disable sqlite3 unicode extension on linux-arm64

### DIFF
--- a/server/Database.js
+++ b/server/Database.js
@@ -17,6 +17,14 @@ class Database {
 
     this.settings = []
 
+    this.loadUnicodeExtionsion = process.platform === 'linux' && process.arch === 'arm64' ? false : true
+
+    if (this.loadUnicodeExtionsion) {
+      this.normalize = (value) => `lower(unaccent(${value}))`
+    } else {
+      this.normalize = (value) => value
+    }
+
     // Cached library filter data
     this.libraryFilterData = {}
 
@@ -205,9 +213,11 @@ class Database {
     // Helper function
     this.sequelize.uppercaseFirst = (str) => (str ? `${str[0].toUpperCase()}${str.substr(1)}` : '')
 
+    const extensions = this.loadUnicodeExtionsion ? [process.env.SQLEAN_UNICODE_PATH] : []
+
     try {
       await this.sequelize.authenticate()
-      await this.loadExtensions([process.env.SQLEAN_UNICODE_PATH])
+      await this.loadExtensions(extensions)
       Logger.info(`[Database] Db connection was successful`)
       return true
     } catch (error) {
@@ -824,15 +834,6 @@ class Database {
     if (badSessionsRemoved > 0) {
       Logger.warn(`Removed ${badSessionsRemoved} sessions that were 3 seconds or less`)
     }
-  }
-
-  /**
-   *
-   * @param {string} value
-   * @returns {string}
-   */
-  normalize(value) {
-    return `lower(unaccent(${value}))`
   }
 
   /**


### PR DESCRIPTION
This fixes #3231.

I temporarily disabled the loading and usage of the unicode extension for linux-arm64, until I'm able to fix the underlying issue.
I'd appreciate if you could push a new release with this fix. I tested it as best as I could on my windows dev setup before setting the condition to linux-arm64 (`this.loadUnicodeExtionsion = process.platform === 'linux' && process.arch === 'arm64' ? false : true`).

This of course reverts the accent-insensitive search change for linux-arm64.

We'll at some point need to find a way to do an integration test on a linux-arm64 machine - I don't have one at my disposal.
I started to play with QEMU, but I haven't fully set it up yet.