### PR TITLE
Feed episode IDs changing on refresh & several other refresh issues

### DIFF
--- a/server/managers/RssFeedManager.js
+++ b/server/managers/RssFeedManager.js
@@ -98,10 +98,21 @@ class RssFeedManager {
             podcastId: feed.entity.mediaId
           },
           attributes: ['id', 'updatedAt'],
-          order: [['createdAt', 'DESC']]
+          order: [['updatedAt', 'DESC']]
         })
+
         if (mostRecentPodcastEpisode && mostRecentPodcastEpisode.updatedAt > newEntityUpdatedAt) {
           newEntityUpdatedAt = mostRecentPodcastEpisode.updatedAt
+        }
+      } else {
+        const book = await Database.bookModel.findOne({
+          where: {
+            id: feed.entity.mediaId
+          },
+          attributes: ['id', 'updatedAt']
+        })
+        if (book && book.updatedAt > newEntityUpdatedAt) {
+          newEntityUpdatedAt = book.updatedAt
         }
       }
 
@@ -111,7 +122,7 @@ class RssFeedManager {
         attributes: ['id', 'updatedAt'],
         include: {
           model: Database.bookModel,
-          attributes: ['id'],
+          attributes: ['id', 'updatedAt'],
           through: {
             attributes: []
           },
@@ -125,8 +136,9 @@ class RssFeedManager {
       let newEntityUpdatedAt = feed.entity.updatedAt
 
       const mostRecentItemUpdatedAt = feed.entity.books.reduce((mostRecent, book) => {
-        if (book.libraryItem.updatedAt > mostRecent) {
-          return book.libraryItem.updatedAt
+        let updatedAt = book.libraryItem.updatedAt > book.updatedAt ? book.libraryItem.updatedAt : book.updatedAt
+        if (updatedAt > mostRecent) {
+          return updatedAt
         }
         return mostRecent
       }, 0)

--- a/server/models/Feed.js
+++ b/server/models/Feed.js
@@ -190,7 +190,8 @@ class Feed extends Model {
     const booksWithTracks = collectionExpanded.books.filter((book) => book.includedAudioFiles.length)
 
     const entityUpdatedAt = booksWithTracks.reduce((mostRecent, book) => {
-      return book.libraryItem.updatedAt > mostRecent ? book.libraryItem.updatedAt : mostRecent
+      const updatedAt = book.libraryItem.updatedAt > book.updatedAt ? book.libraryItem.updatedAt : book.updatedAt
+      return updatedAt > mostRecent ? updatedAt : mostRecent
     }, collectionExpanded.updatedAt)
 
     const firstBookWithCover = booksWithTracks.find((book) => book.coverPath)
@@ -278,7 +279,8 @@ class Feed extends Model {
   static getFeedObjForSeries(userId, seriesExpanded, slug, serverAddress, feedOptions = null) {
     const booksWithTracks = seriesExpanded.books.filter((book) => book.includedAudioFiles.length)
     const entityUpdatedAt = booksWithTracks.reduce((mostRecent, book) => {
-      return book.libraryItem.updatedAt > mostRecent ? book.libraryItem.updatedAt : mostRecent
+      const updatedAt = book.libraryItem.updatedAt > book.updatedAt ? book.libraryItem.updatedAt : book.updatedAt
+      return updatedAt > mostRecent ? updatedAt : mostRecent
     }, seriesExpanded.updatedAt)
 
     const firstBookWithCover = booksWithTracks.find((book) => book.coverPath)
@@ -474,8 +476,6 @@ class Feed extends Model {
   async updateFeedForEntity() {
     /** @type {typeof import('./FeedEpisode')} */
     const feedEpisodeModel = this.sequelize.models.feedEpisode
-
-    this.feedEpisodes = await this.getFeedEpisodes()
 
     let feedObj = null
     let feedEpisodeCreateFunc = null


### PR DESCRIPTION
## Brief summary

Feed episodes were dropping and re-creating the table record anytime a feed needed to be updated. Since the generated RSS feed uses the content url as the GUID this was changing on every update causing podcast clients to think it is a new episode.

## Which issue is fixed?

https://github.com/advplyr/audiobookshelf/issues/3757

## In-depth Description

To fix this the existing `FeedEpisode` records are loaded and the `filePath` is compared to see if a `FeedEpisode` should be updated. So if the filepath changes then the generated RSS feed guid will change.
Another option could be using the inode value but this would require storing the inode value in the `FeedEpisode` model and would cause issues for users using a file system that doesn't support unique inode values.

This fixes 3 other issues that I found while testing.
1. For audiobook feeds. When book chapters are updated the Book.updatedAt timestamp changes but the LibraryItem.updatedAt timestamp does not. So changing book chapters wasn't causing a refresh of the feed. To fix this I add an additional check to see if the Book.updatedAt is more recent than the LibraryItem.updatedAt and use that as the Feed.entityUpdatedAt if so.
2. For podcast feeds. The check was using the most recent PodcastEpisode.createdAt instead of PodcastEpisode.updatedAt. So updating a podcast episode wasn't refreshing the feed.
3. For collection & series feeds. When removing a book from the library that belonged to the series or collection the feed would not refresh since it is checking the most recent updatedAt timestamp of the available books. To fix this I added a check to see if the total number of audio tracks has changed.

## How have you tested this?

Opened a feed for a podcast, an audiobook, a collection and a series. Tested adding/removing/updating the entity and child entities.
