### PR TITLE
Handle library scan failure gracefully

### DIFF
--- a/server/scanner/LibraryScan.js
+++ b/server/scanner/LibraryScan.js
@@ -75,13 +75,14 @@ class LibraryScan {
     return date.format(new Date(), 'YYYY-MM-DD') + '_' + this.id + '.txt'
   }
   get scanResultsString() {
-    if (this.error) return this.error
     const strs = []
     if (this.resultsAdded) strs.push(`${this.resultsAdded} added`)
     if (this.resultsUpdated) strs.push(`${this.resultsUpdated} updated`)
     if (this.resultsMissing) strs.push(`${this.resultsMissing} missing`)
-    if (!strs.length) return `Everything was up to date (${elapsedPretty(this.elapsed / 1000)})`
-    return strs.join(', ') + ` (${elapsedPretty(this.elapsed / 1000)})`
+    const changesDetected = strs.length > 0 ? strs.join(', ') : 'No changes detected'
+    const timeElapsed = `(${elapsedPretty(this.elapsed / 1000)})`
+    const error = this.error ? `${this.error}. ` : ''
+    return `${error}${changesDetected} ${timeElapsed}`
   }
 
   toJSON() {


### PR DESCRIPTION
This is in partial response to #3406

Library scan is a complex process and can fail in unexpected ways.
This tries wrap it up with a try-catch block, do the sensible things on error, save the scan log, and not crash the server.

There are a couple of questions I still have regarding the code:
- In the following code:
  ```js
      if (canceled && !libraryScan.totalResults) {
        task.setFinished('Scan canceled')
        TaskManager.taskFinished(task)

        const emitData = libraryScan.getScanEmitData
        emitData.results = null
        return
      }
  ```
  what is the last part trying to achieve? it seems it has no effect. Also, the premature return prevents some cleanups from happening.
- In the following code:
  ```js
    if (libraryScan.totalResults) {
      libraryScan.saveLog()
    }
  ```
  Why do we check library.Scan.totalResults? don't we want to save the scan log anyway?