### PR TITLE
Fix path normalization to support UNC paths

### DIFF
--- a/server/utils/fileUtils.js
+++ b/server/utils/fileUtils.js
@@ -15,7 +15,7 @@ const { AudioMimeType } = require('./constants')
  */
 const filePathToPOSIX = (path) => {
   if (!global.isWin || !path) return path
-  return path.replace(/\\/g, '/')
+  return path.startsWith('\\\\') ? '\\\\' + path.slice(2).replace(/\\/g, '/') : path.replace(/\\/g, '/')
 }
 module.exports.filePathToPOSIX = filePathToPOSIX
 
@@ -169,7 +169,7 @@ async function recurseFiles(path, relPathToReplace = null) {
     extensions: true,
     deep: true,
     realPath: true,
-    normalizePath: true
+    normalizePath: false
   }
   let list = await rra.list(path, options)
   if (list.error) {
@@ -186,6 +186,8 @@ async function recurseFiles(path, relPathToReplace = null) {
         return false
       }
 
+      item.fullname = filePathToPOSIX(item.fullname)
+      item.path = filePathToPOSIX(item.path)
       const relpath = item.fullname.replace(relPathToReplace, '')
       let reldirname = Path.dirname(relpath)
       if (reldirname === '.') reldirname = ''


### PR DESCRIPTION
This fixes #640.

UNC Paths are the standard way to refer to shared netowrk resources on Windows.
Several users have reported that these paths are not supprted in Audiobookshelf (specifically, when you specify a UNC path to a library folder, no error is generated, but scanning of that folder always fails, with weird non-existent library item paths showing up in the scan).

The reason for the bug was posix normalization. Current normalization just changes all backslashes to slashes, which is OK for most Windows paths and doesn't change path semantics. UNC paths, however, begin with a double backslash (`\\`), and when you change it to double slash (`//`), the path semantic is changed and subsequent file/path operations no longer interpret the path as a UNC path.

To fix this, I changed posix path normalization to preserve the double backslash for UNC paths, while still normalizing all other backslashes to slashes.

This seems to fully resolve the issue, and users can now specify UNC paths when setting up library folders.