### PR TITLE
fix memory spike and high cpu usage when getting playlists with podcasts

### DIFF
--- a/server/models/LibraryItem.js
+++ b/server/models/LibraryItem.js
@@ -10,6 +10,7 @@ const { filePathToPOSIX, getFileTimestampsWithIno } = require('../utils/fileUtil
 const LibraryFile = require('../objects/files/LibraryFile')
 const Book = require('./Book')
 const Podcast = require('./Podcast')
+const { Op } = require('sequelize');
 
 /**
  * @typedef LibraryFileObject
@@ -124,9 +125,13 @@ class LibraryItem extends Model {
    * @param {import('sequelize').WhereOptions} [where]
    * @returns {Array<objects.LibraryItem>} old library items
    */
-  static async getAllOldLibraryItems(where = null) {
+  static async getAllOldLibraryItems({ id: libraryItemIds, episodeIds }) {
     let libraryItems = await this.findAll({
-      where,
+      where: {
+        id: {
+          [Op.in]: libraryItemIds
+        }
+      },
       include: [
         {
           model: this.sequelize.models.book,
@@ -147,11 +152,14 @@ class LibraryItem extends Model {
         },
         {
           model: this.sequelize.models.podcast,
-          include: [
-            {
-              model: this.sequelize.models.podcastEpisode
+          include: {
+            model: this.sequelize.models.podcastEpisode,
+            where: {
+              id: {
+                [Op.in]: episodeIds
+              }
             }
-          ]
+          }
         }
       ]
     })

--- a/server/models/Playlist.js
+++ b/server/models/Playlist.js
@@ -77,11 +77,12 @@ class Playlist extends Model {
 
     const oldPlaylist = this.sequelize.models.playlist.getOldPlaylist(this)
     const libraryItemIds = oldPlaylist.items.map((i) => i.libraryItemId)
+    const episodeIds = oldPlaylist.items.map((i) => i.episodeId).filter(id => id !== null)
 
     let libraryItems = await this.sequelize.models.libraryItem.getAllOldLibraryItems({
-      id: libraryItemIds
+      id: libraryItemIds,
+      episodeIds: episodeIds
     })
-
     const playlistExpanded = oldPlaylist.toJSONExpanded(libraryItems)
 
     if (include?.includes('rssfeed')) {
@@ -93,6 +94,7 @@ class Playlist extends Model {
 
     return playlistExpanded
   }
+
 
   static createFromOld(oldPlaylist) {
     const playlist = this.getFromOld(oldPlaylist)


### PR DESCRIPTION
This might be related to https://github.com/advplyr/audiobookshelf/pull/3015 

- I have a large number of podcasts, and some podcasts with a large number of episodes.  
- The current way podcasts are queried in playlists is very slow. 
- As far as I can tell, after looking up the `libraryItemIds` it grabs all episodes for any `podcastId`in the playlist.
- It only then filters the podcasts episodes contained in the playlist causing
-  Having so many podcasts episodes loaded everytime something is done with a playlist creates big memory spikes and cpu usage.

I do not know if this works for audiobooks, because I do not have a library to test it on, but it does seem to work for podcasts, so even if it breaks something hopefully it will give you some ideas on how to fix.

PS. I don't code JS, so apologies for messing up your codebase. 