### PR TITLE
Resolved a server crash when a playback session lacked media metadata

### DIFF
--- a/server/utils/queries/userStats.js
+++ b/server/utils/queries/userStats.js
@@ -127,20 +127,20 @@ module.exports = {
           bookListeningMap[ls.displayTitle] += listeningSessionListeningTime
         }
 
-        const authors = ls.mediaMetadata.authors || []
+        const authors = ls.mediaMetadata?.authors || []
         authors.forEach((au) => {
           if (!authorListeningMap[au.name]) authorListeningMap[au.name] = 0
           authorListeningMap[au.name] += listeningSessionListeningTime
         })
 
-        const narrators = ls.mediaMetadata.narrators || []
+        const narrators = ls.mediaMetadata?.narrators || []
         narrators.forEach((narrator) => {
           if (!narratorListeningMap[narrator]) narratorListeningMap[narrator] = 0
           narratorListeningMap[narrator] += listeningSessionListeningTime
         })
 
         // Filter out bad genres like "audiobook" and "audio book"
-        const genres = (ls.mediaMetadata.genres || []).filter((g) => g && !g.toLowerCase().includes('audiobook') && !g.toLowerCase().includes('audio book'))
+        const genres = (ls.mediaMetadata?.genres || []).filter((g) => g && !g.toLowerCase().includes('audiobook') && !g.toLowerCase().includes('audio book'))
         genres.forEach((genre) => {
           if (!genreListeningMap[genre]) genreListeningMap[genre] = 0
           genreListeningMap[genre] += listeningSessionListeningTime


### PR DESCRIPTION
<!-- 
For Work In Progress Pull Requests, please use the Draft PR feature. 
For more details, see [Introducing Draft Pull Requests](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

If this template is not followed, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, workflows will need manual approval before they run.
-->

## Brief Summary

<!-- Please provide a brief summary of what your PR aims to achieve. -->

This PR introduces optional operators to allow stats to function without media metadata for playback Sessions. This change prevents server crashes when media metadata is absent.

## In-depth Description

<!-- 
Describe your solution in more depth. 
How does it work? Why is this the best solution? 
Does it address a broader issue or is it specific to your setup? 
-->

The logic for handling authors, narrators, genres has been updated to handle cases where `mediaMetadata` is absent. This ensures that the server can generate responses without requiring metadata, thereby preventing crashes.

A follow-up PR should be made to pull the `mediaMetadata` when missing from request.

## How Have You Tested This?

<!-- Please describe in detail with reproducible steps how you tested your changes. -->

Tested on a personal server.
