### PR TITLE
Migration indexes

### DIFF
--- a/server/migrations/changelog.md
+++ b/server/migrations/changelog.md
@@ -6,3 +6,4 @@ Please add a record of every database migration that you create to this file. Th
 | -------------- | ---------------------------- | ------------------------------------------------------------------------------------ |
 | v2.15.0        | v2.15.0-series-column-unique | Series must have unique names in the same library                                    |
 | v2.15.1        | v2.15.1-reindex-nocase       | Fix potential db corruption issues due to bad sqlite extension introduced in v2.12.0 |
+| v2.15.2        | v2.15.2-index-creation       | Creates author, series, and podcast episode indexes                                  |

--- a/server/migrations/v2.15.2-index-creation.js
+++ b/server/migrations/v2.15.2-index-creation.js
@@ -8,7 +8,7 @@
  */
 
 /**
- * This upward migration script adds indexes to speed up queries on the `BookAuthor`, `BookSeries`, and `PodcastEpisode` tables.
+ * This upward migration script adds indexes to speed up queries on the `BookAuthor`, `BookSeries`, and `podcastEpisodes` tables.
  *
  * @param {MigrationOptions} options - an object containing the migration context.
  * @returns {Promise<void>} - A promise that resolves when the migration is complete.
@@ -19,23 +19,23 @@ async function up({ context: { queryInterface, logger } }) {
 
   // Create index for bookAuthors
   logger.info('[2.15.2 migration] Creating index for bookAuthors')
-  await queryInterface.addIndex('BookAuthor', ['authorId'], {
+  await queryInterface.addIndex('bookAuthors', ['authorId'], {
     name: 'bookAuthor_authorId'
   })
 
   // Create index for bookSeries
   logger.info('[2.15.2 migration] Creating index for bookSeries')
-  await queryInterface.addIndex('BookSeries', ['seriesId'], {
+  await queryInterface.addIndex('bookSeries', ['seriesId'], {
     name: 'bookSeries_seriesId'
   })
 
   // Delete existing podcastEpisode index
   logger.info('[2.15.2 migration] Deleting existing podcastEpisode index')
-  await queryInterface.removeIndex('PodcastEpisode', 'podcast_episode_created_at')
+  await queryInterface.removeIndex('podcastEpisodes', 'podcast_episode_created_at')
 
   // Create index for podcastEpisode and createdAt
   logger.info('[2.15.2 migration] Creating index for podcastEpisode and createdAt')
-  await queryInterface.addIndex('PodcastEpisode', ['createdAt', 'podcastId'], {
+  await queryInterface.addIndex('podcastEpisodes', ['createdAt', 'podcastId'], {
     name: 'podcastEpisode_createdAt_podcastId'
   })
 
@@ -44,7 +44,7 @@ async function up({ context: { queryInterface, logger } }) {
 }
 
 /**
- * This downward migration script removes the newly created indexes and re-adds the old index on the `PodcastEpisode` table.
+ * This downward migration script removes the newly created indexes and re-adds the old index on the `podcastEpisodes` table.
  *
  * @param {MigrationOptions} options - an object containing the migration context.
  * @returns {Promise<void>} - A promise that resolves when the migration is complete.
@@ -55,19 +55,19 @@ async function down({ context: { queryInterface, logger } }) {
 
   // Remove index for bookAuthors
   logger.info('[2.15.2 migration] Removing index for bookAuthors')
-  await queryInterface.removeIndex('BookAuthor', 'bookAuthor_authorId')
+  await queryInterface.removeIndex('bookAuthors', 'bookAuthor_authorId')
 
   // Remove index for bookSeries
   logger.info('[2.15.2 migration] Removing index for bookSeries')
-  await queryInterface.removeIndex('BookSeries', 'bookSeries_seriesId')
+  await queryInterface.removeIndex('bookSeries', 'bookSeries_seriesId')
 
   // Delete existing podcastEpisode index
   logger.info('[2.15.2 migration] Deleting existing podcastEpisode index')
-  await queryInterface.removeIndex('PodcastEpisode', 'podcastEpisode_createdAt_podcastId')
+  await queryInterface.removeIndex('podcastEpisodes', 'podcastEpisode_createdAt_podcastId')
 
   // Create index for podcastEpisode and createdAt
   logger.info('[2.15.2 migration] Creating index for podcastEpisode createdAt')
-  await queryInterface.addIndex('PodcastEpisode', ['createdAt'], {
+  await queryInterface.addIndex('podcastEpisodes', ['createdAt'], {
     name: 'podcast_episode_created_at'
   })
 

--- a/server/migrations/v2.15.2-index-creation.js
+++ b/server/migrations/v2.15.2-index-creation.js
@@ -31,7 +31,7 @@ async function up({ context: { queryInterface, logger } }) {
 
   // Delete existing podcastEpisode index
   logger.info('[2.15.2 migration] Deleting existing podcastEpisode index')
-  await queryInterface.removeIndex('podcastEpisodes', 'podcast_episode_created_at')
+  await queryInterface.removeIndex('podcastEpisodes', 'podcast_episodes_created_at')
 
   // Create index for podcastEpisode and createdAt
   logger.info('[2.15.2 migration] Creating index for podcastEpisode and createdAt')
@@ -66,9 +66,9 @@ async function down({ context: { queryInterface, logger } }) {
   await queryInterface.removeIndex('podcastEpisodes', 'podcastEpisode_createdAt_podcastId')
 
   // Create index for podcastEpisode and createdAt
-  logger.info('[2.15.2 migration] Creating index for podcastEpisode createdAt')
+  logger.info('[2.15.2 migration] Creating original index for podcastEpisode createdAt')
   await queryInterface.addIndex('podcastEpisodes', ['createdAt'], {
-    name: 'podcast_episode_created_at'
+    name: 'podcast_episodes_created_at'
   })
 
   // Finished migration

--- a/server/migrations/v2.15.2-index-creation.js
+++ b/server/migrations/v2.15.2-index-creation.js
@@ -1,0 +1,78 @@
+/**
+ * @typedef MigrationContext
+ * @property {import('sequelize').QueryInterface} queryInterface - a suquelize QueryInterface object.
+ * @property {import('../Logger')} logger - a Logger object.
+ *
+ * @typedef MigrationOptions
+ * @property {MigrationContext} context - an object containing the migration context.
+ */
+
+/**
+ * This upward migration script adds indexes to speed up queries on the `BookAuthor`, `BookSeries`, and `PodcastEpisode` tables.
+ *
+ * @param {MigrationOptions} options - an object containing the migration context.
+ * @returns {Promise<void>} - A promise that resolves when the migration is complete.
+ */
+async function up({ context: { queryInterface, logger } }) {
+  // Upwards migration script
+  logger.info('[2.15.2 migration] UPGRADE BEGIN: 2.15.2-index-creation')
+
+  // Create index for bookAuthors
+  logger.info('[2.15.2 migration] Creating index for bookAuthors')
+  await queryInterface.addIndex('BookAuthor', ['authorId'], {
+    name: 'bookAuthor_authorId'
+  })
+
+  // Create index for bookSeries
+  logger.info('[2.15.2 migration] Creating index for bookSeries')
+  await queryInterface.addIndex('BookSeries', ['seriesId'], {
+    name: 'bookSeries_seriesId'
+  })
+
+  // Delete existing podcastEpisode index
+  logger.info('[2.15.2 migration] Deleting existing podcastEpisode index')
+  await queryInterface.removeIndex('PodcastEpisode', 'podcast_episode_created_at')
+
+  // Create index for podcastEpisode and createdAt
+  logger.info('[2.15.2 migration] Creating index for podcastEpisode and createdAt')
+  await queryInterface.addIndex('PodcastEpisode', ['createdAt', 'podcastId'], {
+    name: 'podcastEpisode_createdAt_podcastId'
+  })
+
+  // Completed migration
+  logger.info('[2.15.2 migration] UPGRADE END: 2.15.2-index-creation')
+}
+
+/**
+ * This downward migration script removes the newly created indexes and re-adds the old index on the `PodcastEpisode` table.
+ *
+ * @param {MigrationOptions} options - an object containing the migration context.
+ * @returns {Promise<void>} - A promise that resolves when the migration is complete.
+ */
+async function down({ context: { queryInterface, logger } }) {
+  // Downward migration script
+  logger.info('[2.15.2 migration] DOWNGRADE BEGIN: 2.15.2-index-creation')
+
+  // Remove index for bookAuthors
+  logger.info('[2.15.2 migration] Removing index for bookAuthors')
+  await queryInterface.removeIndex('BookAuthor', 'bookAuthor_authorId')
+
+  // Remove index for bookSeries
+  logger.info('[2.15.2 migration] Removing index for bookSeries')
+  await queryInterface.removeIndex('BookSeries', 'bookSeries_seriesId')
+
+  // Delete existing podcastEpisode index
+  logger.info('[2.15.2 migration] Deleting existing podcastEpisode index')
+  await queryInterface.removeIndex('PodcastEpisode', 'podcastEpisode_createdAt_podcastId')
+
+  // Create index for podcastEpisode and createdAt
+  logger.info('[2.15.2 migration] Creating index for podcastEpisode createdAt')
+  await queryInterface.addIndex('PodcastEpisode', ['createdAt'], {
+    name: 'podcast_episode_created_at'
+  })
+
+  // Finished migration
+  logger.info('[2.15.2 migration] DOWNGRADE END: 2.15.2-index-creation')
+}
+
+module.exports = { up, down }

--- a/server/migrations/v2.15.2-index-creation.js
+++ b/server/migrations/v2.15.2-index-creation.js
@@ -19,15 +19,25 @@ async function up({ context: { queryInterface, logger } }) {
 
   // Create index for bookAuthors
   logger.info('[2.15.2 migration] Creating index for bookAuthors')
-  await queryInterface.addIndex('bookAuthors', ['authorId'], {
-    name: 'bookAuthor_authorId'
-  })
+  const bookAuthorsIndexes = await queryInterface.showIndex('bookAuthors')
+  if (!bookAuthorsIndexes.some((index) => index.name === 'bookAuthor_authorId')) {
+    await queryInterface.addIndex('bookAuthors', ['authorId'], {
+      name: 'bookAuthor_authorId'
+    })
+  } else {
+    logger.info('[2.15.2 migration] Index bookAuthor_authorId already exists')
+  }
 
   // Create index for bookSeries
   logger.info('[2.15.2 migration] Creating index for bookSeries')
-  await queryInterface.addIndex('bookSeries', ['seriesId'], {
-    name: 'bookSeries_seriesId'
-  })
+  const bookSeriesIndexes = await queryInterface.showIndex('bookSeries')
+  if (!bookSeriesIndexes.some((index) => index.name === 'bookSeries_seriesId')) {
+    await queryInterface.addIndex('bookSeries', ['seriesId'], {
+      name: 'bookSeries_seriesId'
+    })
+  } else {
+    logger.info('[2.15.2 migration] Index bookSeries_seriesId already exists')
+  }
 
   // Delete existing podcastEpisode index
   logger.info('[2.15.2 migration] Deleting existing podcastEpisode index')
@@ -35,9 +45,14 @@ async function up({ context: { queryInterface, logger } }) {
 
   // Create index for podcastEpisode and createdAt
   logger.info('[2.15.2 migration] Creating index for podcastEpisode and createdAt')
-  await queryInterface.addIndex('podcastEpisodes', ['createdAt', 'podcastId'], {
-    name: 'podcastEpisode_createdAt_podcastId'
-  })
+  const podcastEpisodesIndexes = await queryInterface.showIndex('podcastEpisodes')
+  if (!podcastEpisodesIndexes.some((index) => index.name === 'podcastEpisode_createdAt_podcastId')) {
+    await queryInterface.addIndex('podcastEpisodes', ['createdAt', 'podcastId'], {
+      name: 'podcastEpisode_createdAt_podcastId'
+    })
+  } else {
+    logger.info('[2.15.2 migration] Index podcastEpisode_createdAt_podcastId already exists')
+  }
 
   // Completed migration
   logger.info('[2.15.2 migration] UPGRADE END: 2.15.2-index-creation')

--- a/server/models/BookAuthor.js
+++ b/server/models/BookAuthor.js
@@ -54,7 +54,13 @@ class BookAuthor extends Model {
         sequelize,
         modelName: 'bookAuthor',
         timestamps: true,
-        updatedAt: false
+        updatedAt: false,
+        indexes: [
+          {
+            name: 'bookAuthor_authorId',
+            fields: ['authorId']
+          }
+        ]
       }
     )
 

--- a/server/models/BookSeries.js
+++ b/server/models/BookSeries.js
@@ -43,7 +43,13 @@ class BookSeries extends Model {
         sequelize,
         modelName: 'bookSeries',
         timestamps: true,
-        updatedAt: false
+        updatedAt: false,
+        indexes: [
+          {
+            name: 'bookSeries_seriesId',
+            fields: ['seriesId']
+          }
+        ]
       }
     )
 

--- a/server/models/PodcastEpisode.js
+++ b/server/models/PodcastEpisode.js
@@ -157,7 +157,7 @@ class PodcastEpisode extends Model {
         modelName: 'podcastEpisode',
         indexes: [
           {
-            fields: ['createdAt']
+            fields: ['createdAt', 'podcastId']
           }
         ]
       }

--- a/server/models/PodcastEpisode.js
+++ b/server/models/PodcastEpisode.js
@@ -157,6 +157,7 @@ class PodcastEpisode extends Model {
         modelName: 'podcastEpisode',
         indexes: [
           {
+            name: 'podcastEpisode_createdAt_podcastId',
             fields: ['createdAt', 'podcastId']
           }
         ]


### PR DESCRIPTION
This PR fixes https://github.com/advplyr/audiobookshelf/issues/3259, https://github.com/advplyr/audiobookshelf/issues/3525, and https://github.com/advplyr/audiobookshelf/issues/3237.

This PR adds migrations for the following indices:
- `BookAuthor` on `authorId`
- `BookSeries` on `seriesId`
- `PodcastEpisode` on `createdAt` and `podcastId` from https://github.com/advplyr/audiobookshelf/pull/3528

The author and series indexes reduce query time from multiple seconds/minutes for large databases (more than 20k items) to less than a second. I have not done much testing with large podcast databases yet. I am still investigating why some of the select book queries did not improve too much and whether this can be solved by another index.

To test the difference in query time, I did the following on a moderately sized database so the loop ran in a reasonable amount of time.
Database stats:
- Authors: 3217
- Series: 947
- Books: 5892
1. Enable benchmark logging for each SQL query
2. Generated a HAR file of navigating around through the web client to get a variety of SQL requests
3. Used a combination of Python/bash scripts to:
    - Delete and copy database from a backup to start at the same point for all tests
    - Start the server
    - Run all requests from HAR file
    - Stop the server
    - Repeat above steps 10 times
    - Copy the log file and rename according to index so we can keep all queries for this specific test separate
    - Parse the log files to build a table comparing worst time of each query for each data set

I sorted the times by the runtime without indexes, and created the following table (did not include all sets of indexes being added to show best/worst case):
![Book_Index_Comparison](https://github.com/user-attachments/assets/e4a44b5b-3a71-451e-91ea-642961e5c4f2)