### PR TITLE
added postcssOptions to remove npm warning

### DIFF
--- a/client/nuxt.config.js
+++ b/client/nuxt.config.js
@@ -129,10 +129,12 @@ module.exports = {
   // Build Configuration: https://go.nuxtjs.dev/config-build
   build: {
     postcss: {
-      plugins: {
-        tailwindcss: {},
-        autoprefixer: {},
-      },
+      postcssOptions: {
+        plugins: {
+          tailwindcss: {},
+          autoprefixer: {},
+        }
+      }
     }
   },
   watchers: {


### PR DESCRIPTION
npm run generate had a warning related to the different format that postcss expected

edited nuxt.config.js to fix it