### PR TITLE
Update api linting workflow

### DIFF
--- a/.github/workflows/lint-openapi.yml
+++ b/.github/workflows/lint-openapi.yml
@@ -7,6 +7,10 @@ on:
     paths:
       - 'docs/**'
 
+# This action only needs read permissions
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint-openapi.yml
+++ b/.github/workflows/lint-openapi.yml
@@ -1,13 +1,11 @@
 name: API linting
 
-# Run on pull requests or pushes when there is a change to the OpenAPI file
+# Run on pull requests or pushes when there is a change to any OpenAPI files in docs/
 on:
+  pull_request:
   push:
     paths:
-      - docs/
-  pull_request:
-    paths:
-      - docs/
+      - 'docs/**'
 
 jobs:
   build:


### PR DESCRIPTION
This PR fixes the trigger for the OpenAPI linting workflow, as well as limits the permissions for the workflow to read-only of `contents`.