### PR TITLE
retire unicode handling workaround for Author and Series title

### DIFF
--- a/server/controllers/LibraryController.js
+++ b/server/controllers/LibraryController.js
@@ -9,7 +9,6 @@ const libraryItemsBookFilters = require('../utils/queries/libraryItemsBookFilter
 const libraryItemFilters = require('../utils/queries/libraryItemFilters')
 const seriesFilters = require('../utils/queries/seriesFilters')
 const fileUtils = require('../utils/fileUtils')
-const { asciiOnlyToLowerCase } = require('../utils/index')
 const { createNewSortInstance } = require('../libs/fastSort')
 const naturalSort = createNewSortInstance({
   comparer: new Intl.Collator(undefined, { numeric: true, sensitivity: 'base' }).compare
@@ -809,7 +808,7 @@ class LibraryController {
     }
 
     const limit = req.query.limit || 12
-    const query = asciiOnlyToLowerCase(req.query.q.trim())
+    const query = req.query.q.trim()
 
     const matches = await libraryItemFilters.search(req.user, req.library, query, limit)
     res.json(matches)

--- a/server/models/Author.js
+++ b/server/models/Author.js
@@ -1,6 +1,5 @@
 const { DataTypes, Model, where, fn, col } = require('sequelize')
 const parseNameString = require('../utils/parsers/parseNameString')
-const { asciiOnlyToLowerCase } = require('../utils/index')
 
 class Author extends Model {
   constructor(values, options) {
@@ -56,7 +55,7 @@ class Author extends Model {
   static async getByNameAndLibrary(authorName, libraryId) {
     return this.findOne({
       where: [
-        where(fn('lower', col('name')), asciiOnlyToLowerCase(authorName)),
+        where(fn('lower', col('name')), authorName.toLowerCase()),
         {
           libraryId
         }

--- a/server/models/Series.js
+++ b/server/models/Series.js
@@ -1,7 +1,6 @@
 const { DataTypes, Model, where, fn, col } = require('sequelize')
 
 const { getTitlePrefixAtEnd } = require('../utils/index')
-const { asciiOnlyToLowerCase } = require('../utils/index')
 
 class Series extends Model {
   constructor(values, options) {
@@ -42,7 +41,7 @@ class Series extends Model {
   static async getByNameAndLibrary(seriesName, libraryId) {
     return this.findOne({
       where: [
-        where(fn('lower', col('name')), asciiOnlyToLowerCase(seriesName)),
+        where(fn('lower', col('name')), seriesName.toLowerCase()),
         {
           libraryId
         }

--- a/server/utils/index.js
+++ b/server/utils/index.js
@@ -195,29 +195,6 @@ module.exports.getTitlePrefixAtEnd = (title) => {
 }
 
 /**
- * to lower case for only ascii characters
- * used to handle sqlite that doesnt support unicode lower
- * @see https://github.com/advplyr/audiobookshelf/issues/2187
- *
- * @param {string} str
- * @returns {string}
- */
-module.exports.asciiOnlyToLowerCase = (str) => {
-  if (!str) return ''
-
-  let temp = ''
-  for (let chars of str) {
-    let value = chars.charCodeAt()
-    if (value >= 65 && value <= 90) {
-      temp += String.fromCharCode(value + 32)
-    } else {
-      temp += chars
-    }
-  }
-  return temp
-}
-
-/**
  * Escape string used in RegExp
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#escaping
  *


### PR DESCRIPTION
PR https://github.com/advplyr/audiobookshelf/pull/3414 introduced a temporary fix for issue https://github.com/advplyr/audiobookshelf/issues/2541.

Due to https://github.com/advplyr/audiobookshelf/pull/3468 the woraround became absolete and now causes the issue it fixed.

This PR retires the changes introduced in the temporary fix.