### PR TITLE
Fix libraryFolder not existing on new `libraryModel`

### DIFF
--- a/server/controllers/MiscController.js
+++ b/server/controllers/MiscController.js
@@ -49,7 +49,8 @@ class MiscController {
       return res.status(404).send(`Library not found with id ${libraryId}`)
     }
     const folder = await Database.libraryFolderModel.findByPk(folderId)
-    if (!folder) {
+    // Verify the folder matches the library ID so we don't accidentally add a podcast to the wrong path
+    if (!folder || folder.libraryId !== library.id) {
       return res.status(404).send(`Folder not found with id ${folderId} in library ${library.name}`)
     }
 

--- a/server/controllers/MiscController.js
+++ b/server/controllers/MiscController.js
@@ -49,7 +49,7 @@ class MiscController {
       return res.status(404).send(`Library not found with id ${libraryId}`)
     }
     const folder = await Database.libraryFolderModel.findByPk(folderId)
-    // Verify the folder matches the library ID so we don't accidentally add a podcast to the wrong path
+    // Verify the folder matches the library ID so we don't accidentally upload to the wrong library
     if (!folder || folder.libraryId !== library.id) {
       return res.status(404).send(`Folder not found with id ${folderId} in library ${library.name}`)
     }

--- a/server/controllers/MiscController.js
+++ b/server/controllers/MiscController.js
@@ -48,7 +48,7 @@ class MiscController {
     if (!library) {
       return res.status(404).send(`Library not found with id ${libraryId}`)
     }
-    const folder = library.libraryFolders.find((fold) => fold.id === folderId)
+    const folder = await Database.libraryFolderModel.findByPk(folderId)
     if (!folder) {
       return res.status(404).send(`Folder not found with id ${folderId} in library ${library.name}`)
     }

--- a/server/controllers/PodcastController.js
+++ b/server/controllers/PodcastController.js
@@ -45,7 +45,8 @@ class PodcastController {
     }
 
     const folder = await Database.libraryFolderModel.findByPk(payload.folderId)
-    if (!folder) {
+    // Verify the folder matches the library ID so we don't accidentally add a podcast to the wrong path
+    if (!folder || folder.libraryId !== library.id) {
       Logger.error(`[PodcastController] Create: Folder not found "${payload.folderId}"`)
       return res.status(404).send('Folder not found')
     }

--- a/server/controllers/PodcastController.js
+++ b/server/controllers/PodcastController.js
@@ -44,7 +44,7 @@ class PodcastController {
       return res.status(404).send('Library not found')
     }
 
-    const folder = library.libraryFolders.find((fold) => fold.id === payload.folderId)
+    const folder = await Database.libraryFolderModel.findByPk(payload.folderId)
     if (!folder) {
       Logger.error(`[PodcastController] Create: Folder not found "${payload.folderId}"`)
       return res.status(404).send('Folder not found')


### PR DESCRIPTION
Fixes https://github.com/advplyr/audiobookshelf/issues/3353, or at least the cause of two crashes I was able to identify in that issue. I am not sure if there are other places where a similar problem occurs.

This PR uses the `libraryFolders` table to ensure the folder exists. This was just my attempt at a quick fix, so no worries if there's a better/easier way to resolve the issue.