### PR TITLE
chore(docs): add client_max_body_size parameter in nginx config

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -114,6 +114,11 @@ server
 
                      proxy_pass                          http://<URL_to_forward_to>;
                      proxy_redirect                      http:// https://;
+
+                     # Prevent 413 Request Entity Too Large error 
+                     # by increasing the maximum allowed size of the client request body
+                     # For example, set it to 10 GiB
+                     client_max_body_size                10240M;
                    }
 }
 ```

--- a/readme.md
+++ b/readme.md
@@ -92,34 +92,33 @@ Toggle websockets support.
 Add this to the site config file on your nginx server after you have changed the relevant parts in the <> brackets, and inserted your certificate paths.
 
 ```bash
-server
-{
-        listen 443 ssl;
-        server_name <sub>.<domain>.<tld>;
+server {
+   listen 443 ssl;
+   server_name <sub>.<domain>.<tld>;
 
-        access_log /var/log/nginx/audiobookshelf.access.log;
-        error_log /var/log/nginx/audiobookshelf.error.log;
+   access_log /var/log/nginx/audiobookshelf.access.log;
+   error_log /var/log/nginx/audiobookshelf.error.log;
 
-        ssl_certificate      /path/to/certificate;
-        ssl_certificate_key  /path/to/key;
+   ssl_certificate      /path/to/certificate;
+   ssl_certificate_key  /path/to/key;
 
-        location / {
-                     proxy_set_header X-Forwarded-For    $proxy_add_x_forwarded_for;
-                     proxy_set_header  X-Forwarded-Proto $scheme;
-                     proxy_set_header  Host              $host;
-                     proxy_set_header Upgrade            $http_upgrade;
-                     proxy_set_header Connection         "upgrade";
+   location / {
+      proxy_set_header X-Forwarded-For    $proxy_add_x_forwarded_for;
+      proxy_set_header  X-Forwarded-Proto $scheme;
+      proxy_set_header  Host              $host;
+      proxy_set_header Upgrade            $http_upgrade;
+      proxy_set_header Connection         "upgrade";
 
-                     proxy_http_version                  1.1;
+      proxy_http_version                  1.1;
 
-                     proxy_pass                          http://<URL_to_forward_to>;
-                     proxy_redirect                      http:// https://;
+      proxy_pass                          http://<URL_to_forward_to>;
+      proxy_redirect                      http:// https://;
 
-                     # Prevent 413 Request Entity Too Large error 
-                     # by increasing the maximum allowed size of the client request body
-                     # For example, set it to 10 GiB
-                     client_max_body_size                10240M;
-                   }
+      # Prevent 413 Request Entity Too Large error 
+      # by increasing the maximum allowed size of the client request body
+      # For example, set it to 10 GiB
+      client_max_body_size                10240M;
+   }
 }
 ```
 


### PR DESCRIPTION
Added additional parameter in the example nginx configuration that prevents 413 Request Entity Too Large error (https://github.com/advplyr/audiobookshelf/issues/825#issuecomment-1211867159)

Additionally, I changed the indentation of the config

