### PR TITLE
Change: height of RSS feed preview to match aspect ratio

### DIFF
--- a/client/pages/config/rss-feeds.vue
+++ b/client/pages/config/rss-feeds.vue
@@ -25,7 +25,7 @@
           <tr v-for="feed in feeds" :key="feed.id" class="cursor-pointer h-12" @click="showFeed(feed)">
             <!--  -->
             <td>
-              <img :src="coverUrl(feed)" class="h-full w-full" />
+              <img :src="coverUrl(feed)" class="h-auto w-full" />
             </td>
             <!--  -->
             <td class="w-48 max-w-64 min-w-24 text-left truncate">


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

This PR forces the height of the image preview in the RSS feed to be square and match the size of the width.

## Which issue is fixed?

This should fix https://github.com/advplyr/audiobookshelf/issues/3748

## In-depth Description

This PR replaces the `h-full` with `h-auto`. I did play with changing this to be a `div` to force the images to be square, but the current behavior allows for rectangular aspect ratios so I stuck with `h-auto`.

The `h-full` attribute only seems to be an issue in Safari, as per #3748.

## How have you tested this?

Tested with square and rectangular covers. Tested with series and individual books.

Only tested in Firefox, because I do not have access to a Mac for testing on Safari.

## Screenshots

![image](https://github.com/user-attachments/assets/1bce3ea6-04f9-49dc-a301-7f70b4a5b587)

