### PR TITLE
Add db migration management infratructure

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "2.13.3",
       "license": "GPL-3.0",
       "dependencies": {
+        "@rushstack/terminal": "^0.14.0",
         "axios": "^0.27.2",
         "cookie-parser": "^1.4.6",
         "express": "^4.17.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,10 +21,12 @@
         "p-throttle": "^4.1.1",
         "passport": "^0.6.0",
         "passport-jwt": "^4.0.1",
+        "semver": "^7.6.3",
         "sequelize": "^6.35.2",
         "socket.io": "^4.5.4",
         "sqlite3": "^5.1.6",
         "ssrf-req-filter": "^1.1.0",
+        "umzug": "^3.8.1",
         "xml2js": "^0.5.0"
       },
       "bin": {
@@ -173,6 +175,15 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
+    "node_modules/@babel/core/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/@babel/generator": {
       "version": "7.23.3",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.3.tgz",
@@ -211,6 +222,15 @@
       "dev": true,
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/@babel/helper-compilation-targets/node_modules/yallist": {
@@ -586,17 +606,6 @@
         "node-pre-gyp": "bin/node-pre-gyp"
       }
     },
-    "node_modules/@mapbox/node-pre-gyp/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@mapbox/node-pre-gyp/node_modules/nopt": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
@@ -611,18 +620,36 @@
         "node": ">=6"
       }
     },
-    "node_modules/@mapbox/node-pre-gyp/node_modules/semver": {
-      "version": "7.5.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
-      "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
       "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/@npmcli/fs": {
@@ -633,33 +660,6 @@
       "dependencies": {
         "@gar/promisify": "^1.0.1",
         "semver": "^7.3.5"
-      }
-    },
-    "node_modules/@npmcli/fs/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "optional": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@npmcli/fs/node_modules/semver": {
-      "version": "7.5.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
-      "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
-      "optional": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/@npmcli/move-file": {
@@ -674,6 +674,104 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@rushstack/node-core-library": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-5.7.0.tgz",
+      "integrity": "sha512-Ff9Cz/YlWu9ce4dmqNBZpA45AEya04XaBFIjV7xTVeEf+y/kTjEasmozqFELXlNG4ROdevss75JrrZ5WgufDkQ==",
+      "dependencies": {
+        "ajv": "~8.13.0",
+        "ajv-draft-04": "~1.0.0",
+        "ajv-formats": "~3.0.1",
+        "fs-extra": "~7.0.1",
+        "import-lazy": "~4.0.0",
+        "jju": "~1.4.0",
+        "resolve": "~1.22.1",
+        "semver": "~7.5.4"
+      },
+      "peerDependencies": {
+        "@types/node": "*"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rushstack/node-core-library/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@rushstack/node-core-library/node_modules/semver": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@rushstack/terminal": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@rushstack/terminal/-/terminal-0.14.0.tgz",
+      "integrity": "sha512-juTKMAMpTIJKudeFkG5slD8Z/LHwNwGZLtU441l/u82XdTBfsP+LbGKJLCNwP5se+DMCT55GB8x9p6+C4UL7jw==",
+      "dependencies": {
+        "@rushstack/node-core-library": "5.7.0",
+        "supports-color": "~8.1.1"
+      },
+      "peerDependencies": {
+        "@types/node": "*"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rushstack/terminal/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@rushstack/terminal/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/@rushstack/ts-command-line": {
+      "version": "4.22.6",
+      "resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-4.22.6.tgz",
+      "integrity": "sha512-QSRqHT/IfoC5nk9zn6+fgyqOPXHME0BfchII9EUPR19pocsNp/xSbeBCbD3PIR2Lg+Q5qk7OFqk1VhWPMdKHJg==",
+      "dependencies": {
+        "@rushstack/terminal": "0.14.0",
+        "@types/argparse": "1.0.38",
+        "argparse": "~1.0.9",
+        "string-argv": "~0.3.1"
       }
     },
     "node_modules/@sinonjs/commons": {
@@ -733,6 +831,11 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/@types/argparse": {
+      "version": "1.0.38",
+      "resolved": "https://registry.npmjs.org/@types/argparse/-/argparse-1.0.38.tgz",
+      "integrity": "sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA=="
     },
     "node_modules/@types/cookie": {
       "version": "0.4.1",
@@ -869,6 +972,50 @@
         "node": ">=8"
       }
     },
+    "node_modules/ajv": {
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.13.0.tgz",
+      "integrity": "sha512-PRA911Blj99jR5RMeTunVbNXMF6Lp4vZXnk5GQjcnUWUTsrXtekg/pnmFFI2u/I36Y/2bITGS30GZCXei6uNkA==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.4.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-draft-04": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
+      "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
+      "peerDependencies": {
+        "ajv": "^8.5.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/ansi-colors": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
@@ -953,7 +1100,6 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
       "dependencies": {
         "sprintf-js": "~1.0.2"
       }
@@ -1041,12 +1187,11 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-      "dev": true,
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -1642,6 +1787,17 @@
       "integrity": "sha512-T5q3pjQon853xxxHUq3ZP68ZpvJHuSMY2+BZaW3QzjS4HvNuvsMmZ/+lU+nCrftre1jFZ+OSlExynXWBihnXzw==",
       "dev": true
     },
+    "node_modules/emittery": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.13.1.tgz",
+      "integrity": "sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/emittery?sponsor=1"
+      }
+    },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -1876,11 +2032,38 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
+      "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fastq": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
+      "integrity": "sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-      "dev": true,
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -2025,6 +2208,19 @@
         }
       ]
     },
+    "node_modules/fs-extra": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
     "node_modules/fs-minipass": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
@@ -2140,7 +2336,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
       "dependencies": {
         "is-glob": "^4.0.1"
       },
@@ -2212,6 +2407,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/he": {
@@ -2364,6 +2570,14 @@
       "integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==",
       "dev": true
     },
+    "node_modules/import-lazy": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-4.0.0.tgz",
+      "integrity": "sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -2436,11 +2650,24 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-core-module": {
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.15.1.tgz",
+      "integrity": "sha512-z0vtXSwucUJtANQWldhbtbt7BnL0vxiFjIdDLAatwhDYty2bad6s+rijD6Ri4YuYJubLzIJLUidCh09e1djEVQ==",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2457,7 +2684,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
@@ -2475,7 +2701,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
       "engines": {
         "node": ">=0.12.0"
       }
@@ -2576,6 +2801,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/istanbul-lib-instrument/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/istanbul-lib-processinfo": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/istanbul-lib-processinfo/-/istanbul-lib-processinfo-2.0.3.tgz",
@@ -2628,18 +2862,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/istanbul-lib-report/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/istanbul-lib-report/node_modules/make-dir": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
@@ -2653,21 +2875,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/istanbul-lib-report/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/istanbul-lib-report/node_modules/supports-color": {
@@ -2732,6 +2939,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/jju": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz",
+      "integrity": "sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA=="
+    },
     "node_modules/jose": {
       "version": "4.15.4",
       "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.4.tgz",
@@ -2771,6 +2983,11 @@
         "node": ">=4"
       }
     },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -2781,6 +2998,14 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
       }
     },
     "node_modules/jsonwebtoken": {
@@ -2804,35 +3029,10 @@
         "npm": ">=6"
       }
     },
-    "node_modules/jsonwebtoken/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/jsonwebtoken/node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
-    },
-    "node_modules/jsonwebtoken/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
     },
     "node_modules/just-extend": {
       "version": "4.2.1",
@@ -2970,6 +3170,14 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/make-fetch-happen": {
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-9.1.0.tgz",
@@ -3022,12 +3230,32 @@
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
       "integrity": "sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w=="
     },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/methods": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
       "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
       }
     },
     "node_modules/mime": {
@@ -3585,18 +3813,6 @@
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
-    "node_modules/node-gyp/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "optional": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/node-gyp/node_modules/nopt": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
@@ -3625,21 +3841,6 @@
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/node-gyp/node_modules/semver": {
-      "version": "7.5.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
-      "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
-      "optional": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/node-preload": {
@@ -4061,6 +4262,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+    },
     "node_modules/path-to-regexp": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
@@ -4095,7 +4301,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
       "engines": {
         "node": ">=8.6"
       },
@@ -4113,6 +4318,14 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/pony-cause": {
+      "version": "2.1.11",
+      "resolved": "https://registry.npmjs.org/pony-cause/-/pony-cause-2.1.11.tgz",
+      "integrity": "sha512-M7LhCsdNbNgiLYiP4WjsfLUuFmCfnjdF6jKe2R9NKl4WFN+HZPGHJZ9lnLP7f9ZnKe3U9nuWD0szirmj+migUg==",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/process-on-spawn": {
@@ -4164,6 +4377,14 @@
       "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==",
       "dev": true
     },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/qs": {
       "version": "6.11.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
@@ -4177,6 +4398,25 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
     "node_modules/random-bytes": {
       "version": "1.0.0",
@@ -4263,11 +4503,35 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/require-main-filename": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "dev": true
+    },
+    "node_modules/resolve": {
+      "version": "1.22.8",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
+      "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
+      "dependencies": {
+        "is-core-module": "^2.13.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/resolve-from": {
       "version": "5.0.0",
@@ -4292,6 +4556,15 @@
       "resolved": "https://registry.npmjs.org/retry-as-promised/-/retry-as-promised-7.0.4.tgz",
       "integrity": "sha512-XgmCoxKWkDofwH8WddD0w85ZfqYz+ZHlr5yo+3YUCfycWawU56T5ckWXsScsj5B8tqUcIG67DxXByo3VUgiAdA=="
     },
+    "node_modules/reusify": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -4304,6 +4577,28 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
       }
     },
     "node_modules/safe-buffer": {
@@ -4336,11 +4631,14 @@
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
       "bin": {
         "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/send": {
@@ -4456,35 +4754,10 @@
         }
       }
     },
-    "node_modules/sequelize/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/sequelize/node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-    },
-    "node_modules/sequelize/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
     },
     "node_modules/serialize-javascript": {
       "version": "6.0.0",
@@ -4805,8 +5078,7 @@
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-      "dev": true
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
     },
     "node_modules/sqlite3": {
       "version": "5.1.6",
@@ -4874,6 +5146,14 @@
         "safe-buffer": "~5.2.0"
       }
     },
+    "node_modules/string-argv": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
+      "integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==",
+      "engines": {
+        "node": ">=0.6.19"
+      }
+    },
     "node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -4931,6 +5211,17 @@
         "node": ">=4"
       }
     },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/tar": {
       "version": "6.1.15",
       "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.15.tgz",
@@ -4982,7 +5273,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
       "dependencies": {
         "is-number": "^7.0.0"
       },
@@ -5070,6 +5360,32 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/umzug": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/umzug/-/umzug-3.8.1.tgz",
+      "integrity": "sha512-k0HjOc3b/s8vH24BUTvnaFiKhfWI9UQAGpqHDG+3866CGlBTB83Xs5wZ1io1mwYLj/GHvQ34AxKhbpYnWtkRJg==",
+      "dependencies": {
+        "@rushstack/ts-command-line": "^4.12.2",
+        "emittery": "^0.13.0",
+        "fast-glob": "^3.3.2",
+        "pony-cause": "^2.1.4",
+        "type-fest": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/umzug/node_modules/type-fest": {
+      "version": "4.26.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.26.0.tgz",
+      "integrity": "sha512-OduNjVJsFbifKb57UqZ2EMP1i4u64Xwow3NYXUtBbD4vIwJdQd4+xl8YDou1dlm4DVrtwT/7Ky8z8WyCULVfxw==",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/undefsafe": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
@@ -5092,6 +5408,14 @@
       "optional": true,
       "dependencies": {
         "imurmurhash": "^0.1.4"
+      }
+    },
+    "node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "engines": {
+        "node": ">= 4.0.0"
       }
     },
     "node_modules/unpipe": {
@@ -5130,6 +5454,14 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dependencies": {
+        "punycode": "^2.1.0"
       }
     },
     "node_modules/util-deprecate": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "2.13.3",
       "license": "GPL-3.0",
       "dependencies": {
-        "@rushstack/terminal": "^0.14.0",
         "axios": "^0.27.2",
         "cookie-parser": "^1.4.6",
         "express": "^4.17.1",
@@ -27,7 +26,6 @@
         "socket.io": "^4.5.4",
         "sqlite3": "^5.1.6",
         "ssrf-req-filter": "^1.1.0",
-        "umzug": "^3.8.1",
         "xml2js": "^0.5.0"
       },
       "bin": {
@@ -621,38 +619,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/@nodelib/fs.scandir": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
-      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-      "dependencies": {
-        "@nodelib/fs.stat": "2.0.5",
-        "run-parallel": "^1.1.9"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@nodelib/fs.stat": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@nodelib/fs.walk": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
-      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-      "dependencies": {
-        "@nodelib/fs.scandir": "2.1.5",
-        "fastq": "^1.6.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/@npmcli/fs": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-1.1.1.tgz",
@@ -675,104 +641,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/@rushstack/node-core-library": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-5.7.0.tgz",
-      "integrity": "sha512-Ff9Cz/YlWu9ce4dmqNBZpA45AEya04XaBFIjV7xTVeEf+y/kTjEasmozqFELXlNG4ROdevss75JrrZ5WgufDkQ==",
-      "dependencies": {
-        "ajv": "~8.13.0",
-        "ajv-draft-04": "~1.0.0",
-        "ajv-formats": "~3.0.1",
-        "fs-extra": "~7.0.1",
-        "import-lazy": "~4.0.0",
-        "jju": "~1.4.0",
-        "resolve": "~1.22.1",
-        "semver": "~7.5.4"
-      },
-      "peerDependencies": {
-        "@types/node": "*"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@rushstack/node-core-library/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@rushstack/node-core-library/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@rushstack/terminal": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@rushstack/terminal/-/terminal-0.14.0.tgz",
-      "integrity": "sha512-juTKMAMpTIJKudeFkG5slD8Z/LHwNwGZLtU441l/u82XdTBfsP+LbGKJLCNwP5se+DMCT55GB8x9p6+C4UL7jw==",
-      "dependencies": {
-        "@rushstack/node-core-library": "5.7.0",
-        "supports-color": "~8.1.1"
-      },
-      "peerDependencies": {
-        "@types/node": "*"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@rushstack/terminal/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@rushstack/terminal/node_modules/supports-color": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
-    "node_modules/@rushstack/ts-command-line": {
-      "version": "4.22.6",
-      "resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-4.22.6.tgz",
-      "integrity": "sha512-QSRqHT/IfoC5nk9zn6+fgyqOPXHME0BfchII9EUPR19pocsNp/xSbeBCbD3PIR2Lg+Q5qk7OFqk1VhWPMdKHJg==",
-      "dependencies": {
-        "@rushstack/terminal": "0.14.0",
-        "@types/argparse": "1.0.38",
-        "argparse": "~1.0.9",
-        "string-argv": "~0.3.1"
       }
     },
     "node_modules/@sinonjs/commons": {
@@ -832,11 +700,6 @@
       "engines": {
         "node": ">= 6"
       }
-    },
-    "node_modules/@types/argparse": {
-      "version": "1.0.38",
-      "resolved": "https://registry.npmjs.org/@types/argparse/-/argparse-1.0.38.tgz",
-      "integrity": "sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA=="
     },
     "node_modules/@types/cookie": {
       "version": "0.4.1",
@@ -973,50 +836,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/ajv": {
-      "version": "8.13.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.13.0.tgz",
-      "integrity": "sha512-PRA911Blj99jR5RMeTunVbNXMF6Lp4vZXnk5GQjcnUWUTsrXtekg/pnmFFI2u/I36Y/2bITGS30GZCXei6uNkA==",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.4.1"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/ajv-draft-04": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
-      "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
-      "peerDependencies": {
-        "ajv": "^8.5.0"
-      },
-      "peerDependenciesMeta": {
-        "ajv": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/ajv-formats": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
-      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
-      "dependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "ajv": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/ansi-colors": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
@@ -1101,6 +920,7 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
       "dependencies": {
         "sprintf-js": "~1.0.2"
       }
@@ -1188,11 +1008,12 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
-      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "dev": true,
       "dependencies": {
-        "fill-range": "^7.1.1"
+        "fill-range": "^7.0.1"
       },
       "engines": {
         "node": ">=8"
@@ -1788,17 +1609,6 @@
       "integrity": "sha512-T5q3pjQon853xxxHUq3ZP68ZpvJHuSMY2+BZaW3QzjS4HvNuvsMmZ/+lU+nCrftre1jFZ+OSlExynXWBihnXzw==",
       "dev": true
     },
-    "node_modules/emittery": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.13.1.tgz",
-      "integrity": "sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/emittery?sponsor=1"
-      }
-    },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -2033,38 +1843,11 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/fast-deep-equal": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
-    },
-    "node_modules/fast-glob": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
-      "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
-      "dependencies": {
-        "@nodelib/fs.stat": "^2.0.2",
-        "@nodelib/fs.walk": "^1.2.3",
-        "glob-parent": "^5.1.2",
-        "merge2": "^1.3.0",
-        "micromatch": "^4.0.4"
-      },
-      "engines": {
-        "node": ">=8.6.0"
-      }
-    },
-    "node_modules/fastq": {
-      "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
-      "integrity": "sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==",
-      "dependencies": {
-        "reusify": "^1.0.4"
-      }
-    },
     "node_modules/fill-range": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
-      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "dev": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -2209,19 +1992,6 @@
         }
       ]
     },
-    "node_modules/fs-extra": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
-      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
-      "dependencies": {
-        "graceful-fs": "^4.1.2",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=6 <7 || >=8"
-      }
-    },
     "node_modules/fs-minipass": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
@@ -2337,6 +2107,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
       "dependencies": {
         "is-glob": "^4.0.1"
       },
@@ -2408,17 +2179,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dependencies": {
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/he": {
@@ -2571,14 +2331,6 @@
       "integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==",
       "dev": true
     },
-    "node_modules/import-lazy": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-4.0.0.tgz",
-      "integrity": "sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -2651,24 +2403,11 @@
         "node": ">=8"
       }
     },
-    "node_modules/is-core-module": {
-      "version": "2.15.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.15.1.tgz",
-      "integrity": "sha512-z0vtXSwucUJtANQWldhbtbt7BnL0vxiFjIdDLAatwhDYty2bad6s+rijD6Ri4YuYJubLzIJLUidCh09e1djEVQ==",
-      "dependencies": {
-        "hasown": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2685,6 +2424,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
@@ -2702,6 +2442,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
       "engines": {
         "node": ">=0.12.0"
       }
@@ -2940,11 +2681,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/jju": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz",
-      "integrity": "sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA=="
-    },
     "node_modules/jose": {
       "version": "4.15.4",
       "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.4.tgz",
@@ -2984,11 +2720,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
-    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -2999,14 +2730,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/jsonfile": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
       }
     },
     "node_modules/jsonwebtoken": {
@@ -3231,32 +2954,12 @@
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
       "integrity": "sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w=="
     },
-    "node_modules/merge2": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/methods": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
       "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/micromatch": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
-      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-      "dependencies": {
-        "braces": "^3.0.3",
-        "picomatch": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=8.6"
       }
     },
     "node_modules/mime": {
@@ -4263,11 +3966,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/path-parse": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
-    },
     "node_modules/path-to-regexp": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
@@ -4302,6 +4000,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
       "engines": {
         "node": ">=8.6"
       },
@@ -4319,14 +4018,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/pony-cause": {
-      "version": "2.1.11",
-      "resolved": "https://registry.npmjs.org/pony-cause/-/pony-cause-2.1.11.tgz",
-      "integrity": "sha512-M7LhCsdNbNgiLYiP4WjsfLUuFmCfnjdF6jKe2R9NKl4WFN+HZPGHJZ9lnLP7f9ZnKe3U9nuWD0szirmj+migUg==",
-      "engines": {
-        "node": ">=12.0.0"
       }
     },
     "node_modules/process-on-spawn": {
@@ -4378,14 +4069,6 @@
       "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==",
       "dev": true
     },
-    "node_modules/punycode": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
-      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/qs": {
       "version": "6.11.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
@@ -4399,25 +4082,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/queue-microtask": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
     },
     "node_modules/random-bytes": {
       "version": "1.0.0",
@@ -4504,35 +4168,11 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/require-from-string": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/require-main-filename": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "dev": true
-    },
-    "node_modules/resolve": {
-      "version": "1.22.8",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
-      "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
-      "dependencies": {
-        "is-core-module": "^2.13.0",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      },
-      "bin": {
-        "resolve": "bin/resolve"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
     },
     "node_modules/resolve-from": {
       "version": "5.0.0",
@@ -4557,15 +4197,6 @@
       "resolved": "https://registry.npmjs.org/retry-as-promised/-/retry-as-promised-7.0.4.tgz",
       "integrity": "sha512-XgmCoxKWkDofwH8WddD0w85ZfqYz+ZHlr5yo+3YUCfycWawU56T5ckWXsScsj5B8tqUcIG67DxXByo3VUgiAdA=="
     },
-    "node_modules/reusify": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
-      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
-      "engines": {
-        "iojs": ">=1.0.0",
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -4578,28 +4209,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/run-parallel": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
-      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "dependencies": {
-        "queue-microtask": "^1.2.2"
       }
     },
     "node_modules/safe-buffer": {
@@ -5079,7 +4688,8 @@
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "dev": true
     },
     "node_modules/sqlite3": {
       "version": "5.1.6",
@@ -5147,14 +4757,6 @@
         "safe-buffer": "~5.2.0"
       }
     },
-    "node_modules/string-argv": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
-      "integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==",
-      "engines": {
-        "node": ">=0.6.19"
-      }
-    },
     "node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -5212,17 +4814,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/supports-preserve-symlinks-flag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/tar": {
       "version": "6.1.15",
       "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.15.tgz",
@@ -5274,6 +4865,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
       "dependencies": {
         "is-number": "^7.0.0"
       },
@@ -5361,32 +4953,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/umzug": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/umzug/-/umzug-3.8.1.tgz",
-      "integrity": "sha512-k0HjOc3b/s8vH24BUTvnaFiKhfWI9UQAGpqHDG+3866CGlBTB83Xs5wZ1io1mwYLj/GHvQ34AxKhbpYnWtkRJg==",
-      "dependencies": {
-        "@rushstack/ts-command-line": "^4.12.2",
-        "emittery": "^0.13.0",
-        "fast-glob": "^3.3.2",
-        "pony-cause": "^2.1.4",
-        "type-fest": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/umzug/node_modules/type-fest": {
-      "version": "4.26.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.26.0.tgz",
-      "integrity": "sha512-OduNjVJsFbifKb57UqZ2EMP1i4u64Xwow3NYXUtBbD4vIwJdQd4+xl8YDou1dlm4DVrtwT/7Ky8z8WyCULVfxw==",
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/undefsafe": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
@@ -5409,14 +4975,6 @@
       "optional": true,
       "dependencies": {
         "imurmurhash": "^0.1.4"
-      }
-    },
-    "node_modules/universalify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-      "engines": {
-        "node": ">= 4.0.0"
       }
     },
     "node_modules/unpipe": {
@@ -5455,14 +5013,6 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
-      }
-    },
-    "node_modules/uri-js": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
-      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "dependencies": {
-        "punycode": "^2.1.0"
       }
     },
     "node_modules/util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -47,10 +47,12 @@
     "p-throttle": "^4.1.1",
     "passport": "^0.6.0",
     "passport-jwt": "^4.0.1",
+    "semver": "^7.6.3",
     "sequelize": "^6.35.2",
     "socket.io": "^4.5.4",
     "sqlite3": "^5.1.6",
     "ssrf-req-filter": "^1.1.0",
+    "umzug": "^3.8.1",
     "xml2js": "^0.5.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -22,13 +22,11 @@
   "pkg": {
     "assets": [
       "client/dist/**/*",
-      "node_modules/sqlite3/lib/binding/**/*.node",
-      "node_modules/string-argv/commonjs/package.json"
+      "node_modules/sqlite3/lib/binding/**/*.node"
     ],
     "scripts": [
       "prod.js",
-      "server/**/*.js",
-      "node_modules/string-argv/commonjs/*.js"
+      "server/**/*.js"
     ]
   },
   "mocha": {
@@ -37,7 +35,6 @@
   "author": "advplyr",
   "license": "GPL-3.0",
   "dependencies": {
-    "@rushstack/terminal": "^0.14.0",
     "axios": "^0.27.2",
     "cookie-parser": "^1.4.6",
     "express": "^4.17.1",
@@ -55,7 +52,6 @@
     "socket.io": "^4.5.4",
     "sqlite3": "^5.1.6",
     "ssrf-req-filter": "^1.1.0",
-    "umzug": "^3.8.1",
     "xml2js": "^0.5.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -22,11 +22,13 @@
   "pkg": {
     "assets": [
       "client/dist/**/*",
-      "node_modules/sqlite3/lib/binding/**/*.node"
+      "node_modules/sqlite3/lib/binding/**/*.node",
+      "node_modules/string-argv/commonjs/package.json"
     ],
     "scripts": [
       "prod.js",
-      "server/**/*.js"
+      "server/**/*.js",
+      "node_modules/string-argv/commonjs/*.js"
     ]
   },
   "mocha": {
@@ -35,6 +37,7 @@
   "author": "advplyr",
   "license": "GPL-3.0",
   "dependencies": {
+    "@rushstack/terminal": "^0.14.0",
     "axios": "^0.27.2",
     "cookie-parser": "^1.4.6",
     "express": "^4.17.1",

--- a/server/Database.js
+++ b/server/Database.js
@@ -170,14 +170,13 @@ class Database {
       throw new Error('Database connection failed')
     }
 
-    if (!this.isNew) {
-      try {
-        const migrationManager = new MigrationManager(this.sequelize, global.ConfigPath)
-        await migrationManager.runMigrations(packageJson.version)
-      } catch (error) {
-        Logger.error(`[Database] Failed to run migrations`, error)
-        throw new Error('Database migration failed')
-      }
+    try {
+      const migrationManager = new MigrationManager(this.sequelize, global.ConfigPath)
+      await migrationManager.init(packageJson.version)
+      if (!this.isNew) await migrationManager.runMigrations()
+    } catch (error) {
+      Logger.error(`[Database] Failed to run migrations`, error)
+      throw new Error('Database migration failed')
     }
 
     await this.buildModels(force)

--- a/server/Database.js
+++ b/server/Database.js
@@ -8,6 +8,8 @@ const Logger = require('./Logger')
 const dbMigration = require('./utils/migrations/dbMigration')
 const Auth = require('./Auth')
 
+const MigrationManager = require('./managers/MigrationManager')
+
 class Database {
   constructor() {
     this.sequelize = null
@@ -166,6 +168,16 @@ class Database {
 
     if (!(await this.connect())) {
       throw new Error('Database connection failed')
+    }
+
+    if (!this.isNew) {
+      try {
+        const migrationManager = new MigrationManager(this.sequelize, global.ConfigPath)
+        await migrationManager.runMigrations(packageJson.version)
+      } catch (error) {
+        Logger.error(`[Database] Failed to run migrations`, error)
+        throw new Error('Database migration failed')
+      }
     }
 
     await this.buildModels(force)

--- a/server/libs/umzug/LICENSE
+++ b/server/libs/umzug/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2014-2017 Sequelize contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/server/libs/umzug/index.js
+++ b/server/libs/umzug/index.js
@@ -1,0 +1,31 @@
+'use strict'
+var __createBinding =
+  (this && this.__createBinding) ||
+  (Object.create
+    ? function (o, m, k, k2) {
+        if (k2 === undefined) k2 = k
+        var desc = Object.getOwnPropertyDescriptor(m, k)
+        if (!desc || ('get' in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+          desc = {
+            enumerable: true,
+            get: function () {
+              return m[k]
+            }
+          }
+        }
+        Object.defineProperty(o, k2, desc)
+      }
+    : function (o, m, k, k2) {
+        if (k2 === undefined) k2 = k
+        o[k2] = m[k]
+      })
+var __exportStar =
+  (this && this.__exportStar) ||
+  function (m, exports) {
+    for (var p in m) if (p !== 'default' && !Object.prototype.hasOwnProperty.call(exports, p)) __createBinding(exports, m, p)
+  }
+Object.defineProperty(exports, '__esModule', { value: true })
+__exportStar(require('./umzug'), exports)
+__exportStar(require('./storage'), exports)
+__exportStar(require('./types'), exports)
+//# sourceMappingURL=index.js.map

--- a/server/libs/umzug/storage/contract.js
+++ b/server/libs/umzug/storage/contract.js
@@ -1,0 +1,18 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.verifyUmzugStorage = exports.isUmzugStorage = void 0;
+function isUmzugStorage(arg) {
+    return (arg &&
+        typeof arg.logMigration === 'function' &&
+        typeof arg.unlogMigration === 'function' &&
+        typeof arg.executed === 'function');
+}
+exports.isUmzugStorage = isUmzugStorage;
+const verifyUmzugStorage = (arg) => {
+    if (!isUmzugStorage(arg)) {
+        throw new Error(`Invalid umzug storage`);
+    }
+    return arg;
+};
+exports.verifyUmzugStorage = verifyUmzugStorage;
+//# sourceMappingURL=contract.js.map

--- a/server/libs/umzug/storage/index.js
+++ b/server/libs/umzug/storage/index.js
@@ -1,0 +1,24 @@
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __exportStar = (this && this.__exportStar) || function(m, exports) {
+    for (var p in m) if (p !== "default" && !Object.prototype.hasOwnProperty.call(exports, p)) __createBinding(exports, m, p);
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+// codegen:start {preset: barrel}
+__exportStar(require("./contract"), exports);
+__exportStar(require("./json"), exports);
+__exportStar(require("./memory"), exports);
+__exportStar(require("./mongodb"), exports);
+__exportStar(require("./sequelize"), exports);
+// codegen:end
+//# sourceMappingURL=index.js.map

--- a/server/libs/umzug/storage/json.js
+++ b/server/libs/umzug/storage/json.js
@@ -1,0 +1,61 @@
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.JSONStorage = void 0;
+const fs_1 = require("fs");
+const path = __importStar(require("path"));
+const filesystem = {
+    /** reads a file as a string or returns null if file doesn't exist */
+    async readAsync(filepath) {
+        return fs_1.promises.readFile(filepath).then(c => c.toString(), () => null);
+    },
+    /** writes a string as file contents, creating its parent directory if necessary */
+    async writeAsync(filepath, content) {
+        await fs_1.promises.mkdir(path.dirname(filepath), { recursive: true });
+        await fs_1.promises.writeFile(filepath, content);
+    },
+};
+class JSONStorage {
+    constructor(options) {
+        var _a;
+        this.path = (_a = options === null || options === void 0 ? void 0 : options.path) !== null && _a !== void 0 ? _a : path.join(process.cwd(), 'umzug.json');
+    }
+    async logMigration({ name: migrationName }) {
+        const loggedMigrations = await this.executed();
+        loggedMigrations.push(migrationName);
+        await filesystem.writeAsync(this.path, JSON.stringify(loggedMigrations, null, 2));
+    }
+    async unlogMigration({ name: migrationName }) {
+        const loggedMigrations = await this.executed();
+        const updatedMigrations = loggedMigrations.filter(name => name !== migrationName);
+        await filesystem.writeAsync(this.path, JSON.stringify(updatedMigrations, null, 2));
+    }
+    async executed() {
+        const content = await filesystem.readAsync(this.path);
+        return content ? JSON.parse(content) : [];
+    }
+}
+exports.JSONStorage = JSONStorage;
+//# sourceMappingURL=json.js.map

--- a/server/libs/umzug/storage/memory.js
+++ b/server/libs/umzug/storage/memory.js
@@ -1,0 +1,17 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.memoryStorage = void 0;
+const memoryStorage = () => {
+    let executed = [];
+    return {
+        async logMigration({ name }) {
+            executed.push(name);
+        },
+        async unlogMigration({ name }) {
+            executed = executed.filter(n => n !== name);
+        },
+        executed: async () => [...executed],
+    };
+};
+exports.memoryStorage = memoryStorage;
+//# sourceMappingURL=memory.js.map

--- a/server/libs/umzug/storage/mongodb.js
+++ b/server/libs/umzug/storage/mongodb.js
@@ -1,0 +1,31 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.MongoDBStorage = void 0;
+function isMongoDBCollectionOptions(arg) {
+    return Boolean(arg.collection);
+}
+class MongoDBStorage {
+    constructor(options) {
+        var _a, _b;
+        if (!options || (!options.collection && !options.connection)) {
+            throw new Error('MongoDB Connection or Collection required');
+        }
+        this.collection = isMongoDBCollectionOptions(options)
+            ? options.collection
+            : options.connection.collection((_a = options.collectionName) !== null && _a !== void 0 ? _a : 'migrations');
+        this.connection = options.connection; // TODO remove this
+        this.collectionName = (_b = options.collectionName) !== null && _b !== void 0 ? _b : 'migrations'; // TODO remove this
+    }
+    async logMigration({ name: migrationName }) {
+        await this.collection.insertOne({ migrationName });
+    }
+    async unlogMigration({ name: migrationName }) {
+        await this.collection.deleteOne({ migrationName });
+    }
+    async executed() {
+        const records = await this.collection.find({}).sort({ migrationName: 1 }).toArray();
+        return records.map(r => r.migrationName);
+    }
+}
+exports.MongoDBStorage = MongoDBStorage;
+//# sourceMappingURL=mongodb.js.map

--- a/server/libs/umzug/storage/sequelize.js
+++ b/server/libs/umzug/storage/sequelize.js
@@ -1,0 +1,85 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.SequelizeStorage = void 0;
+const DIALECTS_WITH_CHARSET_AND_COLLATE = new Set(['mysql', 'mariadb']);
+class SequelizeStorage {
+    /**
+      Constructs Sequelize based storage. Migrations will be stored in a SequelizeMeta table using the given instance of Sequelize.
+  
+      If a model is given, it will be used directly as the model for the SequelizeMeta table. Otherwise, it will be created automatically according to the given options.
+  
+      If the table does not exist it will be created automatically upon the logging of the first migration.
+      */
+    constructor(options) {
+        var _a, _b, _c, _d, _e, _f;
+        if (!options || (!options.model && !options.sequelize)) {
+            throw new Error('One of "sequelize" or "model" storage option is required');
+        }
+        this.sequelize = (_a = options.sequelize) !== null && _a !== void 0 ? _a : options.model.sequelize;
+        this.columnType = (_b = options.columnType) !== null && _b !== void 0 ? _b : this.sequelize.constructor.DataTypes.STRING;
+        this.columnName = (_c = options.columnName) !== null && _c !== void 0 ? _c : 'name';
+        this.timestamps = (_d = options.timestamps) !== null && _d !== void 0 ? _d : false;
+        this.modelName = (_e = options.modelName) !== null && _e !== void 0 ? _e : 'SequelizeMeta';
+        this.tableName = options.tableName;
+        this.schema = options.schema;
+        this.model = (_f = options.model) !== null && _f !== void 0 ? _f : this.getModel();
+    }
+    getModel() {
+        var _a;
+        if (this.sequelize.isDefined(this.modelName)) {
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+            return this.sequelize.model(this.modelName);
+        }
+        const dialectName = (_a = this.sequelize.dialect) === null || _a === void 0 ? void 0 : _a.name;
+        const hasCharsetAndCollate = dialectName && DIALECTS_WITH_CHARSET_AND_COLLATE.has(dialectName);
+        return this.sequelize.define(this.modelName, {
+            [this.columnName]: {
+                type: this.columnType,
+                allowNull: false,
+                unique: true,
+                primaryKey: true,
+                autoIncrement: false,
+            },
+        }, {
+            tableName: this.tableName,
+            schema: this.schema,
+            timestamps: this.timestamps,
+            charset: hasCharsetAndCollate ? 'utf8' : undefined,
+            collate: hasCharsetAndCollate ? 'utf8_unicode_ci' : undefined,
+        });
+    }
+    async syncModel() {
+        await this.model.sync();
+    }
+    async logMigration({ name: migrationName }) {
+        await this.syncModel();
+        await this.model.create({
+            [this.columnName]: migrationName,
+        });
+    }
+    async unlogMigration({ name: migrationName }) {
+        await this.syncModel();
+        await this.model.destroy({
+            where: {
+                [this.columnName]: migrationName,
+            },
+        });
+    }
+    async executed() {
+        await this.syncModel();
+        const migrations = await this.model.findAll({ order: [[this.columnName, 'ASC']] });
+        return migrations.map(migration => {
+            const name = migration[this.columnName];
+            if (typeof name !== 'string') {
+                throw new TypeError(`Unexpected migration name type: expected string, got ${typeof name}`);
+            }
+            return name;
+        });
+    }
+    // TODO remove this
+    _model() {
+        return this.model;
+    }
+}
+exports.SequelizeStorage = SequelizeStorage;
+//# sourceMappingURL=sequelize.js.map

--- a/server/libs/umzug/templates.js
+++ b/server/libs/umzug/templates.js
@@ -1,0 +1,32 @@
+'use strict'
+/* eslint-disable unicorn/template-indent */
+// templates for migration file creation
+Object.defineProperty(exports, '__esModule', { value: true })
+exports.sqlDown = exports.sqlUp = exports.mjs = exports.ts = exports.js = void 0
+exports.js = `
+/** @type {import('umzug').MigrationFn<any>} */
+exports.up = async params => {};
+
+/** @type {import('umzug').MigrationFn<any>} */
+exports.down = async params => {};
+`.trimStart()
+exports.ts = `
+import type { MigrationFn } from 'umzug';
+
+export const up: MigrationFn = async params => {};
+export const down: MigrationFn = async params => {};
+`.trimStart()
+exports.mjs = `
+/** @type {import('umzug').MigrationFn<any>} */
+export const up = async params => {};
+
+/** @type {import('umzug').MigrationFn<any>} */
+export const down = async params => {};
+`.trimStart()
+exports.sqlUp = `
+-- up migration
+`.trimStart()
+exports.sqlDown = `
+-- down migration
+`.trimStart()
+//# sourceMappingURL=templates.js.map

--- a/server/libs/umzug/types.js
+++ b/server/libs/umzug/types.js
@@ -1,0 +1,12 @@
+'use strict'
+Object.defineProperty(exports, '__esModule', { value: true })
+exports.RerunBehavior = void 0
+exports.RerunBehavior = {
+  /** Hard error if an up migration that has already been run, or a down migration that hasn't, is encountered */
+  THROW: 'THROW',
+  /** Silently skip up migrations that have already been run, or down migrations that haven't */
+  SKIP: 'SKIP',
+  /** Re-run up migrations that have already been run, or down migrations that haven't */
+  ALLOW: 'ALLOW'
+}
+//# sourceMappingURL=types.js.map

--- a/server/libs/umzug/umzug.js
+++ b/server/libs/umzug/umzug.js
@@ -1,0 +1,386 @@
+'use strict'
+var __createBinding =
+  (this && this.__createBinding) ||
+  (Object.create
+    ? function (o, m, k, k2) {
+        if (k2 === undefined) k2 = k
+        var desc = Object.getOwnPropertyDescriptor(m, k)
+        if (!desc || ('get' in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+          desc = {
+            enumerable: true,
+            get: function () {
+              return m[k]
+            }
+          }
+        }
+        Object.defineProperty(o, k2, desc)
+      }
+    : function (o, m, k, k2) {
+        if (k2 === undefined) k2 = k
+        o[k2] = m[k]
+      })
+var __setModuleDefault =
+  (this && this.__setModuleDefault) ||
+  (Object.create
+    ? function (o, v) {
+        Object.defineProperty(o, 'default', { enumerable: true, value: v })
+      }
+    : function (o, v) {
+        o['default'] = v
+      })
+var __importStar =
+  (this && this.__importStar) ||
+  function (mod) {
+    if (mod && mod.__esModule) return mod
+    var result = {}
+    if (mod != null) for (var k in mod) if (k !== 'default' && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k)
+    __setModuleDefault(result, mod)
+    return result
+  }
+var __importDefault =
+  (this && this.__importDefault) ||
+  function (mod) {
+    return mod && mod.__esModule ? mod : { default: mod }
+  }
+var _a
+Object.defineProperty(exports, '__esModule', { value: true })
+exports.Umzug = exports.MigrationError = void 0
+const fs = __importStar(require('fs'))
+const path = __importStar(require('path'))
+const storage_1 = require('./storage')
+const templates = __importStar(require('./templates'))
+const types_1 = require('./types')
+class MigrationError extends Error {
+  // TODO [>=4.0.0] Take a `{ cause: ... }` options bag like the default `Error`, it looks like this because of verror backwards-compatibility.
+  constructor(migration, original) {
+    super(`Migration ${migration.name} (${migration.direction}) failed: ${MigrationError.errorString(original)}`, {
+      cause: original
+    })
+    this.name = 'MigrationError'
+    this.migration = migration
+  }
+  // TODO [>=4.0.0] Remove this backwards-compatibility alias
+  get info() {
+    return this.migration
+  }
+  static errorString(cause) {
+    return cause instanceof Error ? `Original error: ${cause.message}` : `Non-error value thrown. See info for full props: ${cause}`
+  }
+}
+exports.MigrationError = MigrationError
+class Umzug {
+  /** creates a new Umzug instance */
+  constructor(options) {
+    var _b
+    this.options = options
+    this.storage = (0, storage_1.verifyUmzugStorage)((_b = options.storage) !== null && _b !== void 0 ? _b : new storage_1.JSONStorage())
+    this.migrations = this.getMigrationsResolver(this.options.migrations)
+  }
+  logging(message) {
+    var _b
+    ;(_b = this.options.logger) === null || _b === void 0 ? void 0 : _b.info(message)
+  }
+  /** Get the list of migrations which have already been applied */
+  async executed() {
+    return this.runCommand('executed', async ({ context }) => {
+      const list = await this._executed(context)
+      // We do the following to not expose the `up` and `down` functions to the user
+      return list.map((m) => ({ name: m.name, path: m.path }))
+    })
+  }
+  /** Get the list of migrations which have already been applied */
+  async _executed(context) {
+    const [migrations, executedNames] = await Promise.all([this.migrations(context), this.storage.executed({ context })])
+    const executedSet = new Set(executedNames)
+    return migrations.filter((m) => executedSet.has(m.name))
+  }
+  /** Get the list of migrations which are yet to be applied */
+  async pending() {
+    return this.runCommand('pending', async ({ context }) => {
+      const list = await this._pending(context)
+      // We do the following to not expose the `up` and `down` functions to the user
+      return list.map((m) => ({ name: m.name, path: m.path }))
+    })
+  }
+  async _pending(context) {
+    const [migrations, executedNames] = await Promise.all([this.migrations(context), this.storage.executed({ context })])
+    const executedSet = new Set(executedNames)
+    return migrations.filter((m) => !executedSet.has(m.name))
+  }
+  async runCommand(command, cb) {
+    const context = await this.getContext()
+    return await cb({ context })
+  }
+  /**
+   * Apply migrations. By default, runs all pending migrations.
+   * @see MigrateUpOptions for other use cases using `to`, `migrations` and `rerun`.
+   */
+  async up(options = {}) {
+    const eligibleMigrations = async (context) => {
+      var _b
+      if (options.migrations && options.rerun === types_1.RerunBehavior.ALLOW) {
+        // Allow rerun means the specified migrations should be run even if they've run before - so get all migrations, not just pending
+        const list = await this.migrations(context)
+        return this.findMigrations(list, options.migrations)
+      }
+      if (options.migrations && options.rerun === types_1.RerunBehavior.SKIP) {
+        const executedNames = new Set((await this._executed(context)).map((m) => m.name))
+        const filteredMigrations = options.migrations.filter((m) => !executedNames.has(m))
+        return this.findMigrations(await this.migrations(context), filteredMigrations)
+      }
+      if (options.migrations) {
+        return this.findMigrations(await this._pending(context), options.migrations)
+      }
+      const allPending = await this._pending(context)
+      let sliceIndex = (_b = options.step) !== null && _b !== void 0 ? _b : allPending.length
+      if (options.to) {
+        sliceIndex = this.findNameIndex(allPending, options.to) + 1
+      }
+      return allPending.slice(0, sliceIndex)
+    }
+    return this.runCommand('up', async ({ context }) => {
+      const toBeApplied = await eligibleMigrations(context)
+      for (const m of toBeApplied) {
+        const start = Date.now()
+        const params = { name: m.name, path: m.path, context }
+        this.logging({ event: 'migrating', name: m.name })
+        try {
+          await m.up(params)
+        } catch (e) {
+          throw new MigrationError({ direction: 'up', ...params }, e)
+        }
+        await this.storage.logMigration(params)
+        const duration = (Date.now() - start) / 1000
+        this.logging({ event: 'migrated', name: m.name, durationSeconds: duration })
+      }
+      return toBeApplied.map((m) => ({ name: m.name, path: m.path }))
+    })
+  }
+  /**
+   * Revert migrations. By default, the last executed migration is reverted.
+   * @see MigrateDownOptions for other use cases using `to`, `migrations` and `rerun`.
+   */
+  async down(options = {}) {
+    const eligibleMigrations = async (context) => {
+      var _b
+      if (options.migrations && options.rerun === types_1.RerunBehavior.ALLOW) {
+        const list = await this.migrations(context)
+        return this.findMigrations(list, options.migrations)
+      }
+      if (options.migrations && options.rerun === types_1.RerunBehavior.SKIP) {
+        const pendingNames = new Set((await this._pending(context)).map((m) => m.name))
+        const filteredMigrations = options.migrations.filter((m) => !pendingNames.has(m))
+        return this.findMigrations(await this.migrations(context), filteredMigrations)
+      }
+      if (options.migrations) {
+        return this.findMigrations(await this._executed(context), options.migrations)
+      }
+      const executedReversed = (await this._executed(context)).slice().reverse()
+      let sliceIndex = (_b = options.step) !== null && _b !== void 0 ? _b : 1
+      if (options.to === 0 || options.migrations) {
+        sliceIndex = executedReversed.length
+      } else if (options.to) {
+        sliceIndex = this.findNameIndex(executedReversed, options.to) + 1
+      }
+      return executedReversed.slice(0, sliceIndex)
+    }
+    return this.runCommand('down', async ({ context }) => {
+      var _b
+      const toBeReverted = await eligibleMigrations(context)
+      for (const m of toBeReverted) {
+        const start = Date.now()
+        const params = { name: m.name, path: m.path, context }
+        this.logging({ event: 'reverting', name: m.name })
+        try {
+          await ((_b = m.down) === null || _b === void 0 ? void 0 : _b.call(m, params))
+        } catch (e) {
+          throw new MigrationError({ direction: 'down', ...params }, e)
+        }
+        await this.storage.unlogMigration(params)
+        const duration = Number.parseFloat(((Date.now() - start) / 1000).toFixed(3))
+        this.logging({ event: 'reverted', name: m.name, durationSeconds: duration })
+      }
+      return toBeReverted.map((m) => ({ name: m.name, path: m.path }))
+    })
+  }
+  async create(options) {
+    await this.runCommand('create', async ({ context }) => {
+      var _b, _c, _d, _e
+      const isoDate = new Date().toISOString()
+      const prefixes = {
+        TIMESTAMP: isoDate.replace(/\.\d{3}Z$/, '').replace(/\W/g, '.'),
+        DATE: isoDate.split('T')[0].replace(/\W/g, '.'),
+        NONE: ''
+      }
+      const prefixType = (_b = options.prefix) !== null && _b !== void 0 ? _b : 'TIMESTAMP'
+      const fileBasename = [prefixes[prefixType], options.name].filter(Boolean).join('.')
+      const allowedExtensions = options.allowExtension ? [options.allowExtension] : ['.js', '.cjs', '.mjs', '.ts', '.cts', '.mts', '.sql']
+      const existing = await this.migrations(context)
+      const last = existing.slice(-1)[0]
+      const folder = options.folder || ((_c = this.options.create) === null || _c === void 0 ? void 0 : _c.folder) || ((last === null || last === void 0 ? void 0 : last.path) && path.dirname(last.path))
+      if (!folder) {
+        throw new Error(`Couldn't infer a directory to generate migration file in. Pass folder explicitly`)
+      }
+      const filepath = path.join(folder, fileBasename)
+      if (!options.allowConfusingOrdering) {
+        const confusinglyOrdered = existing.find((e) => e.path && e.path >= filepath)
+        if (confusinglyOrdered) {
+          throw new Error(`Can't create ${fileBasename}, since it's unclear if it should run before or after existing migration ${confusinglyOrdered.name}. Use allowConfusingOrdering to bypass this error.`)
+        }
+      }
+      const template =
+        typeof options.content === 'string'
+          ? async () => [[filepath, options.content]]
+          : // eslint-disable-next-line @typescript-eslint/unbound-method
+          (_e = (_d = this.options.create) === null || _d === void 0 ? void 0 : _d.template) !== null && _e !== void 0
+          ? _e
+          : Umzug.defaultCreationTemplate
+      const toWrite = await template(filepath)
+      if (toWrite.length === 0) {
+        toWrite.push([filepath, ''])
+      }
+      toWrite.forEach((pair) => {
+        if (!Array.isArray(pair) || pair.length !== 2) {
+          throw new Error(`Expected [filepath, content] pair. Check that the file template function returns an array of pairs.`)
+        }
+        const ext = path.extname(pair[0])
+        if (!allowedExtensions.includes(ext)) {
+          const allowStr = allowedExtensions.join(', ')
+          const message = `Extension ${ext} not allowed. Allowed extensions are ${allowStr}. See help for allowExtension to avoid this error.`
+          throw new Error(message)
+        }
+        fs.mkdirSync(path.dirname(pair[0]), { recursive: true })
+        fs.writeFileSync(pair[0], pair[1])
+        this.logging({ event: 'created', path: pair[0] })
+      })
+      if (!options.skipVerify) {
+        const [firstFilePath] = toWrite[0]
+        const pending = await this._pending(context)
+        if (!pending.some((p) => p.path && path.resolve(p.path) === path.resolve(firstFilePath))) {
+          const paths = pending.map((p) => p.path).join(', ')
+          throw new Error(`Expected ${firstFilePath} to be a pending migration but it wasn't! Pending migration paths: ${paths}. You should investigate this. Use skipVerify to bypass this error.`)
+        }
+      }
+    })
+  }
+  static defaultCreationTemplate(filepath) {
+    const ext = path.extname(filepath)
+    if ((ext === '.js' && typeof require.main === 'object') || ext === '.cjs') {
+      return [[filepath, templates.js]]
+    }
+    if (ext === '.ts' || ext === '.mts' || ext === '.cts') {
+      return [[filepath, templates.ts]]
+    }
+    if ((ext === '.js' && require.main === undefined) || ext === '.mjs') {
+      return [[filepath, templates.mjs]]
+    }
+    if (ext === '.sql') {
+      const downFilepath = path.join(path.dirname(filepath), 'down', path.basename(filepath))
+      return [
+        [filepath, templates.sqlUp],
+        [downFilepath, templates.sqlDown]
+      ]
+    }
+    return []
+  }
+  findNameIndex(migrations, name) {
+    const index = migrations.findIndex((m) => m.name === name)
+    if (index === -1) {
+      throw new Error(`Couldn't find migration to apply with name ${JSON.stringify(name)}`)
+    }
+    return index
+  }
+  findMigrations(migrations, names) {
+    const map = new Map(migrations.map((m) => [m.name, m]))
+    return names.map((name) => {
+      const migration = map.get(name)
+      if (!migration) {
+        throw new Error(`Couldn't find migration to apply with name ${JSON.stringify(name)}`)
+      }
+      return migration
+    })
+  }
+  async getContext() {
+    const { context = {} } = this.options
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+    return typeof context === 'function' ? context() : context
+  }
+  /** helper for parsing input migrations into a callback returning a list of ready-to-run migrations */
+  getMigrationsResolver(inputMigrations) {
+    var _b
+    if (Array.isArray(inputMigrations)) {
+      return async () => inputMigrations
+    }
+    if (typeof inputMigrations === 'function') {
+      // Lazy migrations definition, recurse.
+      return async (ctx) => {
+        const resolved = await inputMigrations(ctx)
+        return this.getMigrationsResolver(resolved)(ctx)
+      }
+    }
+    const paths = inputMigrations.files
+    const resolver = (_b = inputMigrations.resolve) !== null && _b !== void 0 ? _b : Umzug.defaultResolver
+    return async (context) => {
+      paths.sort()
+      return paths.map((unresolvedPath) => {
+        const filepath = path.resolve(unresolvedPath)
+        const name = path.basename(filepath)
+        return {
+          path: filepath,
+          ...resolver({ name, path: filepath, context })
+        }
+      })
+    }
+  }
+}
+exports.Umzug = Umzug
+_a = Umzug
+Umzug.defaultResolver = ({ name, path: filepath }) => {
+  if (!filepath) {
+    throw new Error(`Can't use default resolver for non-filesystem migrations`)
+  }
+  const ext = path.extname(filepath)
+  const languageSpecificHelp = {
+    '.ts': "TypeScript files can be required by adding `ts-node` as a dependency and calling `require('ts-node/register')` at the program entrypoint before running migrations.",
+    '.sql': 'Try writing a resolver which reads file content and executes it as a sql query.'
+  }
+  languageSpecificHelp['.cts'] = languageSpecificHelp['.ts']
+  languageSpecificHelp['.mts'] = languageSpecificHelp['.ts']
+  let loadModule
+  const jsExt = ext.replace(/\.([cm]?)ts$/, '.$1js')
+  const getModule = async () => {
+    try {
+      return await loadModule()
+    } catch (e) {
+      if ((e instanceof SyntaxError || e instanceof MissingResolverError) && ext in languageSpecificHelp) {
+        e.message += '\n\n' + languageSpecificHelp[ext]
+      }
+      throw e
+    }
+  }
+  if ((jsExt === '.js' && typeof require.main === 'object') || jsExt === '.cjs') {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    loadModule = async () => require(filepath)
+  } else if (jsExt === '.js' || jsExt === '.mjs') {
+    loadModule = async () => import(filepath)
+  } else {
+    loadModule = async () => {
+      throw new MissingResolverError(filepath)
+    }
+  }
+  return {
+    name,
+    path: filepath,
+    up: async ({ context }) => (await getModule()).up({ path: filepath, name, context }),
+    down: async ({ context }) => {
+      var _b, _c
+      return (_c = (_b = await getModule()).down) === null || _c === void 0 ? void 0 : _c.call(_b, { path: filepath, name, context })
+    }
+  }
+}
+class MissingResolverError extends Error {
+  constructor(filepath) {
+    super(`No resolver specified for file ${filepath}. See docs for guidance on how to write a custom resolver.`)
+  }
+}
+//# sourceMappingURL=umzug.js.map

--- a/server/managers/MigrationManager.js
+++ b/server/managers/MigrationManager.js
@@ -1,0 +1,199 @@
+const { Umzug, SequelizeStorage } = require('umzug')
+const { Sequelize } = require('sequelize')
+const semver = require('semver')
+const path = require('path')
+const fs = require('../libs/fsExtra')
+const Logger = require('../Logger')
+
+class MigrationManager {
+  constructor(sequelize, configPath = global.configPath) {
+    if (!sequelize || !(sequelize instanceof Sequelize)) {
+      throw new Error('Sequelize instance is required for MigrationManager.')
+    }
+    this.sequelize = sequelize
+    if (!configPath) {
+      throw new Error('Config path is required for MigrationManager.')
+    }
+    this.configPath = configPath
+    this.migrationsDir = null
+    this.maxVersion = null
+    this.databaseVersion = null
+    this.serverVersion = null
+    this.umzug = null
+  }
+
+  async runMigrations(serverVersion) {
+    await this.init(serverVersion)
+
+    const versionCompare = semver.compare(this.serverVersion, this.databaseVersion)
+    if (versionCompare == 0) {
+      Logger.info('[MigrationManager] Database is already up to date.')
+      return
+    }
+
+    const migrations = await this.umzug.migrations()
+    const executedMigrations = (await this.umzug.executed()).map((m) => m.name)
+
+    const migrationDirection = versionCompare == 1 ? 'up' : 'down'
+
+    let migrationsToRun = []
+    migrationsToRun = this.findMigrationsToRun(migrations, executedMigrations, migrationDirection)
+
+    // Only proceed with migration if there are migrations to run
+    if (migrationsToRun.length > 0) {
+      const originalDbPath = path.join(this.configPath, 'absdatabase.sqlite')
+      const backupDbPath = path.join(this.configPath, 'absdatabase.backup.sqlite')
+      try {
+        Logger.info(`[MigrationManager] Migrating database ${migrationDirection} to version ${this.serverVersion}`)
+        Logger.info(`[MigrationManager] Migrations to run: ${migrationsToRun.join(', ')}`)
+        // Create a backup copy of the SQLite database before starting migrations
+        await fs.copy(originalDbPath, backupDbPath)
+        Logger.info('Created a backup of the original database.')
+
+        // Run migrations
+        await this.umzug[migrationDirection]({ migrations: migrationsToRun })
+
+        // Clean up the backup
+        await fs.remove(backupDbPath)
+
+        Logger.info('[MigrationManager] Migrations successfully applied to the original database.')
+      } catch (error) {
+        Logger.error('[MigrationManager] Migration failed:', error)
+
+        this.sequelize.close()
+
+        // Step 3: If migration fails, save the failed original and restore the backup
+        const failedDbPath = path.join(this.configPath, 'absdatabase.failed.sqlite')
+        await fs.move(originalDbPath, failedDbPath, { overwrite: true })
+        await fs.move(backupDbPath, originalDbPath, { overwrite: true })
+
+        Logger.info('[MigrationManager] Restored the original database from the backup.')
+        Logger.info('[MigrationManager] Saved the failed database as absdatabase.failed.sqlite.')
+
+        process.exit(1)
+      }
+    } else {
+      Logger.info('[MigrationManager] No migrations to run.')
+    }
+  }
+
+  async init(serverVersion, umzugStorage = new SequelizeStorage({ sequelize: this.sequelize })) {
+    if (!(await fs.pathExists(this.configPath))) throw new Error(`Config path does not exist: ${this.configPath}`)
+
+    this.migrationsDir = path.join(this.configPath, 'migrations')
+
+    this.serverVersion = this.extractVersionFromTag(serverVersion)
+    if (!this.serverVersion) throw new Error(`Invalid server version: ${serverVersion}. Expected a version tag like v1.2.3.`)
+
+    await this.fetchVersionsFromDatabase()
+    if (!this.maxVersion || !this.databaseVersion) throw new Error('Failed to fetch versions from the database.')
+
+    if (semver.gt(this.serverVersion, this.maxVersion)) {
+      try {
+        await this.copyMigrationsToConfigDir()
+      } catch (error) {
+        throw new Error('Failed to copy migrations to the config directory.', error)
+      }
+
+      try {
+        await this.updateMaxVersion(serverVersion)
+      } catch (error) {
+        throw new Error('Failed to update max version in the database.', error)
+      }
+    }
+
+    // Step 4: Initialize the Umzug instance
+    if (!this.umzug) {
+      // This check is for dependency injection in tests
+      const cwd = this.migrationsDir
+
+      const parent = new Umzug({
+        migrations: {
+          glob: ['*.js', { cwd }]
+        },
+        context: this.sequelize.getQueryInterface(),
+        storage: umzugStorage,
+        logger: Logger.info
+      })
+
+      // Sort migrations by version
+      this.umzug = new Umzug({
+        ...parent.options,
+        migrations: async () =>
+          (await parent.migrations()).sort((a, b) => {
+            const versionA = this.extractVersionFromTag(a.name)
+            const versionB = this.extractVersionFromTag(b.name)
+            return semver.compare(versionA, versionB)
+          })
+      })
+    }
+  }
+
+  async fetchVersionsFromDatabase() {
+    const [result] = await this.sequelize.query("SELECT json_extract(value, '$.version') AS version, json_extract(value, '$.maxVersion') AS maxVersion FROM settings WHERE key = :key", {
+      replacements: { key: 'server-settings' },
+      type: Sequelize.QueryTypes.SELECT
+    })
+
+    if (result) {
+      try {
+        this.maxVersion = this.extractVersionFromTag(result.maxVersion) || '0.0.0'
+        this.databaseVersion = this.extractVersionFromTag(result.version)
+      } catch (error) {
+        Logger.error('[MigrationManager] Failed to parse server settings from the database.', error)
+      }
+    }
+  }
+
+  extractVersionFromTag(tag) {
+    if (!tag) return null
+    const versionMatch = tag.match(/^v?(\d+\.\d+\.\d+)/)
+    return versionMatch ? versionMatch[1] : null
+  }
+
+  async copyMigrationsToConfigDir() {
+    const migrationsSourceDir = path.join(__dirname, '..', 'migrations')
+
+    await fs.ensureDir(this.migrationsDir) // Ensure the target directory exists
+
+    const files = await fs.readdir(migrationsSourceDir)
+    await Promise.all(
+      files
+        .filter((file) => path.extname(file) === '.js')
+        .map(async (file) => {
+          const sourceFile = path.join(migrationsSourceDir, file)
+          const targetFile = path.join(this.migrationsDir, file)
+          await fs.copy(sourceFile, targetFile) // Asynchronously copy the files
+        })
+    )
+  }
+
+  findMigrationsToRun(migrations, executedMigrations, direction) {
+    const migrationsToRun = migrations
+      .filter((migration) => {
+        const migrationVersion = this.extractVersionFromTag(migration.name)
+        if (direction === 'up') {
+          return semver.gt(migrationVersion, this.databaseVersion) && semver.lte(migrationVersion, this.serverVersion) && !executedMigrations.includes(migration.name)
+        } else {
+          // A down migration should be run even if the associated up migration wasn't executed before
+          return semver.lte(migrationVersion, this.databaseVersion) && semver.gt(migrationVersion, this.serverVersion)
+        }
+      })
+      .map((migration) => migration.name)
+    if (direction === 'down') {
+      return migrationsToRun.reverse()
+    } else {
+      return migrationsToRun
+    }
+  }
+
+  async updateMaxVersion(serverVersion) {
+    await this.sequelize.query("UPDATE settings SET value = JSON_SET(value, '$.maxVersion', ?) WHERE key = 'server-settings'", {
+      replacements: [serverVersion],
+      type: Sequelize.QueryTypes.UPDATE
+    })
+    this.maxVersion = this.serverVersion
+  }
+}
+
+module.exports = MigrationManager

--- a/server/managers/MigrationManager.js
+++ b/server/managers/MigrationManager.js
@@ -9,6 +9,10 @@ const Logger = require('../Logger')
 class MigrationManager {
   static MIGRATIONS_META_TABLE = 'migrationsMeta'
 
+  /**
+   * @param {import('../Database').sequelize} sequelize
+   * @param {string} [configPath]
+   */
   constructor(sequelize, configPath = global.configPath) {
     if (!sequelize || !(sequelize instanceof Sequelize)) throw new Error('Sequelize instance is required for MigrationManager.')
     this.sequelize = sequelize
@@ -23,6 +27,11 @@ class MigrationManager {
     this.umzug = null
   }
 
+  /**
+   * Init version vars and copy migration files to config dir if necessary
+   *
+   * @param {string} serverVersion
+   */
   async init(serverVersion) {
     if (!(await fs.pathExists(this.configPath))) throw new Error(`Config path does not exist: ${this.configPath}`)
 
@@ -212,6 +221,13 @@ class MigrationManager {
     )
   }
 
+  /**
+   *
+   * @param {{ name: string }[]} migrations
+   * @param {string[]} executedMigrations - names of executed migrations
+   * @param {string} direction - 'up' or 'down'
+   * @returns {string[]} - names of migrations to run
+   */
   findMigrationsToRun(migrations, executedMigrations, direction) {
     const migrationsToRun = migrations
       .filter((migration) => {

--- a/server/managers/MigrationManager.js
+++ b/server/managers/MigrationManager.js
@@ -92,13 +92,13 @@ class MigrationManager {
       try {
         await this.copyMigrationsToConfigDir()
       } catch (error) {
-        throw new Error('Failed to copy migrations to the config directory.', error)
+        throw new Error('Failed to copy migrations to the config directory.', { cause: error })
       }
 
       try {
         await this.updateMaxVersion(serverVersion)
       } catch (error) {
-        throw new Error('Failed to update max version in the database.', error)
+        throw new Error('Failed to update max version in the database.', { cause: error })
       }
     }
 
@@ -155,6 +155,8 @@ class MigrationManager {
     const migrationsSourceDir = path.join(__dirname, '..', 'migrations')
 
     await fs.ensureDir(this.migrationsDir) // Ensure the target directory exists
+
+    if (!(await fs.pathExists(migrationsSourceDir))) return
 
     const files = await fs.readdir(migrationsSourceDir)
     await Promise.all(

--- a/server/migrations/changelog.md
+++ b/server/migrations/changelog.md
@@ -1,0 +1,7 @@
+# Migrations Changelog
+
+Please add a record of every database migration that you create to this file. This will help us keep track of changes to the database schema over time.
+
+| Server Version | Migration Script Name | Description |
+| -------------- | --------------------- | ----------- |
+|                |                       |             |

--- a/server/migrations/readme.md
+++ b/server/migrations/readme.md
@@ -1,0 +1,46 @@
+# Database Migrations
+
+This directory contains all the database migration scripts for the server.
+
+## What is a migration?
+
+A migration is a script that changes the structure of the database. This can include creating tables, adding columns, or modifying existing columns. A migration script consists of two parts: an "up" script that applies the changes to the database, and a "down" script that undoes the changes.
+
+## Guidelines for writing migrations
+
+When writing a migration, keep the following guidelines in mind:
+
+- You **_must_** name your migration script according to the following convention: `<server_version>-<migration_name>.js`. For example, `v2.14.0-create-users-table.js`.
+
+  - `server_version` should be the version of the server that the migration was created for (this should usually be the next server release).
+  - `migration_name` should be a short description of the changes that the migration makes.
+
+- The script should export two async functions: `up` and `down`. The `up` function should contain the script that applies the changes to the database, and the `down` function should contain the script that undoes the changes. The `up` and `down` functions should accept a single object parameter with a `context` property that contains a reference to a Sequelize [`QueryInterface`](https://sequelize.org/docs/v6/other-topics/query-interface/) object. A typical migration script might look like this:
+
+  ```javascript
+  async function up({context: queryInterface}) {
+    // Upwards migration script
+    ...
+  }
+
+  async function down({context: queryInterface}) {
+    // Downward migration script
+    ...
+  }
+
+  module.exports = {up, down}
+  ```
+
+- Always implement both the `up` and `down` functions.
+- The `up` and `down` functions should be idempotent (i.e., they should be safe to run multiple times).
+- It's your responsibility to make sure that the down migration undoes the changes made by the up migration.
+- Log detailed information on every step of the migration. Use `Logger.info()` and `Logger.error()`.
+- Test tour migrations thoroughly before committing them.
+  - write unit tests for your migrations (see `test/server/migrations` for an example)
+  - you can force a server version change by modifying the `version` field in `package.json` on your dev environment (but don't forget to revert it back before committing)
+
+## How migrations are run
+
+Migrations are run automatically when the server starts, when the server detects that the server version has changed. Migrations are always run server version order (from oldest to newest up migrations if the server version increased, and from newest to oldest down migrations if the server version decreased). Only the relevant migrations are run, based on the new and old server versions.
+
+This means that you can switch between server releases without having to worry about running migrations manually. The server will automatically apply the necessary migrations when it starts.

--- a/server/migrations/readme.md
+++ b/server/migrations/readme.md
@@ -15,16 +15,18 @@ When writing a migration, keep the following guidelines in mind:
   - `server_version` should be the version of the server that the migration was created for (this should usually be the next server release).
   - `migration_name` should be a short description of the changes that the migration makes.
 
-- The script should export two async functions: `up` and `down`. The `up` function should contain the script that applies the changes to the database, and the `down` function should contain the script that undoes the changes. The `up` and `down` functions should accept a single object parameter with a `context` property that contains a reference to a Sequelize [`QueryInterface`](https://sequelize.org/docs/v6/other-topics/query-interface/) object. A typical migration script might look like this:
+- The script should export two async functions: `up` and `down`. The `up` function should contain the script that applies the changes to the database, and the `down` function should contain the script that undoes the changes. The `up` and `down` functions should accept a single object parameter with a `context` property that contains a reference to a Sequelize [`QueryInterface`](https://sequelize.org/docs/v6/other-topics/query-interface/) object, and a [Logger](https://github.com/advplyr/audiobookshelf/blob/423a2129d10c6d8aaac9e8c75941fa6283889602/server/Logger.js#L4) object for logging. A typical migration script might look like this:
 
   ```javascript
-  async function up({context: queryInterface}) {
+  async function up({ context: { queryInterface, logger } }) {
     // Upwards migration script
+    logger.info('migrating ...');
     ...
   }
 
-  async function down({context: queryInterface}) {
+  async function down({ context: { queryInterface, logger } }) {
     // Downward migration script
+    logger.info('reverting ...');
     ...
   }
 
@@ -33,7 +35,8 @@ When writing a migration, keep the following guidelines in mind:
 
 - Always implement both the `up` and `down` functions.
 - The `up` and `down` functions should be idempotent (i.e., they should be safe to run multiple times).
-- It's your responsibility to make sure that the down migration undoes the changes made by the up migration.
+- Prefer using only `queryInterface` and `logger` parameters, the `sequelize` module, and node.js built-in modules in your migration scripts. You can require other modules, but be aware that they might not be available or change from they ones you tested with.
+- It's your responsibility to make sure that the down migration reverts the changes made by the up migration.
 - Log detailed information on every step of the migration. Use `Logger.info()` and `Logger.error()`.
 - Test tour migrations thoroughly before committing them.
   - write unit tests for your migrations (see `test/server/migrations` for an example)
@@ -41,6 +44,6 @@ When writing a migration, keep the following guidelines in mind:
 
 ## How migrations are run
 
-Migrations are run automatically when the server starts, when the server detects that the server version has changed. Migrations are always run server version order (from oldest to newest up migrations if the server version increased, and from newest to oldest down migrations if the server version decreased). Only the relevant migrations are run, based on the new and old server versions.
+Migrations are run automatically when the server starts, when the server detects that the server version has changed. Migrations are always run in server version order (from oldest to newest up migrations if the server version increased, and from newest to oldest down migrations if the server version decreased). Only the relevant migrations are run, based on the new and old server versions.
 
 This means that you can switch between server releases without having to worry about running migrations manually. The server will automatically apply the necessary migrations when it starts.

--- a/test/server/managers/MigrationManager.test.js
+++ b/test/server/managers/MigrationManager.test.js
@@ -1,0 +1,484 @@
+const { expect, config } = require('chai')
+const sinon = require('sinon')
+const { Sequelize } = require('sequelize')
+const fs = require('../../../server/libs/fsExtra')
+const Logger = require('../../../server/Logger')
+const MigrationManager = require('../../../server/managers/MigrationManager')
+const { Umzug, memoryStorage } = require('umzug')
+const path = require('path')
+
+describe('MigrationManager', () => {
+  let sequelizeStub
+  let umzugStub
+  let migrationManager
+  let loggerInfoStub
+  let loggerErrorStub
+  let fsCopyStub
+  let fsMoveStub
+  let fsRemoveStub
+  let fsEnsureDirStub
+  let fsPathExistsStub
+  let processExitStub
+  let configPath = 'path/to/config'
+
+  const serverVersion = '1.2.0'
+
+  beforeEach(() => {
+    sequelizeStub = sinon.createStubInstance(Sequelize)
+    umzugStub = {
+      migrations: sinon.stub(),
+      executed: sinon.stub(),
+      up: sinon.stub(),
+      down: sinon.stub()
+    }
+    sequelizeStub.getQueryInterface.returns({})
+    migrationManager = new MigrationManager(sequelizeStub, configPath)
+    migrationManager.fetchVersionsFromDatabase = sinon.stub().resolves()
+    migrationManager.copyMigrationsToConfigDir = sinon.stub().resolves()
+    migrationManager.updateMaxVersion = sinon.stub().resolves()
+    migrationManager.umzug = umzugStub
+    loggerInfoStub = sinon.stub(Logger, 'info')
+    loggerErrorStub = sinon.stub(Logger, 'error')
+    fsCopyStub = sinon.stub(fs, 'copy').resolves()
+    fsMoveStub = sinon.stub(fs, 'move').resolves()
+    fsRemoveStub = sinon.stub(fs, 'remove').resolves()
+    fsEnsureDirStub = sinon.stub(fs, 'ensureDir').resolves()
+    fsPathExistsStub = sinon.stub(fs, 'pathExists').resolves(true)
+    processExitStub = sinon.stub(process, 'exit')
+  })
+
+  afterEach(() => {
+    sinon.restore()
+  })
+
+  describe('runMigrations', () => {
+    it('should run up migrations successfully', async () => {
+      // Arrange
+      migrationManager.databaseVersion = '1.1.0'
+      migrationManager.maxVersion = '1.1.0'
+
+      umzugStub.migrations.resolves([{ name: 'v1.1.0-migration.js' }, { name: 'v1.1.1-migration.js' }, { name: 'v1.2.0-migration.js' }])
+      umzugStub.executed.resolves([{ name: 'v1.1.0-migration.js' }])
+
+      // Act
+      await migrationManager.runMigrations('1.2.0')
+
+      // Assert
+      expect(migrationManager.fetchVersionsFromDatabase.calledOnce).to.be.true
+      expect(migrationManager.copyMigrationsToConfigDir.calledOnce).to.be.true
+      expect(migrationManager.updateMaxVersion.calledOnce).to.be.true
+      expect(umzugStub.up.calledOnce).to.be.true
+      expect(umzugStub.up.calledWith({ migrations: ['v1.1.1-migration.js', 'v1.2.0-migration.js'] })).to.be.true
+      expect(fsCopyStub.calledOnce).to.be.true
+      expect(fsCopyStub.calledWith(path.join(configPath, 'absdatabase.sqlite'), path.join(configPath, 'absdatabase.backup.sqlite'))).to.be.true
+      expect(fsRemoveStub.calledOnce).to.be.true
+      expect(fsRemoveStub.calledWith(path.join(configPath, 'absdatabase.backup.sqlite'))).to.be.true
+      expect(loggerInfoStub.calledWith(sinon.match('Migrations successfully applied'))).to.be.true
+    })
+
+    it('should run down migrations successfully', async () => {
+      // Arrange
+      migrationManager.databaseVersion = '1.2.0'
+      migrationManager.maxVersion = '1.2.0'
+
+      umzugStub.migrations.resolves([{ name: 'v1.1.0-migration.js' }, { name: 'v1.1.1-migration.js' }, { name: 'v1.2.0-migration.js' }])
+      umzugStub.executed.resolves([{ name: 'v1.1.0-migration.js' }, { name: 'v1.1.1-migration.js' }, { name: 'v1.2.0-migration.js' }])
+
+      // Act
+      await migrationManager.runMigrations('1.1.0')
+
+      // Assert
+      expect(migrationManager.fetchVersionsFromDatabase.calledOnce).to.be.true
+      expect(migrationManager.copyMigrationsToConfigDir.called).to.be.false
+      expect(migrationManager.updateMaxVersion.called).to.be.false
+      expect(umzugStub.down.calledOnce).to.be.true
+      expect(umzugStub.down.calledWith({ migrations: ['v1.2.0-migration.js', 'v1.1.1-migration.js'] })).to.be.true
+      expect(fsCopyStub.calledOnce).to.be.true
+      expect(fsCopyStub.calledWith(path.join(configPath, 'absdatabase.sqlite'), path.join(configPath, 'absdatabase.backup.sqlite'))).to.be.true
+      expect(fsRemoveStub.calledOnce).to.be.true
+      expect(fsRemoveStub.calledWith(path.join(configPath, 'absdatabase.backup.sqlite'))).to.be.true
+      expect(loggerInfoStub.calledWith(sinon.match('Migrations successfully applied'))).to.be.true
+    })
+
+    it('should log that no migrations are needed if serverVersion equals databaseVersion', async () => {
+      // Arrange
+      migrationManager.serverVersion = '1.2.0'
+      migrationManager.databaseVersion = '1.2.0'
+      migrationManager.maxVersion = '1.2.0'
+
+      // Act
+      await migrationManager.runMigrations(serverVersion)
+
+      // Assert
+      expect(umzugStub.up.called).to.be.false
+      expect(loggerInfoStub.calledWith(sinon.match('Database is already up to date.'))).to.be.true
+    })
+
+    it('should handle migration failure and restore the original database', async () => {
+      // Arrange
+      migrationManager.serverVersion = '1.2.0'
+      migrationManager.databaseVersion = '1.1.0'
+      migrationManager.maxVersion = '1.1.0'
+
+      umzugStub.migrations.resolves([{ name: 'v1.2.0-migration.js' }])
+      umzugStub.executed.resolves([{ name: 'v1.1.0-migration.js' }])
+      umzugStub.up.rejects(new Error('Migration failed'))
+
+      const originalDbPath = path.join(configPath, 'absdatabase.sqlite')
+      const backupDbPath = path.join(configPath, 'absdatabase.backup.sqlite')
+
+      // Act
+      await migrationManager.runMigrations(serverVersion)
+
+      // Assert
+      expect(umzugStub.up.calledOnce).to.be.true
+      expect(loggerErrorStub.calledWith(sinon.match('Migration failed'))).to.be.true
+      expect(fsMoveStub.calledWith(originalDbPath, sinon.match('absdatabase.failed.sqlite'), { overwrite: true })).to.be.true
+      expect(fsMoveStub.calledWith(backupDbPath, originalDbPath, { overwrite: true })).to.be.true
+      expect(loggerInfoStub.calledWith(sinon.match('Restored the original database'))).to.be.true
+      expect(processExitStub.calledOnce).to.be.true
+    })
+  })
+
+  describe('init', () => {
+    it('should throw error if serverVersion is not provided', async () => {
+      // Act
+      try {
+        const result = await migrationManager.init()
+        expect.fail('Expected init to throw an error, but it did not.')
+      } catch (error) {
+        expect(error.message).to.equal('Invalid server version: undefined. Expected a version tag like v1.2.3.')
+      }
+    })
+
+    it('should initialize the MigrationManager', async () => {
+      // arrange
+      migrationManager.databaseVersion = '1.1.0'
+      migrationManager.maxVersion = '1.1.0'
+      migrationManager.umzug = null
+      migrationManager.configPath = __dirname
+
+      // Act
+      await migrationManager.init(serverVersion, memoryStorage())
+
+      // Assert
+      expect(migrationManager.serverVersion).to.equal('1.2.0')
+      expect(migrationManager.sequelize).to.equal(sequelizeStub)
+      expect(migrationManager.umzug).to.be.an.instanceOf(Umzug)
+      expect((await migrationManager.umzug.migrations()).map((m) => m.name)).to.deep.equal(['v1.0.0-migration.js', 'v1.1.0-migration.js', 'v1.2.0-migration.js', 'v1.10.0-migration.js'])
+    })
+  })
+
+  describe('fetchVersionsFromDatabase', () => {
+    it('should fetch versions from a real database', async () => {
+      // Arrange
+      const sequelize = new Sequelize({ dialect: 'sqlite', storage: ':memory:', logging: false })
+      const serverSettings = { version: 'v1.1.0', maxVersion: 'v1.1.0' }
+      // Create a settings table with a single row
+      await sequelize.query('CREATE TABLE settings (key TEXT, value JSON)')
+      await sequelize.query('INSERT INTO settings (key, value) VALUES (:key, :value)', { replacements: { key: 'server-settings', value: JSON.stringify(serverSettings) } })
+      const migrationManager = new MigrationManager(sequelize, configPath)
+
+      // Act
+      await migrationManager.fetchVersionsFromDatabase()
+
+      // Assert
+      expect(migrationManager.maxVersion).to.equal('1.1.0')
+      expect(migrationManager.databaseVersion).to.equal('1.1.0')
+    })
+
+    it('should set versions to null if no result is returned from the database', async () => {
+      // Arrange
+      const sequelize = new Sequelize({ dialect: 'sqlite', storage: ':memory:', logging: false })
+      await sequelize.query('CREATE TABLE settings (key TEXT, value JSON)')
+      const migrationManager = new MigrationManager(sequelize, configPath)
+
+      // Act
+      await migrationManager.fetchVersionsFromDatabase()
+
+      // Assert
+      expect(migrationManager.maxVersion).to.be.null
+      expect(migrationManager.databaseVersion).to.be.null
+    })
+
+    it('should return a default maxVersion if no maxVersion is set in the database', async () => {
+      // Arrange
+      const sequelize = new Sequelize({ dialect: 'sqlite', storage: ':memory:', logging: false })
+      const serverSettings = { version: 'v1.1.0' }
+      // Create a settings table with a single row
+      await sequelize.query('CREATE TABLE settings (key TEXT, value JSON)')
+      await sequelize.query('INSERT INTO settings (key, value) VALUES (:key, :value)', { replacements: { key: 'server-settings', value: JSON.stringify(serverSettings) } })
+      const migrationManager = new MigrationManager(sequelize, configPath)
+
+      // Act
+      await migrationManager.fetchVersionsFromDatabase()
+
+      // Assert
+      expect(migrationManager.maxVersion).to.equal('0.0.0')
+      expect(migrationManager.databaseVersion).to.equal('1.1.0')
+    })
+
+    it('should throw an error if the database query fails', async () => {
+      // Arrange
+      const sequelizeStub = sinon.createStubInstance(Sequelize)
+      sequelizeStub.query.rejects(new Error('Database query failed'))
+      const migrationManager = new MigrationManager(sequelizeStub, configPath)
+
+      // Act
+      try {
+        await migrationManager.fetchVersionsFromDatabase()
+        expect.fail('Expected fetchVersionsFromDatabase to throw an error, but it did not.')
+      } catch (error) {
+        // Assert
+        expect(error.message).to.equal('Database query failed')
+      }
+    })
+  })
+
+  describe('updateMaxVersion', () => {
+    it('should update the maxVersion in the database', async () => {
+      // Arrange
+      const sequelize = new Sequelize({ dialect: 'sqlite', storage: ':memory:', logging: false })
+      const serverSettings = { version: 'v1.1.0', maxVersion: 'v1.1.0' }
+      // Create a settings table with a single row
+      await sequelize.query('CREATE TABLE settings (key TEXT, value JSON)')
+      await sequelize.query('INSERT INTO settings (key, value) VALUES (:key, :value)', { replacements: { key: 'server-settings', value: JSON.stringify(serverSettings) } })
+      const migrationManager = new MigrationManager(sequelize, configPath)
+
+      // Act
+      await migrationManager.updateMaxVersion('v1.2.0')
+
+      // Assert
+      const [result] = await sequelize.query("SELECT json_extract(value, '$.maxVersion') AS maxVersion FROM settings WHERE key = :key", { replacements: { key: 'server-settings' }, type: Sequelize.QueryTypes.SELECT })
+      expect(result.maxVersion).to.equal('v1.2.0')
+    })
+  })
+
+  describe('extractVersionFromTag', () => {
+    it('should return null if tag is not provided', () => {
+      // Arrange
+      const migrationManager = new MigrationManager(sequelizeStub, configPath)
+
+      // Act
+      const result = migrationManager.extractVersionFromTag()
+
+      // Assert
+      expect(result).to.be.null
+    })
+
+    it('should return null if tag does not match the version format', () => {
+      // Arrange
+      const migrationManager = new MigrationManager(sequelizeStub, configPath)
+      const tag = 'invalid-tag'
+
+      // Act
+      const result = migrationManager.extractVersionFromTag(tag)
+
+      // Assert
+      expect(result).to.be.null
+    })
+
+    it('should extract the version from the tag', () => {
+      // Arrange
+      const migrationManager = new MigrationManager(sequelizeStub, configPath)
+      const tag = 'v1.2.3'
+
+      // Act
+      const result = migrationManager.extractVersionFromTag(tag)
+
+      // Assert
+      expect(result).to.equal('1.2.3')
+    })
+  })
+
+  describe('copyMigrationsToConfigDir', () => {
+    it('should copy migrations to the config directory', async () => {
+      // Arrange
+      const migrationManager = new MigrationManager(sequelizeStub, configPath)
+      migrationManager.migrationsDir = path.join(configPath, 'migrations')
+      const migrationsSourceDir = path.join(__dirname, '..', '..', '..', 'server', 'migrations')
+      const targetDir = migrationManager.migrationsDir
+      const files = ['migration1.js', 'migration2.js', 'readme.md']
+
+      const readdirStub = sinon.stub(fs, 'readdir').resolves(files)
+
+      // Act
+      await migrationManager.copyMigrationsToConfigDir()
+
+      // Assert
+      expect(fsEnsureDirStub.calledOnce).to.be.true
+      expect(fsEnsureDirStub.calledWith(targetDir)).to.be.true
+      expect(readdirStub.calledOnce).to.be.true
+      expect(readdirStub.calledWith(migrationsSourceDir)).to.be.true
+      expect(fsCopyStub.calledTwice).to.be.true
+      expect(fsCopyStub.calledWith(path.join(migrationsSourceDir, 'migration1.js'), path.join(targetDir, 'migration1.js'))).to.be.true
+      expect(fsCopyStub.calledWith(path.join(migrationsSourceDir, 'migration2.js'), path.join(targetDir, 'migration2.js'))).to.be.true
+    })
+
+    it('should throw an error if copying the migrations fails', async () => {
+      // Arrange
+      const migrationManager = new MigrationManager(sequelizeStub, configPath)
+      migrationManager.migrationsDir = path.join(configPath, 'migrations')
+      const migrationsSourceDir = path.join(__dirname, '..', '..', '..', 'server', 'migrations')
+      const targetDir = migrationManager.migrationsDir
+      const files = ['migration1.js', 'migration2.js', 'readme.md']
+
+      const readdirStub = sinon.stub(fs, 'readdir').resolves(files)
+      fsCopyStub.restore()
+      fsCopyStub = sinon.stub(fs, 'copy').rejects()
+
+      // Act
+      try {
+        // Act
+        await migrationManager.copyMigrationsToConfigDir()
+        expect.fail('Expected copyMigrationsToConfigDir to throw an error, but it did not.')
+      } catch (error) {}
+
+      // Assert
+      expect(fsEnsureDirStub.calledOnce).to.be.true
+      expect(fsEnsureDirStub.calledWith(targetDir)).to.be.true
+      expect(readdirStub.calledOnce).to.be.true
+      expect(readdirStub.calledWith(migrationsSourceDir)).to.be.true
+      expect(fsCopyStub.calledTwice).to.be.true
+      expect(fsCopyStub.calledWith(path.join(migrationsSourceDir, 'migration1.js'), path.join(targetDir, 'migration1.js'))).to.be.true
+      expect(fsCopyStub.calledWith(path.join(migrationsSourceDir, 'migration2.js'), path.join(targetDir, 'migration2.js'))).to.be.true
+    })
+  })
+
+  describe('findMigrationsToRun', () => {
+    it('should return migrations to run when direction is "up"', () => {
+      // Arrange
+      const migrations = [{ name: 'v1.0.0-migration.js' }, { name: 'v1.1.0-migration.js' }, { name: 'v1.2.0-migration.js' }, { name: 'v1.3.0-migration.js' }]
+      const executedMigrations = ['v1.0.0-migration.js']
+      migrationManager.databaseVersion = '1.0.0'
+      migrationManager.serverVersion = '1.2.0'
+      const direction = 'up'
+
+      // Act
+      const result = migrationManager.findMigrationsToRun(migrations, executedMigrations, direction)
+
+      // Assert
+      expect(result).to.deep.equal(['v1.1.0-migration.js', 'v1.2.0-migration.js'])
+    })
+
+    it('should return migrations to run when direction is "down"', () => {
+      // Arrange
+      const migrations = [{ name: 'v1.0.0-migration.js' }, { name: 'v1.1.0-migration.js' }, { name: 'v1.2.0-migration.js' }, { name: 'v1.3.0-migration.js' }]
+      const executedMigrations = ['v1.2.0-migration.js', 'v1.3.0-migration.js']
+      migrationManager.databaseVersion = '1.3.0'
+      migrationManager.serverVersion = '1.2.0'
+      const direction = 'down'
+
+      // Act
+      const result = migrationManager.findMigrationsToRun(migrations, executedMigrations, direction)
+
+      // Assert
+      expect(result).to.deep.equal(['v1.3.0-migration.js'])
+    })
+
+    it('should return empty array when no migrations to run up', () => {
+      // Arrange
+      const migrations = [{ name: 'v1.0.0-migration.js' }, { name: 'v1.1.0-migration.js' }, { name: 'v1.2.0-migration.js' }, { name: 'v1.3.0-migration.js' }]
+      const executedMigrations = ['v1.0.0-migration.js', 'v1.1.0-migration.js', 'v1.2.0-migration.js', 'v1.3.0-migration.js']
+      migrationManager.databaseVersion = '1.3.0'
+      migrationManager.serverVersion = '1.4.0'
+      const direction = 'up'
+
+      // Act
+      const result = migrationManager.findMigrationsToRun(migrations, executedMigrations, direction)
+
+      // Assert
+      expect(result).to.deep.equal([])
+    })
+
+    it('should return empty array when no migrations to run down', () => {
+      // Arrange
+      const migrations = [{ name: 'v1.0.0-migration.js' }, { name: 'v1.1.0-migration.js' }, { name: 'v1.2.0-migration.js' }, { name: 'v1.3.0-migration.js' }]
+      const executedMigrations = []
+      migrationManager.databaseVersion = '1.4.0'
+      migrationManager.serverVersion = '1.3.0'
+      const direction = 'down'
+
+      // Act
+      const result = migrationManager.findMigrationsToRun(migrations, executedMigrations, direction)
+
+      // Assert
+      expect(result).to.deep.equal([])
+    })
+
+    it('should return down migrations to run when direction is "down" and up migration was not executed', () => {
+      // Arrange
+      const migrations = [{ name: 'v1.0.0-migration.js' }, { name: 'v1.1.0-migration.js' }, { name: 'v1.2.0-migration.js' }, { name: 'v1.3.0-migration.js' }]
+      const executedMigrations = []
+      migrationManager.databaseVersion = '1.3.0'
+      migrationManager.serverVersion = '1.0.0'
+      const direction = 'down'
+
+      // Act
+      const result = migrationManager.findMigrationsToRun(migrations, executedMigrations, direction)
+
+      // Assert
+      expect(result).to.deep.equal(['v1.3.0-migration.js', 'v1.2.0-migration.js', 'v1.1.0-migration.js'])
+    })
+
+    it('should return empty array when direction is "down" and server version is higher than database version', () => {
+      // Arrange
+      const migrations = [{ name: 'v1.0.0-migration.js' }, { name: 'v1.1.0-migration.js' }, { name: 'v1.2.0-migration.js' }, { name: 'v1.3.0-migration.js' }]
+      const executedMigrations = ['v1.0.0-migration.js', 'v1.1.0-migration.js', 'v1.2.0-migration.js', 'v1.3.0-migration.js']
+      migrationManager.databaseVersion = '1.0.0'
+      migrationManager.serverVersion = '1.3.0'
+      const direction = 'down'
+
+      // Act
+      const result = migrationManager.findMigrationsToRun(migrations, executedMigrations, direction)
+
+      // Assert
+      expect(result).to.deep.equal([])
+    })
+
+    it('should return empty array when direction is "up" and server version is lower than database version', () => {
+      // Arrange
+      const migrations = [{ name: 'v1.0.0-migration.js' }, { name: 'v1.1.0-migration.js' }, { name: 'v1.2.0-migration.js' }, { name: 'v1.3.0-migration.js' }]
+      const executedMigrations = ['v1.0.0-migration.js', 'v1.1.0-migration.js', 'v1.2.0-migration.js', 'v1.3.0-migration.js']
+      migrationManager.databaseVersion = '1.3.0'
+      migrationManager.serverVersion = '1.0.0'
+      const direction = 'up'
+
+      // Act
+      const result = migrationManager.findMigrationsToRun(migrations, executedMigrations, direction)
+
+      // Assert
+      expect(result).to.deep.equal([])
+    })
+
+    it('should return up migrations to run when server version is between migrations', () => {
+      // Arrange
+      const migrations = [{ name: 'v1.0.0-migration.js' }, { name: 'v1.1.0-migration.js' }, { name: 'v1.2.0-migration.js' }, { name: 'v1.3.0-migration.js' }]
+      const executedMigrations = ['v1.0.0-migration.js', 'v1.1.0-migration.js']
+      migrationManager.databaseVersion = '1.1.0'
+      migrationManager.serverVersion = '1.2.3'
+      const direction = 'up'
+
+      // Act
+      const result = migrationManager.findMigrationsToRun(migrations, executedMigrations, direction)
+
+      // Assert
+      expect(result).to.deep.equal(['v1.2.0-migration.js'])
+    })
+
+    it('should return down migrations to run when server version is between migrations', () => {
+      // Arrange
+      const migrations = [{ name: 'v1.0.0-migration.js' }, { name: 'v1.1.0-migration.js' }, { name: 'v1.2.0-migration.js' }, { name: 'v1.3.0-migration.js' }]
+      const executedMigrations = ['v1.0.0-migration.js', 'v1.1.0-migration.js', 'v1.2.0-migration.js']
+      migrationManager.databaseVersion = '1.2.0'
+      migrationManager.serverVersion = '1.1.3'
+      const direction = 'down'
+
+      // Act
+      const result = migrationManager.findMigrationsToRun(migrations, executedMigrations, direction)
+
+      // Assert
+      expect(result).to.deep.equal(['v1.2.0-migration.js'])
+    })
+  })
+})

--- a/test/server/managers/migrations/v1.0.0-migration.js
+++ b/test/server/managers/migrations/v1.0.0-migration.js
@@ -1,0 +1,9 @@
+async function up() {
+  console.log('v1.0.0 up')
+}
+
+async function down() {
+  console.log('v1.0.0 down')
+}
+
+module.exports = { up, down }

--- a/test/server/managers/migrations/v1.1.0-migration.js
+++ b/test/server/managers/migrations/v1.1.0-migration.js
@@ -1,0 +1,9 @@
+async function up() {
+  console.log('v1.1.0 up')
+}
+
+async function down() {
+  console.log('v1.1.0 down')
+}
+
+module.exports = { up, down }

--- a/test/server/managers/migrations/v1.10.0-migration.js
+++ b/test/server/managers/migrations/v1.10.0-migration.js
@@ -1,0 +1,9 @@
+async function up() {
+  console.log('v1.10.0 up')
+}
+
+async function down() {
+  console.log('v1.10.0 down')
+}
+
+module.exports = { up, down }

--- a/test/server/managers/migrations/v1.2.0-migration.js
+++ b/test/server/managers/migrations/v1.2.0-migration.js
@@ -1,0 +1,9 @@
+async function up() {
+  console.log('v1.2.0 up')
+}
+
+async function down() {
+  console.log('v1.2.0 down')
+}
+
+module.exports = { up, down }

--- a/test/server/migrations/v0.0.1-migration_example.js
+++ b/test/server/migrations/v0.0.1-migration_example.js
@@ -1,0 +1,42 @@
+const { DataTypes } = require('sequelize')
+const Logger = require('../../../server/Logger')
+
+/**
+ * This is an example of an upward migration script.
+ *
+ * @param {import { QueryInterface } from "sequelize";} options.context.queryInterface - a suquelize QueryInterface object.
+ * @returns {Promise<void>} - A promise that resolves when the migration is complete.
+ */
+async function up({ context: queryInterface }) {
+  Logger.info('Running migration_example up...')
+  Logger.info('Creating example_table...')
+  await queryInterface.createTable('example_table', {
+    id: {
+      type: DataTypes.INTEGER,
+      primaryKey: true,
+      autoIncrement: true
+    },
+    name: {
+      type: DataTypes.STRING,
+      allowNull: false
+    }
+  })
+  Logger.info('example_table created.')
+  Logger.info('migration_example up complete.')
+}
+
+/**
+ * This is an example of a downward migration script.
+ *
+ * @param {import { QueryInterface } from "sequelize";} options.context.queryInterface - a suquelize QueryInterface object.
+ * @returns {Promise<void>} - A promise that resolves when the migration is complete.
+ */
+async function down({ context: queryInterface }) {
+  Logger.info('Running migration_example down...')
+  Logger.info('Dropping example_table...')
+  await queryInterface.dropTable('example_table')
+  Logger.info('example_table dropped.')
+  Logger.info('migration_example down complete.')
+}
+
+module.exports = { up, down }

--- a/test/server/migrations/v0.0.1-migration_example.js
+++ b/test/server/migrations/v0.0.1-migration_example.js
@@ -1,15 +1,15 @@
 const { DataTypes } = require('sequelize')
-const Logger = require('../../../server/Logger')
 
 /**
  * This is an example of an upward migration script.
  *
  * @param {import { QueryInterface } from "sequelize";} options.context.queryInterface - a suquelize QueryInterface object.
+ * @param {import { Logger } from "../../../server/Logger";} options.context.logger - a Logger object.
  * @returns {Promise<void>} - A promise that resolves when the migration is complete.
  */
-async function up({ context: queryInterface }) {
-  Logger.info('Running migration_example up...')
-  Logger.info('Creating example_table...')
+async function up({ context: { queryInterface, logger } }) {
+  logger.info('Running migration_example up...')
+  logger.info('Creating example_table...')
   await queryInterface.createTable('example_table', {
     id: {
       type: DataTypes.INTEGER,
@@ -21,22 +21,23 @@ async function up({ context: queryInterface }) {
       allowNull: false
     }
   })
-  Logger.info('example_table created.')
-  Logger.info('migration_example up complete.')
+  logger.info('example_table created.')
+  logger.info('migration_example up complete.')
 }
 
 /**
  * This is an example of a downward migration script.
  *
  * @param {import { QueryInterface } from "sequelize";} options.context.queryInterface - a suquelize QueryInterface object.
+ * @param {import { Logger } from "../../../server/Logger";} options.context.logger - a Logger object.
  * @returns {Promise<void>} - A promise that resolves when the migration is complete.
  */
-async function down({ context: queryInterface }) {
-  Logger.info('Running migration_example down...')
-  Logger.info('Dropping example_table...')
+async function down({ context: { queryInterface, logger } }) {
+  logger.info('Running migration_example down...')
+  logger.info('Dropping example_table...')
   await queryInterface.dropTable('example_table')
-  Logger.info('example_table dropped.')
-  Logger.info('migration_example down complete.')
+  logger.info('example_table dropped.')
+  logger.info('migration_example down complete.')
 }
 
 module.exports = { up, down }

--- a/test/server/migrations/v0.0.1-migration_example.js
+++ b/test/server/migrations/v0.0.1-migration_example.js
@@ -1,10 +1,18 @@
 const { DataTypes } = require('sequelize')
 
 /**
+ * @typedef MigrationContext
+ * @property {import('sequelize').QueryInterface} queryInterface - a suquelize QueryInterface object.
+ * @property {import('../Logger')} logger - a Logger object.
+ *
+ * @typedef MigrationOptions
+ * @property {MigrationContext} context - an object containing the migration context.
+ */
+
+/**
  * This is an example of an upward migration script.
  *
- * @param {import { QueryInterface } from "sequelize";} options.context.queryInterface - a suquelize QueryInterface object.
- * @param {import { Logger } from "../../../server/Logger";} options.context.logger - a Logger object.
+ * @param {MigrationOptions} options - an object containing the migration context.
  * @returns {Promise<void>} - A promise that resolves when the migration is complete.
  */
 async function up({ context: { queryInterface, logger } }) {
@@ -28,8 +36,7 @@ async function up({ context: { queryInterface, logger } }) {
 /**
  * This is an example of a downward migration script.
  *
- * @param {import { QueryInterface } from "sequelize";} options.context.queryInterface - a suquelize QueryInterface object.
- * @param {import { Logger } from "../../../server/Logger";} options.context.logger - a Logger object.
+ * @param {MigrationOptions} options - an object containing the migration context.
  * @returns {Promise<void>} - A promise that resolves when the migration is complete.
  */
 async function down({ context: { queryInterface, logger } }) {

--- a/test/server/migrations/v0.0.1-migration_example.test.js
+++ b/test/server/migrations/v0.0.1-migration_example.test.js
@@ -21,7 +21,7 @@ describe('migration_example', () => {
 
   describe('up', () => {
     it('should create example_table', async () => {
-      await up({ context: queryInterface })
+      await up({ context: { queryInterface, logger: Logger } })
 
       expect(loggerInfoStub.callCount).to.equal(4)
       expect(loggerInfoStub.getCall(0).calledWith(sinon.match('Running migration_example up...'))).to.be.true
@@ -39,8 +39,8 @@ describe('migration_example', () => {
 
   describe('down', () => {
     it('should drop example_table', async () => {
-      await up({ context: queryInterface })
-      await down({ context: queryInterface })
+      await up({ context: { queryInterface, logger: Logger } })
+      await down({ context: { queryInterface, logger: Logger } })
 
       expect(loggerInfoStub.callCount).to.equal(8)
       expect(loggerInfoStub.getCall(4).calledWith(sinon.match('Running migration_example down...'))).to.be.true

--- a/test/server/migrations/v0.0.1-migration_example.test.js
+++ b/test/server/migrations/v0.0.1-migration_example.test.js
@@ -1,0 +1,53 @@
+const { expect } = require('chai')
+const sinon = require('sinon')
+const { up, down } = require('./v0.0.1-migration_example')
+const { Sequelize } = require('sequelize')
+const Logger = require('../../../server/Logger')
+
+describe('migration_example', () => {
+  let sequelize
+  let queryInterface
+  let loggerInfoStub
+
+  beforeEach(() => {
+    sequelize = new Sequelize({ dialect: 'sqlite', storage: ':memory:', logging: false })
+    queryInterface = sequelize.getQueryInterface()
+    loggerInfoStub = sinon.stub(Logger, 'info')
+  })
+
+  afterEach(() => {
+    sinon.restore()
+  })
+
+  describe('up', () => {
+    it('should create example_table', async () => {
+      await up({ context: queryInterface })
+
+      expect(loggerInfoStub.callCount).to.equal(4)
+      expect(loggerInfoStub.getCall(0).calledWith(sinon.match('Running migration_example up...'))).to.be.true
+      expect(loggerInfoStub.getCall(1).calledWith(sinon.match('Creating example_table...'))).to.be.true
+      expect(loggerInfoStub.getCall(2).calledWith(sinon.match('example_table created.'))).to.be.true
+      expect(loggerInfoStub.getCall(3).calledWith(sinon.match('migration_example up complete.'))).to.be.true
+      expect(await queryInterface.showAllTables()).to.include('example_table')
+      const tableDescription = await queryInterface.describeTable('example_table')
+      expect(tableDescription).to.deep.equal({
+        id: { type: 'INTEGER', allowNull: true, defaultValue: undefined, primaryKey: true, unique: false },
+        name: { type: 'VARCHAR(255)', allowNull: false, defaultValue: undefined, primaryKey: false, unique: false }
+      })
+    })
+  })
+
+  describe('down', () => {
+    it('should drop example_table', async () => {
+      await up({ context: queryInterface })
+      await down({ context: queryInterface })
+
+      expect(loggerInfoStub.callCount).to.equal(8)
+      expect(loggerInfoStub.getCall(4).calledWith(sinon.match('Running migration_example down...'))).to.be.true
+      expect(loggerInfoStub.getCall(5).calledWith(sinon.match('Dropping example_table...'))).to.be.true
+      expect(loggerInfoStub.getCall(6).calledWith(sinon.match('example_table dropped.'))).to.be.true
+      expect(loggerInfoStub.getCall(7).calledWith(sinon.match('migration_example down complete.'))).to.be.true
+      expect(await queryInterface.showAllTables()).not.to.include('example_table')
+    })
+  })
+})


### PR DESCRIPTION
This adds migration management infrastructure, based on the design and discussion [here](https://github.com/mikiher/audiobookshelf/discussions/2). 

This is for initial review - please don't merge this yet. Currently missing:
- I have not e2e-tested this yet with actual migrations (it runs, but I only ran it with an empty migrations directetory)
- I have not modified backup yet to store and restore the migrations directory.

Other than that, I think this is pretty complete. 

Please review carefully - I tried to unit test everything thoroughly, but of course I might have missed stuff.

Also, please review the readme and changlog files in `server/migrations`