### PR TITLE
Add in-memory user cache

### DIFF
--- a/server/Auth.js
+++ b/server/Auth.js
@@ -990,28 +990,18 @@ class Auth {
         })
       }
     }
-
-    Database.userModel
-      .update(
-        {
-          pash: pw
-        },
-        {
-          where: { id: matchingUser.id }
-        }
-      )
-      .then(() => {
-        Logger.info(`[Auth] User "${matchingUser.username}" changed password`)
-        res.json({
-          success: true
-        })
+    try {
+      await matchingUser.update({ pash: pw })
+      Logger.info(`[Auth] User "${matchingUser.username}" changed password`)
+      res.json({
+        success: true
       })
-      .catch((error) => {
-        Logger.error(`[Auth] User "${matchingUser.username}" failed to change password`, error)
-        res.json({
-          error: 'Unknown error'
-        })
+    } catch (error) {
+      Logger.error(`[Auth] User "${matchingUser.username}" failed to change password`, error)
+      res.json({
+        error: 'Unknown error'
       })
+    }
   }
 }
 


### PR DESCRIPTION
This PR Addresses point 5 from the [conclusions](https://github.com/advplyr/audiobookshelf/discussions/3570#discussioncomment-11119792) of the image loading performance analysis. 

An in-memory cache check and insert is introduced in all user model methods that return a single user (with their media progress) from the database. Caching this saves around 15 ms per authenticated request.

The cache doesn't have a TTL, and is invalidated only if needed (i.e. when changes to the user were not made through the cached object). I have convinced myself that all relevant writes to user and media progress are made through user model methods that are covered by a call to the `maybeInvalidate` method (and specifically in `createUpdateMediaProgressFromPayload`)

Note that this covers point 5, but I've decided not address point 4 (Remove media progress from req.user), since at this point media progress is quite entangled with req.user and requires quite a few changes in the code, which aren't worth it since the cache already solves the db performance issue. I think it would still be worthwhile disentangle them in the future, but this change makes it less urgent.