### PR TITLE
Add server proxies for all server paths

### DIFF
--- a/client/nuxt.config.js
+++ b/client/nuxt.config.js
@@ -2,6 +2,8 @@ const pkg = require('./package.json')
 
 const routerBasePath = process.env.ROUTER_BASE_PATH || ''
 const serverHostUrl = process.env.NODE_ENV === 'production' ? '' : 'http://localhost:3333'
+const serverPaths = ['api/', 'public/', 'hls/', 'auth/', 'feed/', 'status', 'login', 'logout', 'init']
+const proxy = Object.fromEntries(serverPaths.map((path) => [`${routerBasePath}/${path}`, { target: process.env.NODE_ENV !== 'production' ? serverHostUrl : '/' }]))
 
 module.exports = {
   // Disable server-side rendering: https://go.nuxtjs.dev/ssr-mode
@@ -55,12 +57,7 @@ module.exports = {
   // Modules: https://go.nuxtjs.dev/config-modules
   modules: ['nuxt-socket-io', '@nuxtjs/axios', '@nuxtjs/proxy'],
 
-  proxy: {
-    [`${routerBasePath}/api/`]: { target: process.env.NODE_ENV !== 'production' ? serverHostUrl : '/' },
-    [`${routerBasePath}/public/`]: { target: process.env.NODE_ENV !== 'production' ? serverHostUrl : '/' },
-    [`${routerBasePath}/hls/`]: { target: process.env.NODE_ENV !== 'production' ? serverHostUrl : '/' },
-    [`${routerBasePath}/dev/`]: { target: process.env.NODE_ENV !== 'production' ? serverHostUrl : '/', pathRewrite: { '^/dev/': '' } }
-  },
+  proxy,
 
   io: {
     sockets: [

--- a/client/plugins/axios.js
+++ b/client/plugins/axios.js
@@ -14,7 +14,6 @@ export default function ({ $axios, store, $config }) {
 
     if (process.env.NODE_ENV === 'development') {
       console.log('Making request to ' + config.url)
-      config.url = `/dev${config.url}`
     }
   })
 


### PR DESCRIPTION
Your recent [Add in /dev proxy for development](https://github.com/advplyr/audiobookshelf/commit/9d1f51c6ba0201f42e72f56a3b25e539a19a8c66) is incomplete since it doesn't take care of all url references. Since the `/dev' prefix is added only for axios calls, it doesn't cover references to the server that are not through axios calls.

For this to work properly without having to modify individual references in the client code, we need to proxy all routes that need to go to the server. 

Unfortunately there's no top-level namespace (like `/server`) that identifies server paths from client paths, so we just need to specify all server paths that are referenced by the client individually.

This is what's implemented in this PR. 
- `/login`, `/logout`, `/status`, and `/init` now work properly. 
- Also added proxies for `/feed/` and `/auth/` which probably also did not work properly before.
- There are no references to `/ping` or `healthcheck` so I left them out of the list
- Made the proxy definition more compact