### PR TITLE
Change: no compression when downloading library item as zip file

### DIFF
--- a/server/utils/zipHelpers.js
+++ b/server/utils/zipHelpers.js
@@ -7,7 +7,7 @@ module.exports.zipDirectoryPipe = (path, filename, res) => {
     res.attachment(filename)
 
     const archive = archiver('zip', {
-      zlib: { level: 9 } // Sets the compression level.
+      zlib: { level: 0 } // Sets the compression level.
     })
 
     // listen for all archive data to be written


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

This PR speeds up the endpoint for downloading the zip of a library item by removing compression.

## Which issue is fixed?

Partially fixes https://github.com/advplyr/audiobookshelf/issues/3081

## In-depth Description

Removing compression on downloads for library items greatly reduces CPU usage (removes costly compression, just streams directly from file to response). This does increase file size by about 2-3%, but removes the limit of 10-15 MBps (depending on hardware) for downloading a zip file. Compressing already compressed files does not really save any bandwidth. More discussion in https://github.com/advplyr/audiobookshelf/issues/3081#issuecomment-2526359501

This can increase download time if the network connection is slower than 10 MBps by about 2-3% due to the file size being slightly larger.

I did investigate adding the `Content-Length` header to give users a better "estimated time remaining", but this ended up being a bit difficult due to the length of the zip file not being a direct sum of each file size. https://stackoverflow.com/questions/10927442/calculate-size-of-zip-file-with-compression-level-0/19380600#19380600

## How have you tested this?

I have tested downloading over Ethernet, WiFi, and cellular data to benchmark each connection.

## Screenshots

N/A
