### PR TITLE
Experimental proxy support by manually following redirects

### DIFF
--- a/server/Server.js
+++ b/server/Server.js
@@ -56,23 +56,24 @@ class Server {
     global.AllowCors = process.env.ALLOW_CORS === '1'
 
     if (process.env.EXP_PROXY_SUPPORT === '1') {
-      Logger.info(`[Server] Experimental Proxy Support Enabled, SSRF Request Filter was Disabled`);
+      // https://github.com/advplyr/audiobookshelf/pull/3754
+      Logger.info(`[Server] Experimental Proxy Support Enabled, SSRF Request Filter was Disabled`)
       global.DisableSsrfRequestFilter = () => true
-      
-      axios.defaults.maxRedirects = 0;
+
+      axios.defaults.maxRedirects = 0
       axios.interceptors.response.use(
-        response => response,
-        error => {
+        (response) => response,
+        (error) => {
           if ([301, 302].includes(error.response?.status)) {
             return axios({
               ...error.config,
-              url: error.response.headers.location,
-            });
+              url: error.response.headers.location
+            })
           }
-    
-          return Promise.reject(error);
+
+          return Promise.reject(error)
         }
-      );
+      )
     } else if (process.env.DISABLE_SSRF_REQUEST_FILTER === '1') {
       Logger.info(`[Server] SSRF Request Filter Disabled`)
       global.DisableSsrfRequestFilter = () => true

--- a/server/Server.js
+++ b/server/Server.js
@@ -6,6 +6,7 @@ const util = require('util')
 const fs = require('./libs/fsExtra')
 const fileUpload = require('./libs/expressFileupload')
 const cookieParser = require('cookie-parser')
+const axios = require('axios')
 
 const { version } = require('../package.json')
 
@@ -54,7 +55,25 @@ class Server {
     global.XAccel = process.env.USE_X_ACCEL
     global.AllowCors = process.env.ALLOW_CORS === '1'
 
-    if (process.env.DISABLE_SSRF_REQUEST_FILTER === '1') {
+    if (process.env.EXP_PROXY_SUPPORT === '1') {
+      Logger.info(`[Server] Experimental Proxy Support Enabled, SSRF Request Filter was Disabled`);
+      global.DisableSsrfRequestFilter = () => true
+      
+      axios.defaults.maxRedirects = 0;
+      axios.interceptors.response.use(
+        response => response,
+        error => {
+          if ([301, 302].includes(error.response?.status)) {
+            return axios({
+              ...error.config,
+              url: error.response.headers.location,
+            });
+          }
+    
+          return Promise.reject(error);
+        }
+      );
+    } else if (process.env.DISABLE_SSRF_REQUEST_FILTER === '1') {
       Logger.info(`[Server] SSRF Request Filter Disabled`)
       global.DisableSsrfRequestFilter = () => true
     } else if (process.env.SSRF_REQUEST_FILTER_WHITELIST?.length) {


### PR DESCRIPTION
## Brief summary
Make downloading podcast episodes work when `HTTP_PROXY`/`HTTPS_PROXY` environment variable are present.

## Which issue is fixed?

<!-- Which issue number does this PR fix? Ex: "Fixes #1234" -->
#1313 

## In-depth Description

<!--
Describe your solution in more depth.
How does it work? Why is this the best solution?
Does it solve a problem that affects multiple users or is this an edge case for your setup?
-->
Mannually following redirects seems to fix the bug in axios when using a proxy. It is merely a workaround while we wait to upgrade axios / replace pkg like mentionned [here](https://github.com/advplyr/audiobookshelf/pull/2666#issuecomment-1974083316).


## How have you tested this?

<!-- Please describe in detail with reproducible steps how you tested your changes. -->
Ran a forward proxy locally using docker, and added both `HTTP_PROXY` and `HTTPS_PROXY` to the start command. Then, I searched and downloaded a few podcast episodes.

