### PR TITLE
Fix unicode.so loading

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN apk update && \
     tzdata \
     ffmpeg \
     make \
+    gcompat \
     python3 \
     g++ \
     tini


### PR DESCRIPTION
`unicode.so` is dynamically linked against glibc but Alpine only comes with musl. Installing the compatibility layer fixes it.

Fix https://github.com/advplyr/audiobookshelf/issues/3231
Fix https://github.com/advplyr/audiobookshelf/issues/3234
Close https://github.com/advplyr/audiobookshelf/pull/3235
