### PR TITLE
Add podcastId index to podcastEpisodes

### DIFF
--- a/server/models/PodcastEpisode.js
+++ b/server/models/PodcastEpisode.js
@@ -157,7 +157,7 @@ class PodcastEpisode extends Model {
         modelName: 'podcastEpisode',
         indexes: [
           {
-            fields: ['createdAt']
+            fields: ['createdAt','podcastId']
           }
         ]
       }


### PR DESCRIPTION
I have roughly 40k podcast episodes on around 200 podcasts, and performance was becoming an issue.  I noticed the only index on `podcastEpisodes` was `createdAt`.  Since joins are frequently done between `podcasts` and `podcastEpisodes` this will slow things down quite a bit without an index.  There is a foreign key constraint, but AFAIK sqlite3 does not create an index for FKs automatically.

This change adds an index on `podcastEpisodes.podcastId`.  It improves performance (loading time) for me on the `/library/......`, `/library/.../bookshelf`, and `/library/...../podcast/latest` webpages

I am not a JS dev.  I looked through the migration code, and it seems like the addition of an index should migrate, but I am unsure.  

Feel free to ask questions, or I'm on discord too (mggw)