### PR TITLE
Fix tag permissions

### DIFF
--- a/server/controllers/UserController.js
+++ b/server/controllers/UserController.js
@@ -270,8 +270,10 @@ class UserController {
       const permissions = {
         ...user.permissions
       }
+      const defaultPermissions = Database.userModel.getDefaultPermissionsForUserType(updatePayload.type || 'user')
       for (const key in updatePayload.permissions) {
-        if (permissions[key] !== undefined) {
+        // Check that the key is a valid permission key or is included in the default permissions
+        if (permissions[key] !== undefined || defaultPermissions[key] !== undefined) {
           if (typeof updatePayload.permissions[key] !== 'boolean') {
             Logger.warn(`[UserController] update: Invalid permission value for key ${key}. Should be boolean`)
           } else if (permissions[key] !== updatePayload.permissions[key]) {

--- a/server/controllers/UserController.js
+++ b/server/controllers/UserController.js
@@ -270,7 +270,7 @@ class UserController {
       const permissions = {
         ...user.permissions
       }
-      const defaultPermissions = Database.userModel.getDefaultPermissionsForUserType(updatePayload.type || 'user')
+      const defaultPermissions = Database.userModel.getDefaultPermissionsForUserType(updatePayload.type || user.type || 'user')
       for (const key in updatePayload.permissions) {
         // Check that the key is a valid permission key or is included in the default permissions
         if (permissions[key] !== undefined || defaultPermissions[key] !== undefined) {

--- a/server/models/User.js
+++ b/server/models/User.js
@@ -108,6 +108,7 @@ class User extends Model {
       accessAllLibraries: true,
       accessAllTags: true,
       accessExplicitContent: true,
+      selectedTagsNotAccessible: false,
       librariesAccessible: [],
       itemTagsSelected: []
     }


### PR DESCRIPTION
Fixes https://github.com/advplyr/audiobookshelf/issues/3365

This PR updates the default User model to include `selectedTagsNotAccessible` on the default user creation. The `patch` request for `/api/users/{id}` is also updated to compare the payload against the default permissions to allow for values to be updated by clients on existing users which do not have the key in the `permissions` array. I'm not sure if that's the best way to do this, but figured it was more secure to validate against the default properties instead of allowing arbitrary keys to be created by a client.

This does not go through and update existing users which do not have `selectedTagsNotAccessible`.