### PR TITLE
Book query optimizations

### DIFF
--- a/server/migrations/changelog.md
+++ b/server/migrations/changelog.md
@@ -12,3 +12,4 @@ Please add a record of every database migration that you create to this file. Th
 | v2.17.4        | v2.17.4-use-subfolder-for-oidc-redirect-uris | Save subfolder to OIDC redirect URIs to support existing installations                                        |
 | v2.17.5        | v2.17.5-remove-host-from-feed-urls           | removes the host (serverAddress) from URL columns in the feeds and feedEpisodes tables                        |
 | v2.17.6        | v2.17.6-share-add-isdownloadable             | Adds the isDownloadable column to the mediaItemShares table                                                   |
+| v2.17.7        | v2.17.7-add-indices                          | Adds indices to the libraryItems and books tables to reduce query times                                       |

--- a/server/migrations/v2.17.7-add-indices.js
+++ b/server/migrations/v2.17.7-add-indices.js
@@ -1,0 +1,81 @@
+/**
+ * @typedef MigrationContext
+ * @property {import('sequelize').QueryInterface} queryInterface - a suquelize QueryInterface object.
+ * @property {import('../Logger')} logger - a Logger object.
+ *
+ * @typedef MigrationOptions
+ * @property {MigrationContext} context - an object containing the migration context.
+ */
+
+const migrationVersion = '2.17.7'
+const migrationName = `${migrationVersion}-add-indices`
+const loggerPrefix = `[${migrationVersion} migration]`
+
+/**
+ * This upward migration adds some indices to the libraryItems and books tables to improve query performance
+ *
+ * @param {MigrationOptions} options - an object containing the migration context.
+ * @returns {Promise<void>} - A promise that resolves when the migration is complete.
+ */
+async function up({ context: { queryInterface, logger } }) {
+  // Upwards migration script
+  logger.info(`${loggerPrefix} UPGRADE BEGIN: ${migrationName}`)
+
+  await addIndex(queryInterface, logger, 'libraryItems', ['libraryId', 'mediaType', 'size'])
+
+  logger.info(`${loggerPrefix} UPGRADE END: ${migrationName}`)
+}
+
+/**
+ * This downward migration script removes the indices added in the upward migration script
+ *
+ * @param {MigrationOptions} options - an object containing the migration context.
+ * @returns {Promise<void>} - A promise that resolves when the migration is complete.
+ */
+async function down({ context: { queryInterface, logger } }) {
+  // Downward migration script
+  logger.info(`${loggerPrefix} DOWNGRADE BEGIN: ${migrationName}`)
+
+  await removeIndex(queryInterface, logger, 'libraryItems', ['libraryId', 'mediaType', 'size'])
+
+  logger.info(`${loggerPrefix} DOWNGRADE END: ${migrationName}`)
+}
+
+/**
+ * Utility function to add an index to a table. If the index already exists, it logs a message and continues.
+ *
+ * @param {import('sequelize').QueryInterface} queryInterface
+ * @param {import ('../Logger')} logger
+ * @param {string} tableName
+ * @param {string[]} columns
+ */
+async function addIndex(queryInterface, logger, tableName, columns) {
+  try {
+    logger.info(`${loggerPrefix} adding index [${columns.join(', ')}] to table "${tableName}"`)
+    await queryInterface.addIndex(tableName, columns)
+    logger.info(`${loggerPrefix} added index [${columns.join(', ')}] to table "${tableName}"`)
+  } catch (error) {
+    if (error.name === 'SequelizeDatabaseError' && error.message.includes('already exists')) {
+      logger.info(`${loggerPrefix} index [${columns.join(', ')}] for table "${tableName}" already exists`)
+    } else {
+      throw error
+    }
+  }
+}
+
+/**
+ * Utility function to remove an index from a table.
+ * Sequelize implemets it using DROP INDEX IF EXISTS, so it won't throw an error if the index doesn't exist.
+ *
+ * @param {import('sequelize').QueryInterface} queryInterface
+ * @param {import ('../Logger')} logger
+ * @param {string} tableName
+ * @param {string[]} columns
+ */
+async function removeIndex(queryInterface, logger, tableName, columns) {
+  logger.info(`${loggerPrefix} removing index [${columns.join(', ')}] from table "${tableName}"`)
+  await queryInterface.removeIndex(tableName, columns)
+  logger.info(`${loggerPrefix} removed index [${columns.join(', ')}] from table "${tableName}"`)
+}
+
+module.exports = { up, down }

--- a/server/migrations/v2.17.7-add-indices.js
+++ b/server/migrations/v2.17.7-add-indices.js
@@ -22,6 +22,7 @@ async function up({ context: { queryInterface, logger } }) {
   logger.info(`${loggerPrefix} UPGRADE BEGIN: ${migrationName}`)
 
   await addIndex(queryInterface, logger, 'libraryItems', ['libraryId', 'mediaType', 'size'])
+  await addIndex(queryInterface, logger, 'books', ['duration'])
 
   logger.info(`${loggerPrefix} UPGRADE END: ${migrationName}`)
 }
@@ -37,6 +38,7 @@ async function down({ context: { queryInterface, logger } }) {
   logger.info(`${loggerPrefix} DOWNGRADE BEGIN: ${migrationName}`)
 
   await removeIndex(queryInterface, logger, 'libraryItems', ['libraryId', 'mediaType', 'size'])
+  await removeIndex(queryInterface, logger, 'books', ['duration'])
 
   logger.info(`${loggerPrefix} DOWNGRADE END: ${migrationName}`)
 }

--- a/server/models/Book.js
+++ b/server/models/Book.js
@@ -321,10 +321,10 @@ class Book extends Model {
           // },
           {
             fields: ['publishedYear']
+          },
+          {
+            fields: ['duration']
           }
-          // {
-          //   fields: ['duration']
-          // }
         ]
       }
     )

--- a/server/models/LibraryItem.js
+++ b/server/models/LibraryItem.js
@@ -1062,6 +1062,9 @@ class LibraryItem extends Model {
             fields: ['libraryId', 'mediaType']
           },
           {
+            fields: ['libraryId', 'mediaType', 'size']
+          },
+          {
             fields: ['libraryId', 'mediaId', 'mediaType']
           },
           {


### PR DESCRIPTION
## Brief summary

This adds indices to significantly improve database library query time when sorting by size or duration.

## Which issue is fixed?

There's no issue. I encountered this while working on PR #3726.

## In-depth Description

The following query in `libraryItemsBookFilters.js` is where most of books fetch time is spent and its performance heavily depends on `sortOrder`. When fast scrolling on the library page happens, this can lead to choking on the server if a number of page requests are handled concurrently.

```js
    const { rows: books, count } = await Database.bookModel.findAndCountAll({
      where: bookWhere,
      distinct: true,
      attributes: bookAttributes,
      replacements,
      include: [
        {
          model: Database.libraryItemModel,
          required: true,
          where: libraryItemWhere,
          include: libraryItemIncludes
        },
        seriesInclude,
        authorInclude,
        ...bookIncludes
      ],
      order: sortOrder,
      subQuery: false,
      limit: limit || null,
      offset
    })
```

I fixed a couple of the easy cases by introducing indices on size and duration.
This leads to a significant improvement in the query performance when paging through the library with sortBy size or duration.

I only dealt with size and duration for now because they were the easiest. Other sort orders are either already covered by existing indices, or they're trickier to optimize because of the existing database schema (e.g. sorting by author). Maybe I'll try to improve them in a future PR.

## How have you tested this?

I tested by running 35 consecutive page requests, by scrolling down the library page. There was no parallel fetching.

### Sorting by size

Current:

```
Histogram {
  min: 78,
  max: 1048,
  mean: 588.3714285714286,
  exceeds: 0,
  stddev: 305.3454330252669,
  count: 35,
  percentiles: SafeMap(8) [Map] {
    0 => 78,
    50 => 549,
    75 => 870,
    87.5 => 983,
    93.75 => 1019,
    96.875 => 1023,
    98.4375 => 1048,
    100 => 1048
  }
}
```

After adding index on `(library_id, media_type, size)` on table `libraryItems`:

```
Histogram {
  min: 37,
  max: 70,
  mean: 46.82857142857143,
  exceeds: 0,
  stddev: 5.940109254818776,
  count: 35,
  percentiles: SafeMap(8) [Map] {
    0 => 37,
    50 => 46,
    75 => 49,
    87.5 => 53,
    93.75 => 55,
    96.875 => 55,
    98.4375 => 70,
    100 => 70
  }
}
```

### Sorting by duration

Current:

```
histogram: Histogram {
  min: 72,
  max: 258,
  mean: 162.82857142857142,
  exceeds: 0,
  stddev: 46.34497088714818,
  count: 35,
  percentiles: SafeMap(8) [Map] {
    0 => 72,
    50 => 154,
    75 => 182,
    87.5 => 238,
    93.75 => 254,
    96.875 => 254,
    98.4375 => 258,
    100 => 258
  }
}
```

After adding index on `duration` on table `books`:

```
Histogram {
  min: 25,
  max: 61,
  mean: 30.542857142857144,
  exceeds: 0,
  stddev: 6.030128438067621,
  count: 35,
  percentiles: SafeMap(8) [Map] {
    0 => 25,
    50 => 29,
    75 => 32,
    87.5 => 34,
    93.75 => 37,
    96.875 => 37,
    98.4375 => 61,
    100 => 61
  }
}
```

As you can the indices improve performance significantly.

One thing to note here is that even with the added index, the query performance slowly degrades with increasing offset.
This is because the larger the offset, the more records need to be examined to satisfy the query (this is a known issue when working with offsets). There's a technique to deal with this (keyset pagination), but it is a bit more tricky to implement. If you think it's worth the effort, I'll look into it.