### PR TITLE
Fix MigrationManager initial run behavior

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   "pkg": {
     "assets": [
       "client/dist/**/*",
-      "node_modules/sqlite3/lib/binding/**/*.node"
+      "node_modules/sqlite3/lib/binding/**/*.node",
+      "server/migrations/*.js"
     ],
     "scripts": [
       "prod.js",

--- a/server/Database.js
+++ b/server/Database.js
@@ -171,9 +171,9 @@ class Database {
     }
 
     try {
-      const migrationManager = new MigrationManager(this.sequelize, global.ConfigPath)
+      const migrationManager = new MigrationManager(this.sequelize, this.isNew, global.ConfigPath)
       await migrationManager.init(packageJson.version)
-      if (!this.isNew) await migrationManager.runMigrations()
+      await migrationManager.runMigrations()
     } catch (error) {
       Logger.error(`[Database] Failed to run migrations`, error)
       throw new Error('Database migration failed')


### PR DESCRIPTION
This fixes #3415 more comprehensively.

- The initial value for databaseVersion is fixed
- The isNewDatabase logic was pushed inside MigrationManager, with new tests added
- Usage of MigrationManager becomes simpler (construct, init, runMigrations unconditionally)