### PR TITLE
Fix "Extract Cover Error" for files with multiple embedded covers

### DIFF
--- a/server/utils/ffmpegHelpers.js
+++ b/server/utils/ffmpegHelpers.js
@@ -55,7 +55,7 @@ async function extractCoverArt(filepath, outputpath) {
   return new Promise((resolve) => {
     /** @type {import('../libs/fluentFfmpeg/index').FfmpegCommand} */
     var ffmpeg = Ffmpeg(filepath)
-    ffmpeg.addOption(['-map 0:v', '-frames:v 1'])
+    ffmpeg.addOption(['-map 0:v:0', '-frames:v 1'])
     ffmpeg.output(outputpath)
 
     ffmpeg.on('start', (cmd) => {


### PR DESCRIPTION
I've encountered the same issue as in https://github.com/advplyr/audiobookshelf/issues/2316 for files with multiple embedded covers (ex. Front and Back covers for disks)

```
2024-10-17 00:02:33.221455-07:00[2024-10-17 00:02:33.221] ERROR: [FfmpegHelpers] Extract Cover Error Error: ffmpeg exited with code 234: frame=    1 fps=0.0 q=11.2 Lq=6.8 size=N/A time=00:00:00.00 bitrate=N/A speed=   0x    
2024-10-17 00:02:33.221494-07:00Conversion failed!
```

The issue comes from the input video stream selection which is not limited to a single video stream for ffmpeg, leading to the following error:
```
[image2 @ 000001c697da0440] The specified filename 'out.jpg' does not contain an image sequence pattern or a pattern is invalid.
[image2 @ 000001c697da0440] Use a pattern such as %03d for an image sequence or use the -update option (with -frames:v 1 if needed) to write a single image.
[image2 @ 000001c697da0440] Cannot write more than one file with the same name. Are you missing the -update option or a sequence pattern?
```

The proposed change limits the input selection to a single video stream, fixing the error.  (Good explanation here https://stackoverflow.com/a/63928441)
