### PR TITLE
Improve cover image performance

### DIFF
--- a/client/store/globals.js
+++ b/client/store/globals.js
@@ -98,7 +98,7 @@ export const getters = {
       const userToken = rootGetters['user/getToken']
       const lastUpdate = libraryItem.updatedAt || Date.now()
       const libraryItemId = libraryItem.libraryItemId || libraryItem.id // Workaround for /users/:id page showing media progress covers
-      return `${rootState.routerBasePath}/api/items/${libraryItemId}/cover?token=${userToken}&ts=${lastUpdate}${raw ? '&raw=1' : ''}`
+      return `${rootState.routerBasePath}/api/items/${libraryItemId}/cover?ts=${lastUpdate}${raw ? '&raw=1' : ''}`
     },
   getLibraryItemCoverSrcById:
     (state, getters, rootState, rootGetters) =>
@@ -106,7 +106,7 @@ export const getters = {
       const placeholder = `${rootState.routerBasePath}/book_placeholder.jpg`
       if (!libraryItemId) return placeholder
       const userToken = rootGetters['user/getToken']
-      return `${rootState.routerBasePath}/api/items/${libraryItemId}/cover?token=${userToken}${raw ? '&raw=1' : ''}${timestamp ? `&ts=${timestamp}` : ''}`
+      return `${rootState.routerBasePath}/api/items/${libraryItemId}/cover?${raw ? '&raw=1' : ''}${timestamp ? `&ts=${timestamp}` : ''}`
     },
   getIsBatchSelectingMediaItems: (state) => {
     return state.selectedMediaItems.length

--- a/server/Auth.js
+++ b/server/Auth.js
@@ -23,7 +23,7 @@ class Auth {
 
   /**
    * Checks if the request should not be authenticated.
-   * @param {import('express').Request} req
+   * @param {Request} req
    * @returns {boolean}
    * @private
    */

--- a/server/Auth.js
+++ b/server/Auth.js
@@ -18,6 +18,26 @@ class Auth {
   constructor() {
     // Map of openId sessions indexed by oauth2 state-variable
     this.openIdAuthSession = new Map()
+    this.ignorePattern = /\/api\/items\/[^/]+\/cover/
+  }
+
+  /**
+   * Checks if the request should not be authenticated.
+   * @param {import('express').Request} req
+   * @returns {boolean}
+   * @private
+   */
+  authNotNeeded(req) {
+    return req.method === 'GET' && this.ignorePattern.test(req.originalUrl)
+  }
+
+  ifAuthNeeded(middleware) {
+    return (req, res, next) => {
+      if (this.authNotNeeded(req)) {
+        return next()
+      }
+      middleware(req, res, next)
+    }
   }
 
   /**

--- a/server/Database.js
+++ b/server/Database.js
@@ -808,28 +808,6 @@ class Database {
       return `${normalizedColumn} LIKE ${pattern}`
     }
   }
-
-  async getLibraryItemCoverPath(libraryItemId) {
-    const libraryItem = await this.libraryItemModel.findByPk(libraryItemId, {
-      attributes: ['id', 'mediaType', 'mediaId', 'libraryId'],
-      include: [
-        {
-          model: this.bookModel,
-          attributes: ['id', 'coverPath']
-        },
-        {
-          model: this.podcastModel,
-          attributes: ['id', 'coverPath']
-        }
-      ]
-    })
-    if (!libraryItem) {
-      Logger.warn(`[Database] getCover: Library item "${libraryItemId}" does not exist`)
-      return null
-    }
-
-    return libraryItem.media.coverPath
-  }
 }
 
 module.exports = new Database()

--- a/server/Database.js
+++ b/server/Database.js
@@ -808,6 +808,28 @@ class Database {
       return `${normalizedColumn} LIKE ${pattern}`
     }
   }
+
+  async getLibraryItemCoverPath(libraryItemId) {
+    const libraryItem = await this.libraryItemModel.findByPk(libraryItemId, {
+      attributes: ['id', 'mediaType', 'mediaId', 'libraryId'],
+      include: [
+        {
+          model: this.bookModel,
+          attributes: ['id', 'coverPath']
+        },
+        {
+          model: this.podcastModel,
+          attributes: ['id', 'coverPath']
+        }
+      ]
+    })
+    if (!libraryItem) {
+      Logger.warn(`[Database] getCover: Library item "${libraryItemId}" does not exist`)
+      return null
+    }
+
+    return libraryItem.media.coverPath
+  }
 }
 
 module.exports = new Database()

--- a/server/controllers/LibraryItemController.js
+++ b/server/controllers/LibraryItemController.js
@@ -342,44 +342,25 @@ class LibraryItemController {
       query: { width, height, format, raw }
     } = req
 
-    const libraryItem = await Database.libraryItemModel.findByPk(req.params.id, {
-      attributes: ['id', 'mediaType', 'mediaId', 'libraryId'],
-      include: [
-        {
-          model: Database.bookModel,
-          attributes: ['id', 'coverPath', 'tags', 'explicit']
-        },
-        {
-          model: Database.podcastModel,
-          attributes: ['id', 'coverPath', 'tags', 'explicit']
-        }
-      ]
-    })
-    if (!libraryItem) {
-      Logger.warn(`[LibraryItemController] getCover: Library item "${req.params.id}" does not exist`)
-      return res.sendStatus(404)
-    }
-
-    // Check if user can access this library item
-    if (!req.user.checkCanAccessLibraryItem(libraryItem)) {
-      return res.sendStatus(403)
-    }
-
-    // Check if library item media has a cover path
-    if (!libraryItem.media.coverPath || !(await fs.pathExists(libraryItem.media.coverPath))) {
-      return res.sendStatus(404)
-    }
-
     if (req.query.ts) res.set('Cache-Control', 'private, max-age=86400')
 
+    const libraryItemId = req.params.id
+    if (!libraryItemId) {
+      return res.sendStatus(400)
+    }
+
     if (raw) {
+      const coverPath = await Database.getLibraryItemCoverPath(libraryItemId)
+      if (!coverPath || !(await fs.pathExists(coverPath))) {
+        return res.sendStatus(404)
+      }
       // any value
       if (global.XAccel) {
-        const encodedURI = encodeUriPath(global.XAccel + libraryItem.media.coverPath)
+        const encodedURI = encodeUriPath(global.XAccel + coverPath)
         Logger.debug(`Use X-Accel to serve static file ${encodedURI}`)
         return res.status(204).header({ 'X-Accel-Redirect': encodedURI }).send()
       }
-      return res.sendFile(libraryItem.media.coverPath)
+      return res.sendFile(coverPath)
     }
 
     const options = {
@@ -387,7 +368,7 @@ class LibraryItemController {
       height: height ? parseInt(height) : null,
       width: width ? parseInt(width) : null
     }
-    return CacheManager.handleCoverCache(res, libraryItem.id, libraryItem.media.coverPath, options)
+    return CacheManager.handleCoverCache(res, libraryItemId, options)
   }
 
   /**

--- a/server/controllers/LibraryItemController.js
+++ b/server/controllers/LibraryItemController.js
@@ -350,7 +350,7 @@ class LibraryItemController {
     }
 
     if (raw) {
-      const coverPath = await Database.getLibraryItemCoverPath(libraryItemId)
+      const coverPath = await Database.libraryItemModel.getCoverPath(libraryItemId)
       if (!coverPath || !(await fs.pathExists(coverPath))) {
         return res.sendStatus(404)
       }

--- a/server/managers/CacheManager.js
+++ b/server/managers/CacheManager.js
@@ -59,7 +59,7 @@ class CacheManager {
     }
 
     // Cached cover does not exist, generate it
-    const coverPath = await Database.getLibraryItemCoverPath(libraryItemId)
+    const coverPath = await Database.libraryItemModel.getCoverPath(libraryItemId)
     if (!coverPath || !(await fs.pathExists(coverPath))) {
       return res.sendStatus(404)
     }

--- a/server/managers/CacheManager.js
+++ b/server/managers/CacheManager.js
@@ -4,6 +4,7 @@ const stream = require('stream')
 const Logger = require('../Logger')
 const { resizeImage } = require('../utils/ffmpegHelpers')
 const { encodeUriPath } = require('../utils/fileUtils')
+const Database = require('../Database')
 
 class CacheManager {
   constructor() {
@@ -29,24 +30,24 @@ class CacheManager {
     await fs.ensureDir(this.ItemCachePath)
   }
 
-  async handleCoverCache(res, libraryItemId, coverPath, options = {}) {
+  async handleCoverCache(res, libraryItemId, options = {}) {
     const format = options.format || 'webp'
     const width = options.width || 400
     const height = options.height || null
 
     res.type(`image/${format}`)
 
-    const path = Path.join(this.CoverCachePath, `${libraryItemId}_${width}${height ? `x${height}` : ''}`) + '.' + format
+    const cachePath = Path.join(this.CoverCachePath, `${libraryItemId}_${width}${height ? `x${height}` : ''}`) + '.' + format
 
     // Cache exists
-    if (await fs.pathExists(path)) {
+    if (await fs.pathExists(cachePath)) {
       if (global.XAccel) {
-        const encodedURI = encodeUriPath(global.XAccel + path)
+        const encodedURI = encodeUriPath(global.XAccel + cachePath)
         Logger.debug(`Use X-Accel to serve static file ${encodedURI}`)
         return res.status(204).header({ 'X-Accel-Redirect': encodedURI }).send()
       }
 
-      const r = fs.createReadStream(path)
+      const r = fs.createReadStream(cachePath)
       const ps = new stream.PassThrough()
       stream.pipeline(r, ps, (err) => {
         if (err) {
@@ -57,7 +58,13 @@ class CacheManager {
       return ps.pipe(res)
     }
 
-    const writtenFile = await resizeImage(coverPath, path, width, height)
+    // Cached cover does not exist, generate it
+    const coverPath = await Database.getLibraryItemCoverPath(libraryItemId)
+    if (!coverPath || !(await fs.pathExists(coverPath))) {
+      return res.sendStatus(404)
+    }
+
+    const writtenFile = await resizeImage(coverPath, cachePath, width, height)
     if (!writtenFile) return res.sendStatus(500)
 
     if (global.XAccel) {

--- a/server/models/LibraryItem.js
+++ b/server/models/LibraryItem.js
@@ -865,6 +865,33 @@ class LibraryItem extends Model {
 
   /**
    *
+   * @param {string} libraryItemId
+   * @returns {Promise<string>}
+   */
+  static async getCoverPath(libraryItemId) {
+    const libraryItem = await this.findByPk(libraryItemId, {
+      attributes: ['id', 'mediaType', 'mediaId', 'libraryId'],
+      include: [
+        {
+          model: this.bookModel,
+          attributes: ['id', 'coverPath']
+        },
+        {
+          model: this.podcastModel,
+          attributes: ['id', 'coverPath']
+        }
+      ]
+    })
+    if (!libraryItem) {
+      Logger.warn(`[LibraryItem] getCoverPath: Library item "${libraryItemId}" does not exist`)
+      return null
+    }
+
+    return libraryItem.media.coverPath
+  }
+
+  /**
+   *
    * @param {import('sequelize').FindOptions} options
    * @returns {Promise<Book|Podcast>}
    */

--- a/server/models/LibraryItem.js
+++ b/server/models/LibraryItem.js
@@ -873,11 +873,11 @@ class LibraryItem extends Model {
       attributes: ['id', 'mediaType', 'mediaId', 'libraryId'],
       include: [
         {
-          model: this.bookModel,
+          model: this.sequelize.models.book,
           attributes: ['id', 'coverPath']
         },
         {
-          model: this.podcastModel,
+          model: this.sequelize.models.podcast,
           attributes: ['id', 'coverPath']
         }
       ]


### PR DESCRIPTION
Following the experiments described [here](https://github.com/advplyr/audiobookshelf/discussions/3570), I made the following changes to cover image GET requests (I will do the same for author images in separate PR - wanted to focus on covers here):
- Removed authentication and user deserialization (req.user) from cover requests
- Optimized `LibraryItemController.getCover` so that no database access is made if the resized image is already in the covers disk cache
- Removed the token parameter from cover urls on the web client

This reduces the average completion time for cover requests by a factor of ~10 when acessing the server through https, and minimizes concurrent access to the database.