### PR TITLE
Refactor Feed model to create new feed for library item

### DIFF
--- a/server/models/Book.js
+++ b/server/models/Book.js
@@ -106,6 +106,9 @@ class Book extends Model {
     this.updatedAt
     /** @type {Date} */
     this.createdAt
+
+    /** @type {import('./Author')[]} - optional if expanded */
+    this.authors
   }
 
   static getOldBook(libraryItemExpanded) {
@@ -319,6 +322,32 @@ class Book extends Model {
         ]
       }
     )
+  }
+
+  /**
+   * Comma separated array of author names
+   * Requires authors to be loaded
+   *
+   * @returns {string}
+   */
+  get authorName() {
+    if (this.authors === undefined) {
+      Logger.error(`[Book] authorName: Cannot get authorName because authors are not loaded`)
+      return ''
+    }
+    return this.authors.map((au) => au.name).join(', ')
+  }
+  get includedAudioFiles() {
+    return this.audioFiles.filter((af) => !af.exclude)
+  }
+  get trackList() {
+    let startOffset = 0
+    return this.includedAudioFiles.map((af) => {
+      const track = structuredClone(af)
+      track.startOffset = startOffset
+      startOffset += track.duration
+      return track
+    })
   }
 }
 

--- a/server/models/FeedEpisode.js
+++ b/server/models/FeedEpisode.js
@@ -1,4 +1,8 @@
+const Path = require('path')
 const { DataTypes, Model } = require('sequelize')
+const uuidv4 = require('uuid').v4
+const Logger = require('../Logger')
+const date = require('../libs/dateAndTime')
 
 class FeedEpisode extends Model {
   constructor(values, options) {
@@ -40,29 +44,6 @@ class FeedEpisode extends Model {
     this.updatedAt
   }
 
-  getOldEpisode() {
-    const enclosure = {
-      url: this.enclosureURL,
-      size: this.enclosureSize,
-      type: this.enclosureType
-    }
-    return {
-      id: this.id,
-      title: this.title,
-      description: this.description,
-      enclosure,
-      pubDate: this.pubDate,
-      link: this.siteURL,
-      author: this.author,
-      explicit: this.explicit,
-      duration: this.duration,
-      season: this.season,
-      episode: this.episode,
-      episodeType: this.episodeType,
-      fullPath: this.filePath
-    }
-  }
-
   /**
    * Create feed episode from old model
    *
@@ -94,6 +75,144 @@ class FeedEpisode extends Model {
       filePath: oldFeedEpisode.fullPath,
       explicit: !!oldFeedEpisode.explicit
     }
+  }
+
+  /**
+   *
+   * @param {import('./LibraryItem').LibraryItemExpanded} libraryItemExpanded
+   * @param {import('./Feed')} feed
+   * @param {string} slug
+   * @param {import('./PodcastEpisode')} episode
+   */
+  static getFeedEpisodeObjFromPodcastEpisode(libraryItemExpanded, feed, slug, episode) {
+    return {
+      title: episode.title,
+      author: feed.author,
+      description: episode.description,
+      siteURL: feed.siteURL,
+      enclosureURL: `/feed/${slug}/item/${episode.id}/media${Path.extname(episode.audioFile.metadata.filename)}`,
+      enclosureType: episode.audioFile.mimeType,
+      enclosureSize: episode.audioFile.metadata.size,
+      pubDate: episode.pubDate,
+      season: episode.season,
+      episode: episode.episode,
+      episodeType: episode.episodeType,
+      duration: episode.audioFile.duration,
+      filePath: episode.audioFile.metadata.path,
+      explicit: libraryItemExpanded.media.explicit,
+      feedId: feed.id
+    }
+  }
+
+  /**
+   *
+   * @param {import('./LibraryItem').LibraryItemExpanded} libraryItemExpanded
+   * @param {import('./Feed')} feed
+   * @param {string} slug
+   * @param {import('sequelize').Transaction} transaction
+   * @returns {Promise<FeedEpisode[]>}
+   */
+  static async createFromPodcastEpisodes(libraryItemExpanded, feed, slug, transaction) {
+    const feedEpisodeObjs = []
+
+    // Sort podcastEpisodes by pubDate. episodic is newest to oldest. serial is oldest to newest.
+    if (feed.podcastType === 'episodic') {
+      libraryItemExpanded.media.podcastEpisodes.sort((a, b) => new Date(b.pubDate) - new Date(a.pubDate))
+    } else {
+      libraryItemExpanded.media.podcastEpisodes.sort((a, b) => new Date(a.pubDate) - new Date(b.pubDate))
+    }
+
+    for (const episode of libraryItemExpanded.media.podcastEpisodes) {
+      feedEpisodeObjs.push(this.getFeedEpisodeObjFromPodcastEpisode(libraryItemExpanded, feed, slug, episode))
+    }
+    Logger.info(`[FeedEpisode] Creating ${feedEpisodeObjs.length} episodes for feed ${feed.id}`)
+    return this.bulkCreate(feedEpisodeObjs, { transaction })
+  }
+
+  /**
+   * If chapters for an audiobook match the audio tracks then use chapter titles instead of audio file names
+   *
+   * @param {import('./LibraryItem').LibraryItemExpanded} libraryItemExpanded
+   * @returns {boolean}
+   */
+  static checkUseChapterTitlesForEpisodes(libraryItemExpanded) {
+    const tracks = libraryItemExpanded.media.trackList || []
+    const chapters = libraryItemExpanded.media.chapters || []
+    if (tracks.length !== chapters.length) return false
+    for (let i = 0; i < tracks.length; i++) {
+      if (Math.abs(chapters[i].start - tracks[i].startOffset) >= 1) {
+        return false
+      }
+    }
+    return true
+  }
+
+  /**
+   *
+   * @param {import('./LibraryItem').LibraryItemExpanded} libraryItemExpanded
+   * @param {import('./Feed')} feed
+   * @param {string} slug
+   * @param {import('./Book').AudioFileObject} audioTrack
+   * @param {boolean} useChapterTitles
+   * @param {string} [pubDateOverride]
+   */
+  static getFeedEpisodeObjFromAudiobookTrack(libraryItemExpanded, feed, slug, audioTrack, useChapterTitles, pubDateOverride = null) {
+    // Example: <pubDate>Fri, 04 Feb 2015 00:00:00 GMT</pubDate>
+    let timeOffset = isNaN(audioTrack.index) ? 0 : Number(audioTrack.index) * 1000 // Offset pubdate to ensure correct order
+    let episodeId = uuidv4()
+
+    // e.g. Track 1 will have a pub date before Track 2
+    const audiobookPubDate = pubDateOverride || date.format(new Date(libraryItemExpanded.createdAt.valueOf() + timeOffset), 'ddd, DD MMM YYYY HH:mm:ss [GMT]')
+
+    const contentUrl = `/feed/${slug}/item/${episodeId}/media${Path.extname(audioTrack.metadata.filename)}`
+    const media = libraryItemExpanded.media
+
+    let title = audioTrack.title
+    if (media.trackList.length == 1) {
+      // If audiobook is a single file, use book title instead of chapter/file title
+      title = media.title
+    } else {
+      if (useChapterTitles) {
+        // If audio track start and chapter start are within 1 seconds of eachother then use the chapter title
+        const matchingChapter = media.chapters.find((ch) => Math.abs(ch.start - audioTrack.startOffset) < 1)
+        if (matchingChapter?.title) title = matchingChapter.title
+      }
+    }
+
+    return {
+      id: episodeId,
+      title,
+      author: feed.author,
+      description: media.description || '',
+      siteURL: feed.siteURL,
+      enclosureURL: contentUrl,
+      enclosureType: audioTrack.mimeType,
+      enclosureSize: audioTrack.metadata.size,
+      pubDate: audiobookPubDate,
+      duration: audioTrack.duration,
+      filePath: audioTrack.metadata.path,
+      explicit: media.explicit,
+      feedId: feed.id
+    }
+  }
+
+  /**
+   *
+   * @param {import('./LibraryItem').LibraryItemExpanded} libraryItemExpanded
+   * @param {import('./Feed')} feed
+   * @param {string} slug
+   * @param {import('sequelize').Transaction} transaction
+   * @returns {Promise<FeedEpisode[]>}
+   */
+  static async createFromAudiobookTracks(libraryItemExpanded, feed, slug, transaction) {
+    const useChapterTitles = this.checkUseChapterTitlesForEpisodes(libraryItemExpanded)
+
+    const feedEpisodeObjs = []
+    for (const track of libraryItemExpanded.media.trackList) {
+      feedEpisodeObjs.push(this.getFeedEpisodeObjFromAudiobookTrack(libraryItemExpanded, feed, slug, track, useChapterTitles))
+    }
+    Logger.info(`[FeedEpisode] Creating ${feedEpisodeObjs.length} episodes for feed ${feed.id}`)
+    return this.bulkCreate(feedEpisodeObjs, { transaction })
   }
 
   /**
@@ -135,6 +254,29 @@ class FeedEpisode extends Model {
       onDelete: 'CASCADE'
     })
     FeedEpisode.belongsTo(feed)
+  }
+
+  getOldEpisode() {
+    const enclosure = {
+      url: this.enclosureURL,
+      size: this.enclosureSize,
+      type: this.enclosureType
+    }
+    return {
+      id: this.id,
+      title: this.title,
+      description: this.description,
+      enclosure,
+      pubDate: this.pubDate,
+      link: this.siteURL,
+      author: this.author,
+      explicit: this.explicit,
+      duration: this.duration,
+      season: this.season,
+      episode: this.episode,
+      episodeType: this.episodeType,
+      fullPath: this.filePath
+    }
   }
 }
 

--- a/server/models/LibraryItem.js
+++ b/server/models/LibraryItem.js
@@ -73,6 +73,9 @@ class LibraryItem extends Model {
     this.createdAt
     /** @type {Date} */
     this.updatedAt
+
+    /** @type {Book.BookExpanded|Podcast.PodcastExpanded} - only set when expanded */
+    this.media
   }
 
   /**
@@ -1123,6 +1126,24 @@ class LibraryItem extends Model {
         media.destroy()
       }
     })
+  }
+
+  /**
+   * Check if book or podcast library item has audio tracks
+   * Requires expanded library item
+   *
+   * @returns {boolean}
+   */
+  hasAudioTracks() {
+    if (!this.media) {
+      Logger.error(`[LibraryItem] hasAudioTracks: Library item "${this.id}" does not have media`)
+      return false
+    }
+    if (this.mediaType === 'book') {
+      return this.media.audioFiles?.length > 0
+    } else {
+      return this.media.podcastEpisodes?.length > 0
+    }
   }
 }
 

--- a/server/objects/Feed.js
+++ b/server/objects/Feed.js
@@ -101,64 +101,6 @@ class Feed {
     return true
   }
 
-  setFromItem(userId, slug, libraryItem, serverAddress, preventIndexing = true, ownerName = null, ownerEmail = null) {
-    const media = libraryItem.media
-    const mediaMetadata = media.metadata
-    const isPodcast = libraryItem.mediaType === 'podcast'
-
-    const feedUrl = `/feed/${slug}`
-    const author = isPodcast ? mediaMetadata.author : mediaMetadata.authorName
-
-    this.id = uuidv4()
-    this.slug = slug
-    this.userId = userId
-    this.entityType = 'libraryItem'
-    this.entityId = libraryItem.id
-    this.entityUpdatedAt = libraryItem.updatedAt
-    this.coverPath = media.coverPath || null
-    this.serverAddress = serverAddress
-    this.feedUrl = feedUrl
-
-    const coverFileExtension = this.coverPath ? Path.extname(media.coverPath) : null
-
-    this.meta = new FeedMeta()
-    this.meta.title = mediaMetadata.title
-    this.meta.description = mediaMetadata.description
-    this.meta.author = author
-    this.meta.imageUrl = media.coverPath ? `/feed/${slug}/cover${coverFileExtension}` : `/Logo.png`
-    this.meta.feedUrl = feedUrl
-    this.meta.link = `/item/${libraryItem.id}`
-    this.meta.explicit = !!mediaMetadata.explicit
-    this.meta.type = mediaMetadata.type
-    this.meta.language = mediaMetadata.language
-    this.meta.preventIndexing = preventIndexing
-    this.meta.ownerName = ownerName
-    this.meta.ownerEmail = ownerEmail
-
-    this.episodes = []
-    if (isPodcast) {
-      // PODCAST EPISODES
-      media.episodes.forEach((episode) => {
-        if (episode.updatedAt > this.entityUpdatedAt) this.entityUpdatedAt = episode.updatedAt
-
-        const feedEpisode = new FeedEpisode()
-        feedEpisode.setFromPodcastEpisode(libraryItem, serverAddress, slug, episode, this.meta)
-        this.episodes.push(feedEpisode)
-      })
-    } else {
-      // AUDIOBOOK EPISODES
-      const useChapterTitles = this.checkUseChapterTitlesForEpisodes(libraryItem)
-      media.tracks.forEach((audioTrack) => {
-        const feedEpisode = new FeedEpisode()
-        feedEpisode.setFromAudiobookTrack(libraryItem, serverAddress, slug, audioTrack, this.meta, useChapterTitles)
-        this.episodes.push(feedEpisode)
-      })
-    }
-
-    this.createdAt = Date.now()
-    this.updatedAt = Date.now()
-  }
-
   updateFromItem(libraryItem) {
     const media = libraryItem.media
     const mediaMetadata = media.metadata


### PR DESCRIPTION
## Brief summary

Begin migrating `Feed` and `FeedEpisode` to use the new model.

This PR updates the create feed for library item logic to use the new models in `/models` folder instead of the old models in the `/objects` folder.

## In-depth Description

The objective for the migration is to eventually remove the old models. In the meantime the API will return the same data so the new models will implement `toOldJSON` functions when necessary.

For the first step of the migration, creating feeds from library items is handled in the new `Feed` and `FeedEpisode` models.

This also adds necessary helper functions in the `LibraryItem` and `Book` models.

## How have you tested this?

Tested opening feeds for both audiobooks and podcasts. Tested opening feeds with options (prevent indexing, owner name, owner email).
