### PR TITLE
Improved handling of Authors and Series with names containing non-ASCII characters

### DIFF
--- a/server/models/Author.js
+++ b/server/models/Author.js
@@ -53,14 +53,26 @@ class Author extends Model {
    * @returns {Promise<Author>}
    */
   static async getByNameAndLibrary(authorName, libraryId) {
-    return this.findOne({
-      where: [
-        where(fn('lower', col('name')), authorName.toLowerCase()),
-        {
-          libraryId
+    const containsOnlyASCII = /^[\u0000-\u007f]*$/.test(authorName)
+
+    // SQLite does not support lower with non-Unicode chars
+    if (!containsOnlyASCII) {
+      return this.findOne({
+        where: {
+          name: authorName,
+          libraryId: libraryId
         }
-      ]
-    })
+      })
+    } else {
+      return this.findOne({
+        where: [
+          where(fn('lower', col('name')), authorName.toLowerCase()),
+          {
+            libraryId
+          }
+        ]
+      })
+    }
   }
 
   /**

--- a/server/models/Author.js
+++ b/server/models/Author.js
@@ -1,5 +1,6 @@
 const { DataTypes, Model, where, fn, col } = require('sequelize')
 const parseNameString = require('../utils/parsers/parseNameString')
+const { asciiOnlyToLowerCase } = require('../utils/index')
 
 class Author extends Model {
   constructor(values, options) {
@@ -53,26 +54,14 @@ class Author extends Model {
    * @returns {Promise<Author>}
    */
   static async getByNameAndLibrary(authorName, libraryId) {
-    const containsOnlyASCII = /^[\u0000-\u007f]*$/.test(authorName)
-
-    // SQLite does not support lower with non-Unicode chars
-    if (!containsOnlyASCII) {
-      return this.findOne({
-        where: {
-          name: authorName,
-          libraryId: libraryId
+    return this.findOne({
+      where: [
+        where(fn('lower', col('name')), asciiOnlyToLowerCase(authorName)),
+        {
+          libraryId
         }
-      })
-    } else {
-      return this.findOne({
-        where: [
-          where(fn('lower', col('name')), authorName.toLowerCase()),
-          {
-            libraryId
-          }
-        ]
-      })
-    }
+      ]
+    })
   }
 
   /**

--- a/server/models/Series.js
+++ b/server/models/Series.js
@@ -39,14 +39,26 @@ class Series extends Model {
    * @returns {Promise<Series>}
    */
   static async getByNameAndLibrary(seriesName, libraryId) {
-    return this.findOne({
-      where: [
-        where(fn('lower', col('name')), seriesName.toLowerCase()),
-        {
-          libraryId
+    const containsOnlyASCII = /^[\u0000-\u007f]*$/.test(authorName)
+
+    // SQLite does not support lower with non-Unicode chars
+    if (!containsOnlyASCII) {
+      return this.findOne({
+        where: {
+          name: seriesName,
+          libraryId: libraryId
         }
-      ]
-    })
+      })
+    } else {
+      return this.findOne({
+        where: [
+          where(fn('lower', col('name')), seriesName.toLowerCase()),
+          {
+            libraryId
+          }
+        ]
+      })
+    }
   }
 
   /**

--- a/server/models/Series.js
+++ b/server/models/Series.js
@@ -1,6 +1,7 @@
 const { DataTypes, Model, where, fn, col } = require('sequelize')
 
 const { getTitlePrefixAtEnd } = require('../utils/index')
+const { asciiOnlyToLowerCase } = require('../utils/index')
 
 class Series extends Model {
   constructor(values, options) {
@@ -39,26 +40,14 @@ class Series extends Model {
    * @returns {Promise<Series>}
    */
   static async getByNameAndLibrary(seriesName, libraryId) {
-    const containsOnlyASCII = /^[\u0000-\u007f]*$/.test(authorName)
-
-    // SQLite does not support lower with non-Unicode chars
-    if (!containsOnlyASCII) {
-      return this.findOne({
-        where: {
-          name: seriesName,
-          libraryId: libraryId
+    return this.findOne({
+      where: [
+        where(fn('lower', col('name')), asciiOnlyToLowerCase(seriesName)),
+        {
+          libraryId
         }
-      })
-    } else {
-      return this.findOne({
-        where: [
-          where(fn('lower', col('name')), seriesName.toLowerCase()),
-          {
-            libraryId
-          }
-        ]
-      })
-    }
+      ]
+    })
   }
 
   /**


### PR DESCRIPTION
This PR fixes: https://github.com/advplyr/audiobookshelf/issues/2541

In summary: SQLite does not support the `LOWER`/`UPPER` function (unless it is compiled to do so, which it usually is not).

When checking if a Series/Author is already in the DB, these functions are used. Any name containing a capital non-ASCII character would always test as false and thus a new entry in the DB was created every time.

This checks is the name contains a non-ASCII character. If it does, the `lower` function is not used and the issue is avoided.

Should we not use the `lower` function at all to avoid this issue?