### PR TITLE
Fix player settings modal on share page

### DIFF
--- a/client/components/app/MediaPlayerContainer.vue
+++ b/client/components/app/MediaPlayerContainer.vue
@@ -53,7 +53,6 @@
       @showBookmarks="showBookmarks"
       @showSleepTimer="showSleepTimerModal = true"
       @showPlayerQueueItems="showPlayerQueueItemsModal = true"
-      @showPlayerSettings="showPlayerSettingsModal = true"
     />
 
     <modals-bookmarks-modal v-model="showBookmarksModal" :bookmarks="bookmarks" :current-time="bookmarkCurrentTime" :library-item-id="libraryItemId" @select="selectBookmark" />
@@ -61,8 +60,6 @@
     <modals-sleep-timer-modal v-model="showSleepTimerModal" :timer-set="sleepTimerSet" :timer-type="sleepTimerType" :remaining="sleepTimerRemaining" :has-chapters="!!chapters.length" @set="setSleepTimer" @cancel="cancelSleepTimer" @increment="incrementSleepTimer" @decrement="decrementSleepTimer" />
 
     <modals-player-queue-items-modal v-model="showPlayerQueueItemsModal" />
-
-    <modals-player-settings-modal v-model="showPlayerSettingsModal" />
   </div>
 </template>
 
@@ -81,7 +78,6 @@ export default {
       currentTime: 0,
       showSleepTimerModal: false,
       showPlayerQueueItemsModal: false,
-      showPlayerSettingsModal: false,
       sleepTimerSet: false,
       sleepTimerRemaining: 0,
       sleepTimerType: null,

--- a/client/components/modals/PlayerSettingsModal.vue
+++ b/client/components/modals/PlayerSettingsModal.vue
@@ -59,12 +59,19 @@ export default {
     setJumpBackwardAmount(val) {
       this.jumpBackwardAmount = val
       this.$store.dispatch('user/updateUserSettings', { jumpBackwardAmount: val })
+    },
+    settingsUpdated() {
+      this.useChapterTrack = this.$store.getters['user/getUserSetting']('useChapterTrack')
+      this.jumpForwardAmount = this.$store.getters['user/getUserSetting']('jumpForwardAmount')
+      this.jumpBackwardAmount = this.$store.getters['user/getUserSetting']('jumpBackwardAmount')
     }
   },
   mounted() {
-    this.useChapterTrack = this.$store.getters['user/getUserSetting']('useChapterTrack')
-    this.jumpForwardAmount = this.$store.getters['user/getUserSetting']('jumpForwardAmount')
-    this.jumpBackwardAmount = this.$store.getters['user/getUserSetting']('jumpBackwardAmount')
+    this.settingsUpdated()
+    this.$eventBus.$on('user-settings', this.settingsUpdated)
+  },
+  beforeDestroy() {
+    this.$eventBus.$off('user-settings', this.settingsUpdated)
   }
 }
 </script>

--- a/client/components/player/PlayerUi.vue
+++ b/client/components/player/PlayerUi.vue
@@ -37,7 +37,7 @@
         </ui-tooltip>
 
         <ui-tooltip direction="top" :text="$strings.LabelViewPlayerSettings">
-          <button :aria-label="$strings.LabelViewPlayerSettings" class="outline-none text-gray-300 mx-1 lg:mx-2 hover:text-white" @mousedown.prevent @mouseup.prevent @click.stop="$emit('showPlayerSettings')">
+          <button :aria-label="$strings.LabelViewPlayerSettings" class="outline-none text-gray-300 mx-1 lg:mx-2 hover:text-white" @mousedown.prevent @mouseup.prevent @click.stop="showPlayerSettings">
             <span class="material-symbols text-2xl sm:text-2.5xl">settings_slow_motion</span>
           </button>
         </ui-tooltip>
@@ -64,6 +64,8 @@
     </div>
 
     <modals-chapters-modal v-model="showChaptersModal" :current-chapter="currentChapter" :playback-rate="playbackRate" :chapters="chapters" @select="selectChapter" />
+
+    <modals-player-settings-modal v-model="showPlayerSettingsModal" />
   </div>
 </template>
 
@@ -96,6 +98,7 @@ export default {
       audioEl: null,
       seekLoading: false,
       showChaptersModal: false,
+      showPlayerSettingsModal: false,
       currentTime: 0,
       duration: 0
     }
@@ -314,6 +317,9 @@ export default {
     showChapters() {
       if (!this.chapters.length) return
       this.showChaptersModal = !this.showChaptersModal
+    },
+    showPlayerSettings() {
+      this.showPlayerSettingsModal = !this.showPlayerSettingsModal
     },
     init() {
       this.playbackRate = this.$store.getters['user/getUserSetting']('playbackRate') || 1

--- a/client/pages/share/_slug.vue
+++ b/client/pages/share/_slug.vue
@@ -126,7 +126,8 @@ export default {
       if (!this.localAudioPlayer || !this.hasLoaded) return
       const currentTime = this.localAudioPlayer.getCurrentTime()
       const duration = this.localAudioPlayer.getDuration()
-      this.seek(Math.min(currentTime + 10, duration))
+      const jumpForwardAmount = this.$store.getters['user/getUserSetting']('jumpForwardAmount') || 10
+      this.seek(Math.min(currentTime + jumpForwardAmount, duration))
     },
     jumpBackward() {
       if (!this.localAudioPlayer || !this.hasLoaded) return
@@ -248,6 +249,8 @@ export default {
     }
   },
   mounted() {
+    this.$store.dispatch('user/loadUserSettings')
+
     this.resize()
     window.addEventListener('resize', this.resize)
     window.addEventListener('keydown', this.keyDown)

--- a/client/pages/share/_slug.vue
+++ b/client/pages/share/_slug.vue
@@ -132,7 +132,8 @@ export default {
     jumpBackward() {
       if (!this.localAudioPlayer || !this.hasLoaded) return
       const currentTime = this.localAudioPlayer.getCurrentTime()
-      this.seek(Math.max(currentTime - 10, 0))
+      const jumpBackwardAmount = this.$store.getters['user/getUserSetting']('jumpBackwardAmount') || 10
+      this.seek(Math.max(currentTime - jumpBackwardAmount, 0))
     },
     setVolume(volume) {
       if (!this.localAudioPlayer || !this.hasLoaded) return


### PR DESCRIPTION
## Brief summary

I noticed that the player settings modal did not work when playing a book from the share page so I moved the player settings modal state and component to the PlayerUi component to fix this.

## Screenshots

![image](https://github.com/user-attachments/assets/80d40a98-af10-43b2-b705-b2b26437b89e)
