### PR TITLE
Log actual object details when they appear in log arguments

### DIFF
--- a/server/models/LibraryItem.js
+++ b/server/models/LibraryItem.js
@@ -11,6 +11,7 @@ const Book = require('./Book')
 const Podcast = require('./Podcast')
 
 const ShareManager = require('../managers/ShareManager')
+const { LogLevel } = require('../utils/constants')
 
 /**
  * @typedef LibraryFileObject
@@ -301,8 +302,16 @@ class LibraryItem extends Model {
               let existingValue = existingEpisodeMatch[key]
               if (existingValue instanceof Date) existingValue = existingValue.valueOf()
 
+              // Avoid `[object Object]` logs when troubleshooting.
+              let existingToLog = existingValue
+              let updatedToLog = updatedEpisodeCleaned[key]
+              if (Logger.logLevel <= LogLevel.DEBUG && typeof existingToLog === "object") {
+                existingToLog = JSON.stringify(existingToLog)
+                updatedToLog = JSON.stringify(updatedToLog)
+              }
+
               if (!areEquivalent(updatedEpisodeCleaned[key], existingValue, true)) {
-                Logger.debug(`[LibraryItem] "${libraryItemExpanded.media.title}" episode "${existingEpisodeMatch.title}" ${key} was updated from "${existingValue}" to "${updatedEpisodeCleaned[key]}"`)
+                Logger.debug(`[LibraryItem] "${libraryItemExpanded.media.title}" episode "${existingEpisodeMatch.title}" ${key} was updated from "${existingToLog}" to "${updatedToLog}"`)
                 episodeHasUpdates = true
               }
             }


### PR DESCRIPTION
I'm continuing to hunt down the root cause of #2785 and got tired of seeing `[object Object]` around relevant logging lines. Its impossible to tell what the server is actually seeing change today:
```
{"timestamp":"2024-08-08 00:00:23.785","source":"LibraryItem.js:305","message":"[LibraryItem] \"name\" audioFile was updated from \"[object Object]\" to \"[object Object]\"","levelName":"DEBUG","level":1}
{"timestamp":"2024-08-08 00:00:23.786","source":"LibraryItem.js:305","message":"[LibraryItem] \"name\" extraData was updated from \"null\" to \"[object Object]\"","levelName":"DEBUG","level":1}
```

The changes here serialize the objects into JSON to remove the opaqueness to make them an actual string. Should have no effect on most users since I haven't really seen any logs containing these at non debug levels.

Do let me know if this can be cleaner. I don't usually write JS :)