### PR TITLE
Fixed Day Calculation Logic for Stats Page

### DIFF
--- a/client/components/stats/Heatmap.vue
+++ b/client/components/stats/Heatmap.vue
@@ -197,6 +197,18 @@ export default {
       let maxValue = 0
       let minValue = 0
 
+      const wholeYearDays = (52 * 7 + this.dayOfWeekToday);
+      const wholeYear = this.$addDaysToToday(-wholeYearDays + 1)
+
+      for (let i = 0; i < wholeYearDays; i++) {
+        const date = i === 0 ? wholeYear : this.$addDaysToDate(wholeYear, i)
+        const dateString = this.$formatJsDate(date, 'yyyy-MM-dd')
+        console.log(dateString)
+        if ((this.daysListening[dateString] || 0) > 0) {
+          this.daysListenedInTheLastYear++
+        }
+      }
+
       const dates = []
       for (let i = 0; i < this.daysToShow + 1; i++) {
         const date = i === 0 ? this.firstWeekStart : this.$addDaysToDate(this.firstWeekStart, i)
@@ -215,7 +227,6 @@ export default {
         dates.push(dateObj)
 
         if (dateObj.value > 0) {
-          this.daysListenedInTheLastYear++
           if (dateObj.value > maxValue) maxValue = dateObj.value
           if (!minValue || dateObj.value < minValue) minValue = dateObj.value
         }

--- a/client/components/stats/Heatmap.vue
+++ b/client/components/stats/Heatmap.vue
@@ -203,7 +203,6 @@ export default {
       for (let i = 0; i < wholeYearDays; i++) {
         const date = i === 0 ? wholeYear : this.$addDaysToDate(wholeYear, i)
         const dateString = this.$formatJsDate(date, 'yyyy-MM-dd')
-        console.log(dateString)
         if ((this.daysListening[dateString] || 0) > 0) {
           this.daysListenedInTheLastYear++
         }


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

The calculation of the days listened was based on the days with a displayed value. On a smaller scale, not all days of the last year were rendered. This PR changes the calculation of days to include those outside of the rendered days.


While I tried to incorporating the logic into the current loop, I failed because the day's position depends on "i," which would need to be expanded. Maybe I missed something, but the added burden of either going from back to front or adding logic that calculates the columns and rows based on the viewed days would significantly complicate the logic. Therefore some overhead is added by this PR

## Which issue is fixed?

Discord

## How have you tested this?

Mobile and Desktop, on a "Production" server
