### PR TITLE
Use musl-based libnusqlite3 in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,6 @@ RUN apk update && \
   tzdata \
   ffmpeg \
   make \
-  gcompat \
   python3 \
   g++ \
   tini \
@@ -33,9 +32,9 @@ ENV NUSQLITE3_PATH="${NUSQLITE3_DIR}/libnusqlite3.so"
 
 RUN case "$TARGETPLATFORM" in \
   "linux/amd64") \
-  curl -L -o /tmp/library.zip "https://github.com/mikiher/nunicode-sqlite/releases/download/v1.1/libnusqlite3-linux-x64.zip" ;; \
+  curl -L -o /tmp/library.zip "https://github.com/mikiher/nunicode-sqlite/releases/download/v1.2/libnusqlite3-linux-musl-x64.zip" ;; \
   "linux/arm64") \
-  curl -L -o /tmp/library.zip "https://github.com/mikiher/nunicode-sqlite/releases/download/v1.1/libnusqlite3-linux-arm64.zip" ;; \
+  curl -L -o /tmp/library.zip "https://github.com/mikiher/nunicode-sqlite/releases/download/v1.2/libnusqlite3-linux-musl-arm64.zip" ;; \
   *) echo "Unsupported platform: $TARGETPLATFORM" && exit 1 ;; \
   esac && \
   unzip /tmp/library.zip -d $NUSQLITE3_DIR && \

--- a/server/managers/BinaryManager.js
+++ b/server/managers/BinaryManager.js
@@ -324,7 +324,7 @@ class BinaryManager {
   defaultRequiredBinaries = [
     new Binary('ffmpeg', 'executable', 'FFMPEG_PATH', ['5.1'], ffbinaries), // ffmpeg executable
     new Binary('ffprobe', 'executable', 'FFPROBE_PATH', ['5.1'], ffbinaries), // ffprobe executable
-    new Binary('libnusqlite3', 'library', 'NUSQLITE3_PATH', ['1.1'], nunicode, false) // nunicode sqlite3 extension
+    new Binary('libnusqlite3', 'library', 'NUSQLITE3_PATH', ['1.2'], nunicode, false) // nunicode sqlite3 extension
   ]
 
   constructor(requiredBinaries = this.defaultRequiredBinaries) {


### PR DESCRIPTION
Following @devnoname120's advice, I am switching to a musl-based nunicode sqlite extension on Docker, and doing away with installing and relying on gcompat (which is no longer needed). The new musl-based binaries are obtained from the new v1.2 version of nunicode-binaries.

Other nunicode binaries remain unchanged, but I switched to v1.2 in BinaryManager as well, to keep the versions consistent.

Note: BinaryManager doesn't check the exact linux version and always installs the standard glibc-based version. This means that running if you run on a non-Docker Alpine (probably as a developer), you will have to install gcomapt manually for the program to load. I think this is OK, but let me know if you want me to add a special use-case for Alpine in BinaryManager.

I tested on Docker on both architectures.