### PR TITLE
Fixing 'Narrators' and 'Series' update on re-scan

### DIFF
--- a/server/scanner/AbsMetadataFileScanner.js
+++ b/server/scanner/AbsMetadataFileScanner.js
@@ -40,6 +40,8 @@ class AbsMetadataFileScanner {
         if (key === 'genres' && !abMetadata.genres?.length) continue
         if (key === 'tags' && !abMetadata.tags?.length) continue
         if (key === 'chapters' && !abMetadata.chapters?.length) continue
+        if (key === 'narrators' && !abMetadata.narrators?.length) continue
+        if (key === 'series' && !abMetadata.series?.length) continue
 
         bookMetadata[key] = abMetadata[key]
       }


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

When re-scanning an existing audiobook, I noticed that the 'Narrators' and 'Series' fields will not update if you change the audio tags from empty to something else

## Which issue is fixed?

I did not create an issue for this, instead I figured I would fix it myself

## In-depth Description

Steps to repro:

- Add an audiobook to your library. Leave the 'composer' and 'grouping' audio tags empty.
- Check that audiobookshelf did not somehow pick up data for 'Narrators' and 'Series' fields
- Outside of audiobookshelf, fill in the empty tags
- Inside audiobookshelf, click the 'Re-Scan' button
- See that the two fields are not updated

## How have you tested this?

I followed my repro steps listed above, debugging through the code. I found the problem was the AbsMetadataFileScanner.js was overwriting the new 'Narrator' and 'Series' information with empty data.

## Screenshots
