### PR TITLE
Fix ffmpeg concat file escaping

### DIFF
--- a/server/utils/ffmpegHelpers.js
+++ b/server/utils/ffmpegHelpers.js
@@ -8,8 +8,8 @@ const { filePathToPOSIX, copyToExisting } = require('./fileUtils')
 const LibraryItem = require('../objects/LibraryItem')
 
 function escapeSingleQuotes(path) {
-  // return path.replace(/'/g, '\'\\\'\'')
-  return filePathToPOSIX(path).replace(/ /g, '\\ ').replace(/'/g, "\\'")
+  // A ' within a quoted string is escaped with '\'' in ffmpeg (see https://www.ffmpeg.org/ffmpeg-utils.html#Quoting-and-escaping)
+  return filePathToPOSIX(path).replace(/'/g, "'\\''")
 }
 
 // Returns first track start time
@@ -33,7 +33,7 @@ async function writeConcatFile(tracks, outputPath, startTime = 0) {
 
   var tracksToInclude = tracks.filter((t) => t.index >= trackToStartWithIndex)
   var trackPaths = tracksToInclude.map((t) => {
-    var line = 'file ' + escapeSingleQuotes(t.metadata.path) + '\n' + `duration ${t.duration}`
+    var line = "file '" + escapeSingleQuotes(t.metadata.path) + "'\n" + `duration ${t.duration}`
     return line
   })
   var inputstr = trackPaths.join('\n\n')


### PR DESCRIPTION
## Brief summary

This fixes an escaping issue causing UNC paths not to be read correctly in ffmpeg concat files generated by ABS

## Which issue is fixed?

Fixes the re-opened [audiobookshelf-windows issue #29](https://github.com/mikiher/audiobookshelf-windows/issues/29#issuecomment-2547238819).

## In-depth Description

The issue was that the \\\\ chatacters in the beginning of the UNC path were not escaped in the ffmpeg concat file, and therefore the path was mangled. 

Rather than escaping those, I fixed this by surrounding file paths in the concat file with single quotes (and consequently also modifying `escapeSingleQuotes`)

This way is safer, since now the only character that needs escaping inside a file name is a single quote, which the aptly named `escapeSingleQuotes` function now really does - no other characters (like spaces or backslashes) need to be escaped.

## How have you tested this?

I tested with a combination of UNC paths that also contain single quotes.
I tested both codepaths that call `writeConcatFile` (encode m4b, and stream).