### PR TITLE
API Cache Manager route uses case-insensitive match

### DIFF
--- a/server/managers/ApiCacheManager.js
+++ b/server/managers/ApiCacheManager.js
@@ -42,6 +42,8 @@ class ApiCacheManager {
         Logger.debug(`[ApiCacheManager] Skipping cache for random sort`)
         return next()
       }
+      // Force URL to be lower case for matching against routes
+      req.url = req.url.toLowerCase()
       const key = { user: req.user.username, url: req.url }
       const stringifiedKey = JSON.stringify(key)
       Logger.debug(`[ApiCacheManager] count: ${this.cache.size} size: ${this.cache.calculatedSize}`)

--- a/server/routers/ApiRouter.js
+++ b/server/routers/ApiRouter.js
@@ -65,7 +65,7 @@ class ApiRouter {
     //
     // Library Routes
     //
-    this.router.get(/^\/libraries/, this.apiCacheManager.middleware)
+    this.router.get(/^\/libraries/i, this.apiCacheManager.middleware)
     this.router.post('/libraries', LibraryController.create.bind(this))
     this.router.get('/libraries', LibraryController.findAll.bind(this))
     this.router.get('/libraries/:id', LibraryController.middleware.bind(this), LibraryController.findOne.bind(this))


### PR DESCRIPTION
## Brief summary

Fix case-sensitive matching for API Cache Manager.

## Which issue is fixed?

CodeQL issue from PR #3335.
Workflow output: https://github.com/advplyr/audiobookshelf/pull/3335/checks?check_run_id=35084757148

## In-depth Description

https://github.com/advplyr/audiobookshelf/pull/3335#issuecomment-2567188052
This PR changes the regex path matching to be case insensitive for the API Cache Manager. Two methods I found were to force all request URLs to be lowercase, or to ensure that the regex matches against a case-insensitive string. I chose to use case-insensitive matching for now due to some routes potentially being case sensitive, such as:
`DELETE /api/tags/:tag`
`DELETE /api/genres/:genre`

## How have you tested this?

I changed various API calls in the web client to use various capitalization for library API endpoints and verified that everything was still routed correctly. The API Cache Manager continued to have cache hits and return data correctly.

## Screenshots

N/A
