### PR TITLE
no line breaks in size text

### DIFF
--- a/client/pages/library/_library/stats.vue
+++ b/client/pages/library/_library/stats.vue
@@ -75,7 +75,7 @@
                     <div class="bg-yellow-400 h-full rounded-full" :style="{ width: Math.round((100 * ab.size) / largestItemSize) + '%' }" />
                   </div>
                   <div class="w-4 ml-3">
-                    <p class="text-sm font-bold" style="white-space: nowrap">{{ $bytesPretty(ab.size) }}</p>
+                    <p class="text-sm font-bold whitespace-nowrap">{{ $bytesPretty(ab.size) }}</p>
                   </div>
                 </div>
               </div>

--- a/client/pages/library/_library/stats.vue
+++ b/client/pages/library/_library/stats.vue
@@ -75,7 +75,7 @@
                     <div class="bg-yellow-400 h-full rounded-full" :style="{ width: Math.round((100 * ab.size) / largestItemSize) + '%' }" />
                   </div>
                   <div class="w-4 ml-3">
-                    <p class="text-sm font-bold">{{ $bytesPretty(ab.size) }}</p>
+                    <p class="text-sm font-bold" style="white-space: nowrap">{{ $bytesPretty(ab.size) }}</p>
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
This is a simple change to stop the size in bytes from splitting over two lines, causing layout issues.