### PR TITLE
Use object-cover for author images unless AR is really high or low

### DIFF
--- a/client/components/covers/AuthorImage.vue
+++ b/client/components/covers/AuthorImage.vue
@@ -65,10 +65,6 @@ export default {
   },
   methods: {
     imageLoaded() {
-      var aspectRatio = 1.25
-      if (this.$refs.wrapper) {
-        aspectRatio = this.$refs.wrapper.clientHeight / this.$refs.wrapper.clientWidth
-      }
       if (this.$refs.img) {
         var { naturalWidth, naturalHeight } = this.$refs.img
         var imgAr = naturalHeight / naturalWidth

--- a/client/components/covers/AuthorImage.vue
+++ b/client/components/covers/AuthorImage.vue
@@ -72,8 +72,7 @@ export default {
       if (this.$refs.img) {
         var { naturalWidth, naturalHeight } = this.$refs.img
         var imgAr = naturalHeight / naturalWidth
-        var arDiff = Math.abs(imgAr - aspectRatio)
-        if (arDiff > 0.15) {
+        if (imgAr < 0.5 || imgAr > 2) {
           this.showCoverBg = true
         } else {
           this.showCoverBg = false


### PR DESCRIPTION
While working on lazy loading the Author's page, I felt that we're using object-contain on author images too much - while this works nicely for covers, I feel (subjecively) that the author images look unpolished when we use object-contain. So I modified the current decision algorithm for using object-contain to only use it when the AR is very high or low.

Here's my author page before:
![Screenshot 2024-10-09 150942](https://github.com/user-attachments/assets/ea1e5a78-2673-473f-82ca-38e9e1051541)

And after:
<img width="1733" alt="Screenshot 2024-10-09 151103" src="https://github.com/user-attachments/assets/d68a1f54-8586-419b-bcfe-77415109c762">

Some of the more significant changed are marked on the After screenshot.

I guess it's really subjective, but I find that I like the After much more, even though in some cases (e.g. John Scalzi), it results in a slightly cut image - but I think in those cases the original looks quite bad as well. 

I guess I should also work on allowing users to upload their own author image...