### PR TITLE
Set intitial database version in migrationsMeta to 0.0.0

### DIFF
--- a/server/managers/MigrationManager.js
+++ b/server/managers/MigrationManager.js
@@ -42,6 +42,7 @@ class MigrationManager {
 
     await this.fetchVersionsFromDatabase()
     if (!this.maxVersion || !this.databaseVersion) throw new Error('Failed to fetch versions from the database.')
+    Logger.debug(`[MigrationManager] Database version: ${this.databaseVersion}, Max version: ${this.maxVersion}, Server version: ${this.serverVersion}`)
 
     if (semver.gt(this.serverVersion, this.maxVersion)) {
       try {
@@ -191,10 +192,11 @@ class MigrationManager {
           allowNull: false
         }
       })
-      await this.sequelize.query("INSERT INTO :migrationsMeta (key, value) VALUES ('version', :version), ('maxVersion', '0.0.0')", {
-        replacements: { version: this.serverVersion, migrationsMeta: MigrationManager.MIGRATIONS_META_TABLE },
+      await this.sequelize.query("INSERT INTO :migrationsMeta (key, value) VALUES ('version', '0.0.0'), ('maxVersion', '0.0.0')", {
+        replacements: { migrationsMeta: MigrationManager.MIGRATIONS_META_TABLE },
         type: Sequelize.QueryTypes.INSERT
       })
+      Logger.debug(`[MigrationManager] Created migrationsMeta table: "${MigrationManager.MIGRATIONS_META_TABLE}"`)
     }
   }
 
@@ -219,6 +221,7 @@ class MigrationManager {
           await fs.copy(sourceFile, targetFile) // Asynchronously copy the files
         })
     )
+    Logger.debug(`[MigrationManager] Copied migrations to the config directory: "${this.migrationsDir}"`)
   }
 
   /**

--- a/test/server/managers/MigrationManager.test.js
+++ b/test/server/managers/MigrationManager.test.js
@@ -208,7 +208,7 @@ describe('MigrationManager', () => {
         value: { type: 'VARCHAR(255)', allowNull: false, defaultValue: undefined, primaryKey: false, unique: false }
       })
       expect(migrationManager.maxVersion).to.equal('0.0.0')
-      expect(migrationManager.databaseVersion).to.equal(serverVersion)
+      expect(migrationManager.databaseVersion).to.equal('0.0.0')
     })
 
     it('should throw an error if the database query fails', async () => {


### PR DESCRIPTION
fixes #3415

The issue is that the migrations get copied because the initial maxVersion is 0.0.0 but the migrations don't run because the databaseVersion matches the serverVersion.

Setting the databaseVersion to 0.0.0 on create will have all the migrations be run.

I'm not sure if I'm missing anything here so would appreciate if you can take a look @mikiher 

I tested this by going back to a database state before the migrationsMeta and SequelizeMeta.

Create a migration file for v2.13.4 and update the package.json version to v2.13.5.

This now runs the migration file for v2.13.4