### PR TITLE
[WIP] feat: Implement Forward Authentication

### DIFF
--- a/client/strings/en-us.json
+++ b/client/strings/en-us.json
@@ -155,6 +155,7 @@
   "HeaderOpenRSSFeed": "Open RSS Feed",
   "HeaderOtherFiles": "Other Files",
   "HeaderPasswordAuthentication": "Password Authentication",
+  "HeaderForwardAuthentication": "Forward Authentication",
   "HeaderPermissions": "Permissions",
   "HeaderPlayerQueue": "Player Queue",
   "HeaderPlayerSettings": "Player Settings",

--- a/server/controllers/MiscController.js
+++ b/server/controllers/MiscController.js
@@ -634,7 +634,30 @@ class MiscController {
     for (const key in currentAuthenticationSettings) {
       if (settingsUpdate[key] === undefined) continue
 
-      if (key === 'authActiveAuthMethods') {
+      if (key === 'authForwardAuthPattern') {
+        const updatedValue = settingsUpdate[key]
+        if (updatedValue === '') updatedValue = null
+        let currentValue = currentAuthenticationSettings[key]
+        if (currentValue === '') currentValue = null
+
+        if (updatedValue !== currentValue) {
+          Logger.debug(`[MiscController] Updating auth settings key "${key}" from "${currentValue}" to "${updatedValue}"`)
+          Database.serverSettings[key] = updatedValue
+          hasUpdates = true
+        }
+      } else if (key === 'authForwardAuthEnabled') {
+        if (typeof settingsUpdate[key] !== 'boolean') {
+          Logger.warn(`[MiscController] Invalid value for ${key}. Expected boolean`)
+          continue
+        }
+        let updatedValue = settingsUpdate[key]
+        let currentValue = currentAuthenticationSettings[key]
+        if (updatedValue !== currentValue) {
+          Logger.debug(`[MiscController] Updating auth settings key "${key}" from "${currentValue}" to "${updatedValue}"`)
+          Database.serverSettings[key] = updatedValue
+          hasUpdates = true
+        }
+      } else if (key === 'authActiveAuthMethods') {
         let updatedAuthMethods = settingsUpdate[key]?.filter?.((authMeth) => Database.serverSettings.supportedAuthMethods.includes(authMeth))
         if (Array.isArray(updatedAuthMethods) && updatedAuthMethods.length) {
           updatedAuthMethods.sort()

--- a/server/objects/settings/ServerSettings.js
+++ b/server/objects/settings/ServerSettings.js
@@ -79,6 +79,11 @@ class ServerSettings {
     this.authOpenIDGroupClaim = ''
     this.authOpenIDAdvancedPermsClaim = ''
 
+    // Forward Auth
+    this.authForwardAuthPattern = '127.0.0.1/0' // default to exact localhost
+    this.authForwardAuthPath = ''
+    this.authForwardAuthEnabled = false
+
     if (settings) {
       this.construct(settings)
     }
@@ -153,6 +158,18 @@ class ServerSettings {
     // fallback to local
     if (!Array.isArray(this.authActiveAuthMethods) || this.authActiveAuthMethods.length == 0) {
       this.authActiveAuthMethods = ['local']
+    }
+
+    if (settings.authForwardAuthPattern != undefined) {
+      this.authForwardAuthPattern = settings.authForwardAuthPattern
+    }
+
+    if (settings.authForwardAuthEnabled != undefined) {
+      this.authForwardAuthEnabled = settings.authForwardAuthEnabled
+    }
+
+    if (settings.authForwardAuthPath != undefined) {
+      this.authForwardAuthPath = settings.authForwardAuthPath
     }
 
     // Migrations
@@ -240,7 +257,10 @@ class ServerSettings {
       authOpenIDMatchExistingBy: this.authOpenIDMatchExistingBy,
       authOpenIDMobileRedirectURIs: this.authOpenIDMobileRedirectURIs, // Do not return to client
       authOpenIDGroupClaim: this.authOpenIDGroupClaim, // Do not return to client
-      authOpenIDAdvancedPermsClaim: this.authOpenIDAdvancedPermsClaim // Do not return to client
+      authOpenIDAdvancedPermsClaim: this.authOpenIDAdvancedPermsClaim, // Do not return to client
+      authForwardAuthPattern: this.authForwardAuthPattern,
+      authForwardAuthPath: this.authForwardAuthPath,
+      authForwardAuthEnabled: this.authForwardAuthEnabled
     }
   }
 
@@ -286,6 +306,10 @@ class ServerSettings {
       authOpenIDMobileRedirectURIs: this.authOpenIDMobileRedirectURIs, // Do not return to client
       authOpenIDGroupClaim: this.authOpenIDGroupClaim, // Do not return to client
       authOpenIDAdvancedPermsClaim: this.authOpenIDAdvancedPermsClaim, // Do not return to client
+
+      authForwardAuthPattern: this.authForwardAuthPattern,
+      authForwardAuthPath: this.authForwardAuthPath,
+      authForwardAuthEnabled: this.authForwardAuthEnabled,
 
       authOpenIDSamplePermissions: User.getSampleAbsPermissions()
     }

--- a/server/utils/ForwardStrategy.js
+++ b/server/utils/ForwardStrategy.js
@@ -1,0 +1,111 @@
+const passport = require('passport')
+const requestIp = require('../libs/requestIp')
+
+function ipToBinary(ip) {
+  if (ip === '::1') {
+    ip = '127.0.0.1'
+  }
+  return ip
+    .split('.')
+    .map(Number)
+    .map((num) => num.toString(2).padStart(8, '0'))
+    .join('')
+}
+
+function binaryToIp(binary) {
+  return binary
+    .match(/.{8}/g)
+    .map((bin) => parseInt(bin, 2))
+    .join('.')
+}
+
+function cidrToMask(cidr) {
+  const mask = Array(32).fill('0')
+  for (let i = 0; i < cidr; i++) {
+    mask[i] = '1'
+  }
+  return mask
+    .join('')
+    .match(/.{8}/g)
+    .map((bin) => parseInt(bin, 2))
+    .join('.')
+}
+
+/**
+ * Checks if an IP address falls within a given CIDR range.
+ * If no range is provided, it assumes the CIDR + range are in the "0.0.0.0/0" format.
+ *
+ * @param {string} ip - The IP address to check. Can be either IPv4 or IPv6.
+ * @param {string} cidr - The CIDR notation specifying the network. If `range` is not provided, this value represents the network IP and CIDR in "IP/CIDR" format.
+ * @param {string} [range] - The IP address representing the range or network. Optional. If not provided, the function assumes "0.0.0.0/0" as the default range.
+ * @returns {boolean} `true` if the IP address is within the given CIDR range; otherwise, `false`.
+ */
+function ipInRange(ip, cidr, range) {
+  // if no range is provided, assume the cidr + range are in the "0.0.0.0/0" format
+  if (!range) {
+    let [rangeIp, rangeCidr] = cidr.split('/')
+    if (!rangeCidr) {
+      rangeCidr = '0' // if no cidr is provided, assume 0 (exact match)
+    }
+    return ipInRange(ip, rangeCidr, rangeIp)
+  }
+  const mask = cidrToMask(cidr)
+  const ipBin = ipToBinary(ip)
+  const maskBin = ipToBinary(mask)
+  const rangeBin = ipToBinary(range)
+
+  // Apply the mask to the IP and range
+  const ipNetwork = ipBin.substring(0, maskBin.length)
+  const rangeNetwork = rangeBin.substring(0, maskBin.length)
+
+  return ipNetwork === rangeNetwork
+}
+
+class ForwardStrategy extends passport.Strategy {
+  /**
+   * Creates a new ForwardStrategy instance.
+   * A ForwardStrategy instance authenticates requests based on the contents of the `X-Forwarded-User` header
+   *
+   * @param {Function} verify The function to call to verify the user.
+   */
+  constructor(options, verify) {
+    super()
+    // if verify is not provided, assume the first argument is the verify function
+    if (!verify && typeof options === 'function') {
+      verify = options
+    } else if (!verify) {
+      throw new TypeError('ForwardStrategy requires a verify callback')
+    }
+    this.name = 'forward'
+    this._verify = verify
+    this._header = options.header || 'x-forwarded-user'
+  }
+
+  /**
+   * Authenticate request based on the contents of the `X-Forwarded-User` header.
+   * @param {*} req The request to authenticate.
+   * @returns {void} Calls `success`, `fail`, or `error` based on the result of the authentication.
+   */
+  authenticate(req) {
+    const username = req.headers[this._header]
+    const ip = requestIp.getClientIp(req)
+    if (!username) {
+      return this.fail('No username found')
+    }
+
+    this._verify(req, username, ip, (err, user) => {
+      if (err) {
+        return this.error(err)
+      }
+      if (!user) {
+        return this.fail('No user found')
+      }
+      this.success(user)
+    })
+  }
+}
+
+module.exports = {
+  ForwardStrategy,
+  ipInRange
+}


### PR DESCRIPTION
I've seen there's been a couple different attempts wrt implementing forward auth (#2189 and #1109 ) and this is my attempt. I've yet to test it out on mobile, and  I imagine it's broken there. I have done some basic testing with Authentik + nginx locally and it seems to be working though.

I'd like to have it where the header is user-specified instead of hardcoding `X-Forwarded-User`. And maybe also require a magic password header as an alternative to IP based validation,similar to how [actual budget](https://actualbudget.org/docs/advanced/http-header-auth) implements it.


Other things to consider:
- Do we want to allow the root user to login using this method
- We probably want some way to indicate to the user that misconfiguring this can potentially expose your server to the entire internet. Perhaps require an explicit ENV var to be set to be able to use it

Screenshot of the settings right now:
![image](https://github.com/user-attachments/assets/47d7f4dc-8d6c-4c31-b493-6459af0d46f3)