### PR TITLE
Backup restore clear cache

### DIFF
--- a/server/managers/BackupManager.js
+++ b/server/managers/BackupManager.js
@@ -14,6 +14,7 @@ const fileUtils = require('../utils/fileUtils')
 const { getFileSize } = require('../utils/fileUtils')
 
 const Backup = require('../objects/Backup')
+const CacheManager = require('./CacheManager')
 
 class BackupManager {
   constructor(notificationManager) {
@@ -229,6 +230,9 @@ class BackupManager {
 
     // Reset api cache, set hooks again
     await apiCacheManager.reset()
+
+    // Clear metadata cache
+    await CacheManager.purgeAll()
 
     res.sendStatus(200)
 

--- a/server/managers/CacheManager.js
+++ b/server/managers/CacheManager.js
@@ -23,21 +23,10 @@ class CacheManager {
     this.ImageCachePath = Path.join(this.CachePath, 'images')
     this.ItemCachePath = Path.join(this.CachePath, 'items')
 
-    if (!(await fs.pathExists(this.CachePath))) {
-      await fs.mkdir(this.CachePath)
-    }
-
-    if (!(await fs.pathExists(this.CoverCachePath))) {
-      await fs.mkdir(this.CoverCachePath)
-    }
-
-    if (!(await fs.pathExists(this.ImageCachePath))) {
-      await fs.mkdir(this.ImageCachePath)
-    }
-
-    if (!(await fs.pathExists(this.ItemCachePath))) {
-      await fs.mkdir(this.ItemCachePath)
-    }
+    await fs.ensureDir(this.CachePath)
+    await fs.ensureDir(this.CoverCachePath)
+    await fs.ensureDir(this.ImageCachePath)
+    await fs.ensureDir(this.ItemCachePath)
   }
 
   async handleCoverCache(res, libraryItemId, coverPath, options = {}) {

--- a/server/managers/CacheManager.js
+++ b/server/managers/CacheManager.js
@@ -16,7 +16,8 @@ class CacheManager {
   /**
    * Create cache directory paths if they dont exist
    */
-  async ensureCachePaths() { // Creates cache paths if necessary and sets owner and permissions
+  async ensureCachePaths() {
+    // Creates cache paths if necessary and sets owner and permissions
     this.CachePath = Path.join(global.MetadataPath, 'cache')
     this.CoverCachePath = Path.join(this.CachePath, 'covers')
     this.ImageCachePath = Path.join(this.CachePath, 'images')
@@ -89,23 +90,28 @@ class CacheManager {
   }
 
   async purgeEntityCache(entityId, cachePath) {
-    return Promise.all((await fs.readdir(cachePath)).reduce((promises, file) => {
-      if (file.startsWith(entityId)) {
-        Logger.debug(`[CacheManager] Going to purge ${file}`);
-        promises.push(this.removeCache(Path.join(cachePath, file)))
-      }
-      return promises
-    }, []))
+    return Promise.all(
+      (await fs.readdir(cachePath)).reduce((promises, file) => {
+        if (file.startsWith(entityId)) {
+          Logger.debug(`[CacheManager] Going to purge ${file}`)
+          promises.push(this.removeCache(Path.join(cachePath, file)))
+        }
+        return promises
+      }, [])
+    )
   }
 
   removeCache(path) {
     if (!path) return false
     return fs.pathExists(path).then((exists) => {
       if (!exists) return false
-      return fs.unlink(path).then(() => true).catch((err) => {
-        Logger.error(`[CacheManager] Failed to remove cache "${path}"`, err)
-        return false
-      })
+      return fs
+        .unlink(path)
+        .then(() => true)
+        .catch((err) => {
+          Logger.error(`[CacheManager] Failed to remove cache "${path}"`, err)
+          return false
+        })
     })
   }
 


### PR DESCRIPTION
Fixes https://github.com/advplyr/audiobookshelf/issues/3272

This PR purges the entire cache in `/metadata/cache` after restoring from a backup. The main reasoning for this is that backups may have different images or be done when migrating to a new server, so the cache should be cleared regardless.

I also updated the `CacheManager` to use `ensureDir` to be a little more readable.