### PR TITLE
Nunicode integration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,9 +33,9 @@ ENV NUSQLITE3_PATH="${NUSQLITE3_DIR}/libnusqlite3.so"
 
 RUN case "$TARGETPLATFORM" in \
   "linux/amd64") \
-  curl -L -o /tmp/library.zip "https://github.com/mikiher/nunicode-sqlite/releases/download/v1.0/libnusqlite3-linux-x64.zip" ;; \
+  curl -L -o /tmp/library.zip "https://github.com/mikiher/nunicode-sqlite/releases/download/v1.1/libnusqlite3-linux-x64.zip" ;; \
   "linux/arm64") \
-  curl -L -o /tmp/library.zip "https://github.com/mikiher/nunicode-sqlite/releases/download/v1.0/libnusqlite3-linux-arm64.zip" ;; \
+  curl -L -o /tmp/library.zip "https://github.com/mikiher/nunicode-sqlite/releases/download/v1.1/libnusqlite3-linux-arm64.zip" ;; \
   *) echo "Unsupported platform: $TARGETPLATFORM" && exit 1 ;; \
   esac && \
   unzip /tmp/library.zip -d $NUSQLITE3_DIR && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,19 +11,35 @@ FROM node:20-alpine
 ENV NODE_ENV=production
 
 RUN apk update && \
-    apk add --no-cache --update \
-    curl \
-    tzdata \
-    ffmpeg \
-    make \
-    gcompat \
-    python3 \
-    g++ \
-    tini
+  apk add --no-cache --update \
+  curl \
+  tzdata \
+  ffmpeg \
+  make \
+  gcompat \
+  python3 \
+  g++ \
+  tini \
+  unzip
 
 COPY --from=build /client/dist /client/dist
 COPY index.js package* /
 COPY server server
+
+ARG TARGETPLATFORM
+
+ENV NUSQLITE3_DIR="/usr/local/lib/nusqlite3"
+ENV NUSQLITE3_PATH="${NUSQLITE3_DIR}/libnusqlite3.so"
+
+RUN case "$TARGETPLATFORM" in \
+  "linux/amd64") \
+  curl -L -o /tmp/library.zip "https://github.com/mikiher/nunicode-sqlite/releases/download/v1.0/libnusqlite3-linux-x64.zip" ;; \
+  "linux/arm64") \
+  curl -L -o /tmp/library.zip "https://github.com/mikiher/nunicode-sqlite/releases/download/v1.0/libnusqlite3-linux-arm64.zip" ;; \
+  *) echo "Unsupported platform: $TARGETPLATFORM" && exit 1 ;; \
+  esac && \
+  unzip /tmp/library.zip -d $NUSQLITE3_DIR && \
+  rm /tmp/library.zip
 
 RUN npm ci --only=production
 

--- a/client/components/stats/DailyListeningChart.vue
+++ b/client/components/stats/DailyListeningChart.vue
@@ -35,22 +35,22 @@
     <div class="flex justify-between pt-12">
       <div>
         <p class="text-sm text-center">{{ $strings.LabelStatsWeekListening }}</p>
-        <p class="text-5xl font-semibold text-center" style="line-height: 0.85">{{ totalMinutesListeningThisWeek }}</p>
+        <p class="text-5xl font-semibold text-center" style="line-height: 0.85">{{ $formatNumber(totalMinutesListeningThisWeek) }}</p>
         <p class="text-sm text-center">{{ $strings.LabelStatsMinutes }}</p>
       </div>
       <div>
         <p class="text-sm text-center">{{ $strings.LabelStatsDailyAverage }}</p>
-        <p class="text-5xl font-semibold text-center" style="line-height: 0.85">{{ averageMinutesPerDay }}</p>
+        <p class="text-5xl font-semibold text-center" style="line-height: 0.85">{{ $formatNumber(averageMinutesPerDay) }}</p>
         <p class="text-sm text-center">{{ $strings.LabelStatsMinutes }}</p>
       </div>
       <div>
         <p class="text-sm text-center">{{ $strings.LabelStatsBestDay }}</p>
-        <p class="text-5xl font-semibold text-center" style="line-height: 0.85">{{ mostListenedDay }}</p>
+        <p class="text-5xl font-semibold text-center" style="line-height: 0.85">{{ $formatNumber(mostListenedDay) }}</p>
         <p class="text-sm text-center">{{ $strings.LabelStatsMinutes }}</p>
       </div>
       <div>
         <p class="text-sm text-center">{{ $strings.LabelStatsDays }}</p>
-        <p class="text-5xl font-semibold text-center" style="line-height: 0.85">{{ daysInARow }}</p>
+        <p class="text-5xl font-semibold text-center" style="line-height: 0.85">{{ $formatNumber(daysInARow) }}</p>
         <p class="text-sm text-center">{{ $strings.LabelStatsInARow }}</p>
       </div>
     </div>

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ if (isDev) {
   if (devEnv.MetadataPath) process.env.METADATA_PATH = devEnv.MetadataPath
   if (devEnv.FFmpegPath) process.env.FFMPEG_PATH = devEnv.FFmpegPath
   if (devEnv.FFProbePath) process.env.FFPROBE_PATH = devEnv.FFProbePath
-  if (devEnv.NunicodePath) process.env.NUNICODE_PATH = devEnv.NunicodePath
+  if (devEnv.NunicodePath) process.env.NUSQLITE3_PATH = devEnv.NunicodePath
   if (devEnv.SkipBinariesCheck) process.env.SKIP_BINARIES_CHECK = '1'
   if (devEnv.BackupPath) process.env.BACKUP_PATH = devEnv.BackupPath
   process.env.SOURCE = 'local'

--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ if (isDev) {
   if (devEnv.MetadataPath) process.env.METADATA_PATH = devEnv.MetadataPath
   if (devEnv.FFmpegPath) process.env.FFMPEG_PATH = devEnv.FFmpegPath
   if (devEnv.FFProbePath) process.env.FFPROBE_PATH = devEnv.FFProbePath
+  if (devEnv.NunicodePath) process.env.NUNICODE_PATH = devEnv.NunicodePath
   if (devEnv.SkipBinariesCheck) process.env.SKIP_BINARIES_CHECK = '1'
   if (devEnv.BackupPath) process.env.BACKUP_PATH = devEnv.BackupPath
   process.env.SOURCE = 'local'

--- a/server/Database.js
+++ b/server/Database.js
@@ -786,7 +786,6 @@ class Database {
       const normalizedQueryResult = await this.sequelize.query(`SELECT ${normalizedQueryExpression} as normalized_query`)
       const normalizedQuery = normalizedQueryResult[0][0].normalized_query
       this.hasAccents = escapedQuery !== this.sequelize.escape(normalizedQuery)
-      Logger.debug(`[TextSearchQuery] hasAccents: ${this.hasAccents}`)
     }
 
     /**

--- a/server/controllers/LibraryItemController.js
+++ b/server/controllers/LibraryItemController.js
@@ -480,7 +480,7 @@ class LibraryItemController {
     const libraryId = itemsToDelete[0].libraryId
     for (const libraryItem of itemsToDelete) {
       const libraryItemPath = libraryItem.path
-      Logger.info(`[LibraryItemController] Deleting Library Item "${libraryItem.media.metadata.title}" with id "${libraryItem.id}"`)
+      Logger.info(`[LibraryItemController] (${hardDelete ? 'Hard' : 'Soft'}) deleting Library Item "${libraryItem.media.metadata.title}" with id "${libraryItem.id}"`)
       const mediaItemIds = libraryItem.mediaType === 'podcast' ? libraryItem.media.episodes.map((ep) => ep.id) : [libraryItem.media.id]
       await this.handleDeleteLibraryItem(libraryItem.mediaType, libraryItem.id, mediaItemIds)
       if (hardDelete) {

--- a/server/managers/BinaryManager.js
+++ b/server/managers/BinaryManager.js
@@ -324,7 +324,7 @@ class BinaryManager {
   defaultRequiredBinaries = [
     new Binary('ffmpeg', 'executable', 'FFMPEG_PATH', ['5.1'], ffbinaries), // ffmpeg executable
     new Binary('ffprobe', 'executable', 'FFPROBE_PATH', ['5.1'], ffbinaries), // ffprobe executable
-    new Binary('libnusqlite3', 'library', 'NUSQLITE3_PATH', ['1.0'], nunicode, false) // nunicode sqlite3 extension
+    new Binary('libnusqlite3', 'library', 'NUSQLITE3_PATH', ['1.1'], nunicode, false) // nunicode sqlite3 extension
   ]
 
   constructor(requiredBinaries = this.defaultRequiredBinaries) {

--- a/server/utils/queries/authorFilters.js
+++ b/server/utils/queries/authorFilters.js
@@ -54,13 +54,13 @@ module.exports = {
    * Search authors
    *
    * @param {string} libraryId
-   * @param {string} query
+   * @param {Database.TextQuery} query
    * @param {number} limit
    * @param {number} offset
    * @returns {Promise<Object[]>} oldAuthor with numBooks
    */
   async search(libraryId, query, limit, offset) {
-    const matchAuthor = Database.matchExpression('name', query)
+    const matchAuthor = query.matchExpression('name')
     const authors = await Database.authorModel.findAll({
       where: {
         [Sequelize.Op.and]: [Sequelize.literal(matchAuthor), { libraryId }]

--- a/server/utils/queries/libraryItemsBookFilters.js
+++ b/server/utils/queries/libraryItemsBookFilters.js
@@ -979,8 +979,6 @@ module.exports = {
 
     const matchTitle = textSearchQuery.matchExpression('title')
     const matchSubtitle = textSearchQuery.matchExpression('subtitle')
-    Logger.debug(`[libraryItemsBookFilters] matchTitle: ${matchTitle}`)
-    Logger.debug(`[libraryItemsBookFilters] matchSubtitle: ${matchSubtitle}`)
 
     // Search title, subtitle, asin, isbn
     const books = await Database.bookModel.findAll({

--- a/server/utils/queries/libraryItemsBookFilters.js
+++ b/server/utils/queries/libraryItemsBookFilters.js
@@ -975,10 +975,12 @@ module.exports = {
   async search(user, library, query, limit, offset) {
     const userPermissionBookWhere = this.getUserPermissionBookWhereQuery(user)
 
-    const normalizedQuery = query
+    const textSearchQuery = await Database.createTextSearchQuery(query)
 
-    const matchTitle = Database.matchExpression('title', normalizedQuery)
-    const matchSubtitle = Database.matchExpression('subtitle', normalizedQuery)
+    const matchTitle = textSearchQuery.matchExpression('title')
+    const matchSubtitle = textSearchQuery.matchExpression('subtitle')
+    Logger.debug(`[libraryItemsBookFilters] matchTitle: ${matchTitle}`)
+    Logger.debug(`[libraryItemsBookFilters] matchSubtitle: ${matchSubtitle}`)
 
     // Search title, subtitle, asin, isbn
     const books = await Database.bookModel.findAll({
@@ -1041,7 +1043,7 @@ module.exports = {
       })
     }
 
-    const matchJsonValue = Database.matchExpression('json_each.value', normalizedQuery)
+    const matchJsonValue = textSearchQuery.matchExpression('json_each.value')
 
     // Search narrators
     const narratorMatches = []
@@ -1095,7 +1097,7 @@ module.exports = {
     }
 
     // Search series
-    const matchName = Database.matchExpression('name', normalizedQuery)
+    const matchName = textSearchQuery.matchExpression('name')
     const allSeries = await Database.seriesModel.findAll({
       where: {
         [Sequelize.Op.and]: [
@@ -1136,7 +1138,7 @@ module.exports = {
     }
 
     // Search authors
-    const authorMatches = await authorFilters.search(library.id, normalizedQuery, limit, offset)
+    const authorMatches = await authorFilters.search(library.id, textSearchQuery, limit, offset)
 
     return {
       book: itemMatches,

--- a/server/utils/queries/libraryItemsPodcastFilters.js
+++ b/server/utils/queries/libraryItemsPodcastFilters.js
@@ -315,9 +315,10 @@ module.exports = {
   async search(user, library, query, limit, offset) {
     const userPermissionPodcastWhere = this.getUserPermissionPodcastWhereQuery(user)
 
-    const normalizedQuery = query
-    const matchTitle = Database.matchExpression('title', normalizedQuery)
-    const matchAuthor = Database.matchExpression('author', normalizedQuery)
+    const textSearchQuery = await Database.createTextSearchQuery(query)
+
+    const matchTitle = textSearchQuery.matchExpression('title')
+    const matchAuthor = textSearchQuery.matchExpression('author')
 
     // Search title, author, itunesId, itunesArtistId
     const podcasts = await Database.podcastModel.findAll({
@@ -366,7 +367,7 @@ module.exports = {
       })
     }
 
-    const matchJsonValue = Database.matchExpression('json_each.value', normalizedQuery)
+    const matchJsonValue = textSearchQuery.matchExpression('json_each.value')
 
     // Search tags
     const tagMatches = []


### PR DESCRIPTION
This is my second attempt at integrating an SQLite extension that provides unicode aware case-folding and unaccenting, which fixes #2678 properly.

After numerous attempts and discussions with @devnoname120, I settled on [Nunicode](https://bitbucket.org/alekseyt/nunicode/src/master/) SQLite extension, which, compared to the previous ([SQlean/unicode](https://github.com/nalgeon/sqlean/blob/main/docs/unicode.md)) extension I tried:
- Does not override the SQLite NOCASE collation (which lead to crashes with the previous extension, because indices were not properly re-indexed).
- Provides superior case-folding support which wasn't provided by the previous extension (e.g. `Maße` case-folded to `masse`)
- Supports unicode-aware unaccent(), upper() and lower() functions, and a unicode aware case-insensitive LIKE, like the previous extension
- Like the previous extension, Nunicode doesn't have any dependencies, and generates a very small library (~300Kb)

I set up a separate Github project [nunicode-binaries](https://github.com/mikiher/nunicode-binaries), which builds the extension from source and allows to download the binaries for all the platforms Audiobookshelf server supports (linux-x64, linux-arm64, win-x64, and osx-arm64). The build and release are implemented as Github workflows.

This PR has the following changes:
- BinaryManager now downloads the extension from nunicode-binaries (the download is done directly from the latest release page, not through the API, which has rate limitations).
- BinaryManager now also saves version info for downloaded libraries (and also checks it against the versions defined as valid)
- BinaryManager was also tightened against various failures.
- DockerFile was modified to download and install the extension from nunicode-binaries
- The extension is loaded at Database initialization
- The extension has been defined as _optional_ -  if it is not found or cannot be downloaded for any reason, the server will start without it.
  - This is done in order to deal with any unexpected failures during the initial rollout. After this runs in prod for a while, I'd like to make it required, so we don't have different search behaviours.
- Searches now use the following algorithm (slightly modified from the previous attempt)
  - If the search query does not contains accents, it is matched against an unaccented colum
    - `unaccent(column) LIKE '%query%'`
  - If the search query contains accents, it is matched against the original column 
    - `column LIKE '%qüery%'`
      - this provides a way to match without accent normalization.
  - All searches are unicode-aware case-insensitive, due to the re-implementation of the LIKE operator

The extension integration was tested on Windows, and on linux-x64 and linux-arm64 Docker (and passes our integration test).