### PR TITLE
Remove unnecessary episode_download_queue_updated socket event causing OOM

### DIFF
--- a/client/pages/item/_id/index.vue
+++ b/client/pages/item/_id/index.vue
@@ -638,6 +638,11 @@ export default {
         this.episodesDownloading = this.episodesDownloading.filter((d) => d.id !== episodeDownload.id)
       }
     },
+    episodeDownloadQueueCleared(libraryItemId) {
+      if (libraryItemId === this.libraryItemId) {
+        this.episodeDownloadsQueued = []
+      }
+    },
     rssFeedOpen(data) {
       if (data.entityId === this.libraryItemId) {
         console.log('RSS Feed Opened', data)
@@ -776,6 +781,7 @@ export default {
     this.$root.socket.on('episode_download_queued', this.episodeDownloadQueued)
     this.$root.socket.on('episode_download_started', this.episodeDownloadStarted)
     this.$root.socket.on('episode_download_finished', this.episodeDownloadFinished)
+    this.$root.socket.on('episode_download_queue_cleared', this.episodeDownloadQueueCleared)
   },
   beforeDestroy() {
     this.$eventBus.$off(`${this.libraryItem.id}_updated`, this.libraryItemUpdated)
@@ -787,6 +793,7 @@ export default {
     this.$root.socket.off('episode_download_queued', this.episodeDownloadQueued)
     this.$root.socket.off('episode_download_started', this.episodeDownloadStarted)
     this.$root.socket.off('episode_download_finished', this.episodeDownloadFinished)
+    this.$root.socket.off('episode_download_queue_cleared', this.episodeDownloadQueueCleared)
   }
 }
 </script>

--- a/client/pages/library/_library/podcast/download-queue.vue
+++ b/client/pages/library/_library/podcast/download-queue.vue
@@ -104,9 +104,6 @@ export default {
         this.episodesDownloading = this.episodesDownloading.filter((d) => d.id !== episodeDownload.id)
       }
     },
-    episodeDownloadQueueUpdated(downloadQueueDetails) {
-      this.episodeDownloadsQueued = downloadQueueDetails.queue.filter((q) => q.libraryId == this.libraryId)
-    },
     async loadInitialDownloadQueue() {
       this.processing = true
       const queuePayload = await this.$axios.$get(`/api/libraries/${this.libraryId}/episode-downloads`).catch((error) => {
@@ -128,7 +125,6 @@ export default {
       this.$root.socket.on('episode_download_queued', this.episodeDownloadQueued)
       this.$root.socket.on('episode_download_started', this.episodeDownloadStarted)
       this.$root.socket.on('episode_download_finished', this.episodeDownloadFinished)
-      this.$root.socket.on('episode_download_queue_updated', this.episodeDownloadQueueUpdated)
     }
   },
   mounted() {
@@ -138,7 +134,6 @@ export default {
     this.$root.socket.off('episode_download_queued', this.episodeDownloadQueued)
     this.$root.socket.off('episode_download_started', this.episodeDownloadStarted)
     this.$root.socket.off('episode_download_finished', this.episodeDownloadFinished)
-    this.$root.socket.off('episode_download_queue_updated', this.episodeDownloadQueueUpdated)
   }
 }
 </script>

--- a/server/managers/PodcastManager.js
+++ b/server/managers/PodcastManager.js
@@ -46,6 +46,7 @@ class PodcastManager {
       var itemDownloads = this.getEpisodeDownloadsInQueue(libraryItemId)
       Logger.info(`[PodcastManager] Clearing downloads in queue for item "${libraryItemId}" (${itemDownloads.length})`)
       this.downloadQueue = this.downloadQueue.filter((d) => d.libraryItemId !== libraryItemId)
+      SocketAuthority.emitter('episode_download_queue_cleared', libraryItemId)
     }
   }
 

--- a/server/managers/PodcastManager.js
+++ b/server/managers/PodcastManager.js
@@ -63,7 +63,6 @@ class PodcastManager {
   }
 
   async startPodcastEpisodeDownload(podcastEpisodeDownload) {
-    SocketAuthority.emitter('episode_download_queue_updated', this.getDownloadQueueDetails())
     if (this.currentDownload) {
       this.downloadQueue.push(podcastEpisodeDownload)
       SocketAuthority.emitter('episode_download_queued', podcastEpisodeDownload.toJSONForClient())
@@ -149,7 +148,6 @@ class PodcastManager {
     TaskManager.taskFinished(task)
 
     SocketAuthority.emitter('episode_download_finished', this.currentDownload.toJSONForClient())
-    SocketAuthority.emitter('episode_download_queue_updated', this.getDownloadQueueDetails())
 
     Watcher.removeIgnoreDir(this.currentDownload.libraryItem.path)
 


### PR DESCRIPTION
This fixes #3601.

The first commit removes an unnecessary socket event with a large payload that was emitted every time an episode download was queued. If a large number of episodes `n` were queued, this caused the creation of `O(n^2)` large objects to be created in quick sucession and queued for sending through the web socket, which caused an OOM for n=~2000.

The second commit resolves an unrelated bug in the podcast item page, in which if you pressed on the button to clear the download queue for a library item, the button and the message `{0} Episode(s) queued for download` were not removed after the download queue was emptied.