### PR TITLE
Close comics during scan

### DIFF
--- a/server/utils/parsers/parseComicMetadata.js
+++ b/server/utils/parsers/parseComicMetadata.js
@@ -50,6 +50,9 @@ async function extractCoverImage(comicPath, comicImageFilepath, outputCoverPath)
   } catch (error) {
     Logger.error(`[parseComicMetadata] Failed to extract image from comicPath "${comicPath}"`, error)
     return false
+  } finally {
+    // Ensure we free the memory
+    archive.close()
   }
 }
 module.exports.extractCoverImage = extractCoverImage
@@ -103,6 +106,9 @@ async function parse(ebookFile) {
   } else {
     Logger.warn(`Cover image not found in comic at "${comicPath}"`)
   }
+
+  // Ensure we close the archive to free memory
+  archive.close()
 
   return payload
 }

--- a/server/utils/parsers/parseComicMetadata.js
+++ b/server/utils/parsers/parseComicMetadata.js
@@ -7,12 +7,12 @@ const { xmlToJSON } = require('../index')
 const parseComicInfoMetadata = require('./parseComicInfoMetadata')
 
 /**
- * 
- * @param {string} filepath 
+ *
+ * @param {string} filepath
  * @returns {Promise<Buffer>}
  */
 async function getComicFileBuffer(filepath) {
-  if (!await fs.pathExists(filepath)) {
+  if (!(await fs.pathExists(filepath))) {
     Logger.error(`Comic path does not exist "${filepath}"`)
     return null
   }
@@ -26,10 +26,10 @@ async function getComicFileBuffer(filepath) {
 
 /**
  * Extract cover image from comic return true if success
- * 
- * @param {string} comicPath 
- * @param {string} comicImageFilepath 
- * @param {string} outputCoverPath 
+ *
+ * @param {string} comicPath
+ * @param {string} comicImageFilepath
+ * @param {string} outputCoverPath
  * @returns {Promise<boolean>}
  */
 async function extractCoverImage(comicPath, comicImageFilepath, outputCoverPath) {
@@ -56,8 +56,8 @@ module.exports.extractCoverImage = extractCoverImage
 
 /**
  * Parse metadata from comic
- * 
- * @param {import('../../models/Book').EBookFileObject} ebookFile 
+ *
+ * @param {import('../../models/Book').EBookFileObject} ebookFile
  * @returns {Promise<import('./parseEbookMetadata').EBookFileScanData>}
  */
 async function parse(ebookFile) {
@@ -79,7 +79,7 @@ async function parse(ebookFile) {
   })
 
   let metadata = null
-  const comicInfo = fileObjects.find(fo => fo.file.name === 'ComicInfo.xml')
+  const comicInfo = fileObjects.find((fo) => fo.file.name === 'ComicInfo.xml')
   if (comicInfo) {
     const comicInfoEntry = await comicInfo.file.extract()
     if (comicInfoEntry?.fileData) {
@@ -97,7 +97,7 @@ async function parse(ebookFile) {
     metadata
   }
 
-  const firstImage = fileObjects.find(fo => globals.SupportedImageTypes.includes(Path.extname(fo.file.name).toLowerCase().slice(1)))
+  const firstImage = fileObjects.find((fo) => globals.SupportedImageTypes.includes(Path.extname(fo.file.name).toLowerCase().slice(1)))
   if (firstImage?.file?._path) {
     payload.ebookCoverPath = firstImage.file._path
   } else {


### PR DESCRIPTION
This PR partially addresses some of the CBR/CBZ issues.

As mentioned in https://github.com/advplyr/audiobookshelf/issues/2750, the memory does not get freed until after the comics have completed parsing. This PR adds the `archive.close()` call at the end of the extraction functions.

I tested this by:
- Grabbing a number of random images from my personal photos
- Created a 1.8 GB CBZ and CBR comic file (no cover image, just ran the directory of images through the `zip` and `rar` bash utilities)
- Ran a scan without these changes (server crashed during scan of second book)
- Ran a scan including these changes (server completed scan of both books)

I don't have any "real" comics, so additional testing should be done on `edge` before this is part of a full release. My homemade comics did not actually load in the ereader, but were parsed during the scan.