### PR TITLE
Add duration to local sessions on creation

### DIFF
--- a/server/managers/PlaybackSessionManager.js
+++ b/server/managers/PlaybackSessionManager.js
@@ -164,6 +164,7 @@ class PlaybackSessionManager {
       // New session from local
       session = new PlaybackSession(sessionJson)
       session.deviceInfo = deviceInfo
+      session.duration = libraryItem.media.duration
       Logger.debug(`[PlaybackSessionManager] Inserting new session for "${session.displayTitle}" (${session.id})`)
       await Database.createPlaybackSession(session)
     } else {

--- a/server/managers/PlaybackSessionManager.js
+++ b/server/managers/PlaybackSessionManager.js
@@ -164,7 +164,7 @@ class PlaybackSessionManager {
       // New session from local
       session = new PlaybackSession(sessionJson)
       session.deviceInfo = deviceInfo
-      session.duration = libraryItem.media.duration
+      session.setDuration(libraryItem, sessionJson.episodeId)
       Logger.debug(`[PlaybackSessionManager] Inserting new session for "${session.displayTitle}" (${session.id})`)
       await Database.createPlaybackSession(session)
     } else {

--- a/server/objects/PlaybackSession.js
+++ b/server/objects/PlaybackSession.js
@@ -219,11 +219,7 @@ class PlaybackSession {
     this.displayAuthor = libraryItem.media.getPlaybackAuthor()
     this.coverPath = libraryItem.media.coverPath
 
-    if (episodeId) {
-      this.duration = libraryItem.media.getEpisodeDuration(episodeId)
-    } else {
-      this.duration = libraryItem.media.duration
-    }
+    this.setDuration(libraryItem, episodeId)
 
     this.mediaPlayer = mediaPlayer
     this.deviceInfo = deviceInfo || new DeviceInfo()
@@ -237,6 +233,14 @@ class PlaybackSession {
     this.dayOfWeek = date.format(new Date(), 'dddd')
     this.startedAt = Date.now()
     this.updatedAt = Date.now()
+  }
+
+  setDuration(libraryItem, episodeId) {
+    if (episodeId) {
+      this.duration = libraryItem.media.getEpisodeDuration(episodeId)
+    } else {
+      this.duration = libraryItem.media.duration
+    }
   }
 
   addListeningTime(timeListened) {


### PR DESCRIPTION
If session is not sent in by the clients it defaults to 0. This uses `libraryItem.duration` when creating the session.

Duration seems like something that shouldn't have to be provided by the clients, and can safely be used from the data already present in the server. Additionally this is how it already works for the non-local sessions.

I could switch to only use it if either `!session.duration` or `session.duration !== null`, but I personally feel like there is no need to use anything other than `libraryItem` as the source of truth for this attribute in particular.