### PR TITLE
[Help needed] Misc. RSS Improvements

### DIFF
--- a/server/Server.js
+++ b/server/Server.js
@@ -280,6 +280,9 @@ class Server {
     router.get('/feed/:slug/cover*', (req, res) => {
       this.rssFeedManager.getFeedCover(req, res)
     })
+    router.get('/feed/:slug/item/:episodeId/image*', (req, res) => {
+      this.rssFeedManager.getFeedItemImage(req, res)
+    })
     router.get('/feed/:slug/item/:episodeId/*', (req, res) => {
       Logger.debug(`[Server] Requesting rss feed episode ${req.params.slug}/${req.params.episodeId}`)
       this.rssFeedManager.getFeedItem(req, res)

--- a/server/managers/RssFeedManager.js
+++ b/server/managers/RssFeedManager.js
@@ -202,6 +202,22 @@ class RssFeedManager {
     readStream.pipe(res)
   }
 
+  async getFeedItemImage(req, res) {
+    const feed = await this.findFeedBySlug(req.params.slug)
+    if (!feed) {
+      Logger.debug(`[RssFeedManager] Feed not found ${req.params.slug}`)
+      res.sendStatus(404)
+      return
+    }
+
+    if (!feed.coverPath) {
+      res.sendStatus(404)
+      return
+    }
+
+    // TODO: ???
+  }
+
   /**
    *
    * @param {string} userId

--- a/server/objects/FeedEpisode.js
+++ b/server/objects/FeedEpisode.js
@@ -1,7 +1,6 @@
 const Path = require('path')
 const uuidv4 = require('uuid').v4
 const date = require('../libs/dateAndTime')
-const { secondsToTimestamp } = require('../utils/index')
 
 class FeedEpisode {
   constructor(episode) {
@@ -23,6 +22,7 @@ class FeedEpisode {
     this.episodeId = null
     this.trackIndex = null
     this.fullPath = null
+    this.imageUrl = null
 
     if (episode) {
       this.construct(episode)
@@ -119,6 +119,7 @@ class FeedEpisode {
     const contentUrl = `/feed/${slug}/item/${episodeId}/media${contentFileExtension}`
     const media = libraryItem.media
     const mediaMetadata = media.metadata
+    const coverFileExtension = media.coverPath ? Path.extname(media.coverPath) : null
 
     let title = audioTrack.title
     if (libraryItem.media.tracks.length == 1) {
@@ -149,6 +150,8 @@ class FeedEpisode {
     this.episodeId = null
     this.trackIndex = audioTrack.index
     this.fullPath = audioTrack.metadata.path
+    // debugger
+    this.imageUrl = media.coverPath ? `${serverAddress}/feed/${slug}/item/${media.libraryItemId}/image${coverFileExtension}` : meta.imageUrl
   }
 
   getRSSData() {
@@ -167,7 +170,14 @@ class FeedEpisode {
         { 'itunes:explicit': !!this.explicit },
         { 'itunes:episodeType': this.episodeType },
         { 'itunes:season': this.season },
-        { 'itunes:episode': this.episode }
+        { 'itunes:episode': this.episode },
+        {
+          'itunes:image': {
+            _attr: {
+              href: this.imageUrl
+            }
+          }
+        },
       ]
     }
   }

--- a/server/objects/FeedEpisode.js
+++ b/server/objects/FeedEpisode.js
@@ -162,11 +162,9 @@ class FeedEpisode {
       enclosure: this.enclosure,
       custom_elements: [
         { 'itunes:author': this.author },
-        { 'itunes:duration': secondsToTimestamp(this.duration) },
+        { 'itunes:duration': Math.round(this.duration) },
         { 'itunes:summary': this.description || '' },
-        {
-          'itunes:explicit': !!this.explicit
-        },
+        { 'itunes:explicit': !!this.explicit },
         { 'itunes:episodeType': this.episodeType },
         { 'itunes:season': this.season },
         { 'itunes:episode': this.episode }


### PR DESCRIPTION
## What's new?

- Drops non-standard duration formatting for RSS feed items. Duration is now represented using full seconds
- [WIP] Adds an image for each item in a collection

It's that last one that I need help on. After tracing it out, I've realized that the `FeedEpisode` model doesn't have a `coverPath` attribute for displaying an image.

I could bypass that entirely and instead get the item's cover directly instead of going through `Feed` > `FeedEpisode`, but I'm not sure if that's something you'd be open to.

Please let me know if you have any tips!
