### PR TITLE
feat: Added Australia and New Zealand podcast regions

### DIFF
--- a/client/plugins/i18n.js
+++ b/client/plugins/i18n.js
@@ -42,6 +42,7 @@ Vue.prototype.$languageCodeOptions = Object.keys(languageCodeMap).map((code) => 
 
 // iTunes search API uses ISO 3166 country codes: https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
 const podcastSearchRegionMap = {
+  au: { label: 'Australia' },
   br: { label: 'Brasil' },
   be: { label: 'België / Belgique / Belgien' },
   cz: { label: 'Česko' },
@@ -57,6 +58,7 @@ const podcastSearchRegionMap = {
   hu: { label: 'Magyarország' },
   nl: { label: 'Nederland' },
   no: { label: 'Norge' },
+  nz: { label: 'New Zealand' },
   at: { label: 'Österreich' },
   pl: { label: 'Polska' },
   pt: { label: 'Portugal' },


### PR DESCRIPTION
## Brief summary

Added Australia and New Zealand podcast store regions

## Which issue is fixed?

Added AU/NZ podcast store regions

## In-depth Description

Pretty self explanatory

## How have you tested this?

<!-- Please describe in detail with reproducible steps how you tested your changes. -->

## Screenshots

<!-- If your PR includes any changes to the web client, please include screenshots or a short video from before and after your changes. -->
