### PR TITLE
Convert webp images to jpeg during metadata embed

### DIFF
--- a/server/utils/ffmpegHelpers.js
+++ b/server/utils/ffmpegHelpers.js
@@ -299,6 +299,12 @@ async function addCoverAndMetadataToFile(audioFilePath, coverFilePath, metadataF
         '-metadata:s:v',
         'comment=Cover' // add comment metadata to cover image stream
       ])
+      const ext = Path.extname(coverFilePath).toLowerCase()
+      if (ext === '.webp') {
+        ffmpeg.outputOptions([
+          '-c:v mjpeg' // convert webp images to jpeg
+        ])
+      }
     } else {
       ffmpeg.outputOptions([
         '-map 0:v?' // retain video stream from input file if exists


### PR DESCRIPTION
This fixes #3379.

mp4 containers seem not to support webp images, so now they're converted to jpeg during metadata embedding.