### PR TITLE
Update AuthorController to handle invalid image paths and log a warning

### DIFF
--- a/server/controllers/AuthorController.js
+++ b/server/controllers/AuthorController.js
@@ -368,12 +368,12 @@ class AuthorController {
       author
     } = req
 
-    if (raw) {
-      // any value
-      if (!author.imagePath || !(await fs.pathExists(author.imagePath))) {
-        return res.sendStatus(404)
-      }
+    if (!author.imagePath || !(await fs.pathExists(author.imagePath))) {
+      Logger.warn(`[AuthorController] Author "${author.name}" has invalid imagePath: ${author.imagePath}`)
+      return res.sendStatus(404)
+    }
 
+    if (raw) {
       return res.sendFile(author.imagePath)
     }
 


### PR DESCRIPTION
This fixes #3267 (at least partly)

Up until now, we only tested for `!author.imagePath || !(await fs.pathExists(author.imagePath))` for raw author image requests. 
The fix tests this for all author image requests.