### PR TITLE
Fix next/previous chapter behavior on public share player

### DIFF
--- a/client/pages/share/_slug.vue
+++ b/client/pages/share/_slug.vue
@@ -10,7 +10,7 @@
         <p v-if="mediaItemShare.playbackSession.displayAuthor" class="text-lg lg:text-xl text-slate-400 font-semibold text-center mb-1 truncate">{{ mediaItemShare.playbackSession.displayAuthor }}</p>
 
         <div class="w-full pt-16">
-          <player-ui ref="audioPlayer" :chapters="chapters" :paused="isPaused" :loading="!hasLoaded" :is-podcast="false" hide-bookmarks hide-sleep-timer @playPause="playPause" @jumpForward="jumpForward" @jumpBackward="jumpBackward" @setVolume="setVolume" @setPlaybackRate="setPlaybackRate" @seek="seek" />
+          <player-ui ref="audioPlayer" :chapters="chapters" :current-chapter="currentChapter" :paused="isPaused" :loading="!hasLoaded" :is-podcast="false" hide-bookmarks hide-sleep-timer @playPause="playPause" @jumpForward="jumpForward" @jumpBackward="jumpBackward" @setVolume="setVolume" @setPlaybackRate="setPlaybackRate" @seek="seek" />
         </div>
       </div>
     </div>
@@ -51,7 +51,8 @@ export default {
       windowHeight: 0,
       listeningTimeSinceSync: 0,
       coverRgb: null,
-      coverBgIsLight: false
+      coverBgIsLight: false,
+      currentTime: 0
     }
   },
   computed: {
@@ -82,6 +83,9 @@ export default {
     },
     chapters() {
       return this.playbackSession.chapters || []
+    },
+    currentChapter() {
+      return this.chapters.find((chapter) => chapter.start <= this.currentTime && this.currentTime < chapter.end)
     },
     coverAspectRatio() {
       const coverAspectRatio = this.playbackSession.coverAspectRatio
@@ -154,6 +158,7 @@ export default {
 
       // Update UI
       this.$refs.audioPlayer.setCurrentTime(time)
+      this.currentTime = time
     },
     setDuration() {
       if (!this.localAudioPlayer) return


### PR DESCRIPTION
The `Next/Prev Chapter` player buttons on the new public share page were not functioning correctly.
This fixes this issue (there's no open bug report, I think).