### PR TITLE
Use a simpler database fetch in fullUpdateFromOld

### DIFF
--- a/server/models/LibraryItem.js
+++ b/server/models/LibraryItem.js
@@ -237,35 +237,7 @@ class LibraryItem extends Model {
    * @returns {Promise<boolean>} true if updates were made
    */
   static async fullUpdateFromOld(oldLibraryItem) {
-    const libraryItemExpanded = await this.findByPk(oldLibraryItem.id, {
-      include: [
-        {
-          model: this.sequelize.models.book,
-          include: [
-            {
-              model: this.sequelize.models.author,
-              through: {
-                attributes: []
-              }
-            },
-            {
-              model: this.sequelize.models.series,
-              through: {
-                attributes: ['id', 'sequence']
-              }
-            }
-          ]
-        },
-        {
-          model: this.sequelize.models.podcast,
-          include: [
-            {
-              model: this.sequelize.models.podcastEpisode
-            }
-          ]
-        }
-      ]
-    })
+    const libraryItemExpanded = await this.getExpandedById(oldLibraryItem.id)
     if (!libraryItemExpanded) return false
 
     let hasUpdates = false


### PR DESCRIPTION
This is followup to #3604.

As discussed privately, the database fetch in `LibraryItem.fullUpdateFromOld` causes a memory spike because of the query complexity. This uses a simpler query to achieve the same result.