### PR TITLE
'mpg' and 'mpeg' added as supported audio-type/file-extension

### DIFF
--- a/client/players/LocalAudioPlayer.js
+++ b/client/players/LocalAudioPlayer.js
@@ -147,7 +147,7 @@ export default class LocalAudioPlayer extends EventEmitter {
           timeoutRetry: {
             maxNumRetry: 4,
             retryDelayMs: 0,
-            maxRetryDelayMs: 0,
+            maxRetryDelayMs: 0
           },
           errorRetry: {
             maxNumRetry: 8,
@@ -160,7 +160,7 @@ export default class LocalAudioPlayer extends EventEmitter {
               }
               return retry
             }
-          },
+          }
         }
       }
     }
@@ -194,7 +194,7 @@ export default class LocalAudioPlayer extends EventEmitter {
 
   setDirectPlay() {
     // Set initial track and track time offset
-    var trackIndex = this.audioTracks.findIndex(t => this.startTime >= t.startOffset && this.startTime < (t.startOffset + t.duration))
+    var trackIndex = this.audioTracks.findIndex((t) => this.startTime >= t.startOffset && this.startTime < t.startOffset + t.duration)
     this.currentTrackIndex = trackIndex >= 0 ? trackIndex : 0
 
     this.loadCurrentTrack()
@@ -270,7 +270,7 @@ export default class LocalAudioPlayer extends EventEmitter {
       // Seeking Direct play
       if (time < this.currentTrack.startOffset || time > this.currentTrack.startOffset + this.currentTrack.duration) {
         // Change Track
-        var trackIndex = this.audioTracks.findIndex(t => time >= t.startOffset && time < (t.startOffset + t.duration))
+        var trackIndex = this.audioTracks.findIndex((t) => time >= t.startOffset && time < t.startOffset + t.duration)
         if (trackIndex >= 0) {
           this.startTime = time
           this.currentTrackIndex = trackIndex
@@ -292,7 +292,6 @@ export default class LocalAudioPlayer extends EventEmitter {
     if (!this.player) return
     this.player.volume = volume
   }
-
 
   // Utils
   isValidDuration(duration) {

--- a/client/plugins/constants.js
+++ b/client/plugins/constants.js
@@ -1,6 +1,6 @@
 const SupportedFileTypes = {
   image: ['png', 'jpg', 'jpeg', 'webp'],
-  audio: ['m4b', 'mp3', 'm4a', 'flac', 'opus', 'ogg', 'oga', 'mp4', 'aac', 'wma', 'aiff', 'wav', 'webm', 'webma', 'mka', 'awb', 'caf'],
+  audio: ['m4b', 'mp3', 'm4a', 'flac', 'opus', 'ogg', 'oga', 'mp4', 'aac', 'wma', 'aiff', 'wav', 'webm', 'webma', 'mka', 'awb', 'caf', 'mpeg', 'mpg'],
   ebook: ['epub', 'pdf', 'mobi', 'azw3', 'cbr', 'cbz'],
   info: ['nfo'],
   text: ['txt'],
@@ -81,9 +81,7 @@ const Hotkeys = {
   }
 }
 
-export {
-  Constants
-}
+export { Constants }
 export default ({ app }, inject) => {
   inject('constants', Constants)
   inject('keynames', KeyNames)

--- a/server/utils/constants.js
+++ b/server/utils/constants.js
@@ -49,5 +49,7 @@ module.exports.AudioMimeType = {
   WEBMA: 'audio/webm',
   MKA: 'audio/x-matroska',
   AWB: 'audio/amr-wb',
-  CAF: 'audio/x-caf'
+  CAF: 'audio/x-caf',
+  MPEG: 'audio/mpeg',
+  MPG: 'audio/mpeg'
 }

--- a/server/utils/globals.js
+++ b/server/utils/globals.js
@@ -1,6 +1,6 @@
 const globals = {
   SupportedImageTypes: ['png', 'jpg', 'jpeg', 'webp'],
-  SupportedAudioTypes: ['m4b', 'mp3', 'm4a', 'flac', 'opus', 'ogg', 'oga', 'mp4', 'aac', 'wma', 'aiff', 'wav', 'webm', 'webma', 'mka', 'awb', 'caf'],
+  SupportedAudioTypes: ['m4b', 'mp3', 'm4a', 'flac', 'opus', 'ogg', 'oga', 'mp4', 'aac', 'wma', 'aiff', 'wav', 'webm', 'webma', 'mka', 'awb', 'caf', 'mpg', 'mpeg'],
   SupportedEbookTypes: ['epub', 'pdf', 'mobi', 'azw3', 'cbr', 'cbz'],
   TextFileTypes: ['txt', 'nfo'],
   MetadataFileTypes: ['opf', 'abs', 'xml', 'json']


### PR DESCRIPTION
Hi there,

please add `mpeg` and `mpg` to the supported audio-types/file-extensions.

I have tons of `*.mp(e)g` podcast files in my library; which - at the moment - aren't detected by the scanner at all.
This change will fix this.

Thanks a lot!