### PR TITLE
Fix crash when quick match adds new series

### DIFF
--- a/server/scanner/Scanner.js
+++ b/server/scanner/Scanner.js
@@ -1,6 +1,7 @@
 const Logger = require('../Logger')
 const SocketAuthority = require('../SocketAuthority')
 const Database = require('../Database')
+const { getTitleIgnorePrefix } = require('../utils/index')
 
 // Utils
 const { findMatchingEpisodesInFeed, getPodcastFeed } = require('../utils/podcastUtils')
@@ -230,7 +231,7 @@ class Scanner {
           seriesItem = await Database.seriesModel.create({
             name: seriesMatchItem.series,
             nameIgnorePrefix: getTitleIgnorePrefix(seriesMatchItem.series),
-            libraryId
+            libraryId: libraryItem.libraryId
           })
           // Update filter data
           Database.addSeriesToFilterData(libraryItem.libraryId, seriesItem.name, seriesItem.id)


### PR DESCRIPTION
This fixes #3392

Fixes a couple of bugs recently introduced in [Scanner.js](https://github.com/advplyr/audiobookshelf/commit/db86bfd63d7011fdd1323d5a9c8325861f1b65b2#diff-9c1865dafeba111773e536abdf50e39124a52832acb8c5984c55ef05a2c7db4d).