### PR TITLE
Change PlaybackSession createFromOld to use upsert instead of create

### DIFF
--- a/server/Server.js
+++ b/server/Server.js
@@ -182,7 +182,7 @@ class Server {
      * @see https://nodejs.org/api/process.html#event-unhandledrejection
      */
     process.on('unhandledRejection', async (reason, promise) => {
-      await Logger.fatal(`[Server] Unhandled rejection: ${reason}, promise:`, util.format('%O', promise))
+      await Logger.fatal('[Server] Unhandled rejection:', reason, '\npromise:', util.format('%O', promise))
       process.exit(1)
     })
   }

--- a/server/models/PlaybackSession.js
+++ b/server/models/PlaybackSession.js
@@ -117,7 +117,7 @@ class PlaybackSession extends Model {
 
   static createFromOld(oldPlaybackSession) {
     const playbackSession = this.getFromOld(oldPlaybackSession)
-    return this.create(playbackSession, {
+    return this.upsert(playbackSession, {
       silent: true
     })
   }


### PR DESCRIPTION
This fixes #2662

While I'm not in the position to reproduce this (I don't own an iPhone), I'm pretty sure why the crash happens.

It is very likely due to duplicate /session/local requests (retries?) sent in rapid succession from the client and handled asynchronously on the server, causing a race condition. 

While Request A is awaiting
```js
let session = await Database.getPlaybackSession(sessionJson.id)
```
Request B is also making the same call.
both receive a null response, so each of them calls create() on the PlaybackSession model, and one of them succeeds while the other fails with UniqueConstraintError because it is trying to create a row with the same primary key.

The fix is simple - since the requests are likely identical, it is safe to use upsert instead of create, which will succeed for both A and B (this of course doesn't prevent the race condition - doing that would involve using transactions, which I think is an overkill in this case)