### PR TITLE
Default deny explicit content to users

### DIFF
--- a/client/components/modals/AccountModal.vue
+++ b/client/components/modals/AccountModal.vue
@@ -351,7 +351,7 @@ export default {
         update: type === 'admin',
         delete: type === 'admin',
         upload: type === 'admin',
-        accessExplicitContent: true,
+        accessExplicitContent: type === 'admin',
         accessAllLibraries: true,
         accessAllTags: true,
         selectedTagsNotAccessible: false
@@ -386,7 +386,7 @@ export default {
             upload: false,
             accessAllLibraries: true,
             accessAllTags: true,
-            accessExplicitContent: true,
+            accessExplicitContent: false,
             selectedTagsNotAccessible: false
           },
           librariesAccessible: [],

--- a/server/models/User.js
+++ b/server/models/User.js
@@ -107,7 +107,7 @@ class User extends Model {
       upload: type === 'root' || type === 'admin',
       accessAllLibraries: true,
       accessAllTags: true,
-      accessExplicitContent: false,
+      accessExplicitContent: type === 'root' || type === 'admin',
       selectedTagsNotAccessible: false,
       librariesAccessible: [],
       itemTagsSelected: []

--- a/server/models/User.js
+++ b/server/models/User.js
@@ -107,7 +107,7 @@ class User extends Model {
       upload: type === 'root' || type === 'admin',
       accessAllLibraries: true,
       accessAllTags: true,
-      accessExplicitContent: true,
+      accessExplicitContent: false,
       selectedTagsNotAccessible: false,
       librariesAccessible: [],
       itemTagsSelected: []


### PR DESCRIPTION
[Documentation](https://www.audiobookshelf.org/guides/users/#creating-a-new-user) specifies that new users are created without access to explicit content by default. It looks like in the recent change to the new User model, this behavior was changed. 

Personally, I think defaulting to not allowing explicit content is a safer 'fail closed' kind of mentality. Admins can manually grant explicit content access directly in ABS or through Oauth grants etc