### PR TITLE
Fix remove episode from playlist

### DIFF
--- a/server/Database.js
+++ b/server/Database.js
@@ -695,6 +695,27 @@ class Database {
       await book.destroy()
     }
 
+    const playlistMediaItemsWithNoMediaItem = await this.playlistMediaItemModel.findAll({
+      include: [
+        {
+          model: this.bookModel,
+          attributes: ['id']
+        },
+        {
+          model: this.podcastEpisodeModel,
+          attributes: ['id']
+        }
+      ],
+      where: {
+        '$book.id$': null,
+        '$podcastEpisode.id$': null
+      }
+    })
+    for (const playlistMediaItem of playlistMediaItemsWithNoMediaItem) {
+      Logger.warn(`Found playlistMediaItem with no book or podcastEpisode - removing it`)
+      await playlistMediaItem.destroy()
+    }
+
     // Remove empty series
     const emptySeries = await this.seriesModel.findAll({
       include: {

--- a/server/controllers/LibraryItemController.js
+++ b/server/controllers/LibraryItemController.js
@@ -971,6 +971,7 @@ class LibraryItemController {
       }
     } else if (req.libraryItem.media.podcastEpisodes.some((ep) => ep.audioFile.ino === req.params.fileid)) {
       const episodeToRemove = req.libraryItem.media.podcastEpisodes.find((ep) => ep.audioFile.ino === req.params.fileid)
+      await Database.playlistModel.removeMediaItemsFromPlaylists([episodeToRemove.id])
       await episodeToRemove.destroy()
 
       req.libraryItem.media.podcastEpisodes = req.libraryItem.media.podcastEpisodes.filter((ep) => ep.audioFile.ino !== req.params.fileid)

--- a/server/models/Playlist.js
+++ b/server/models/Playlist.js
@@ -1,5 +1,6 @@
 const { DataTypes, Model, Op } = require('sequelize')
 const Logger = require('../Logger')
+const SocketAuthority = require('../SocketAuthority')
 
 class Playlist extends Model {
   constructor(values, options) {
@@ -161,6 +162,49 @@ class Playlist extends Model {
       playlists.push(playlist)
     }
     return playlists
+  }
+
+  /**
+   * Removes media items and re-orders playlists
+   *
+   * @param {string[]} mediaItemIds
+   */
+  static async removeMediaItemsFromPlaylists(mediaItemIds) {
+    if (!mediaItemIds?.length) return
+
+    const playlistsWithItem = await this.getPlaylistsForMediaItemIds(mediaItemIds)
+
+    if (!playlistsWithItem.length) return
+
+    for (const playlist of playlistsWithItem) {
+      let numMediaItems = playlist.playlistMediaItems.length
+
+      let order = 1
+      // Remove items in playlist and re-order
+      for (const playlistMediaItem of playlist.playlistMediaItems) {
+        if (mediaItemIds.includes(playlistMediaItem.mediaItemId)) {
+          await playlistMediaItem.destroy()
+          numMediaItems--
+        } else {
+          if (playlistMediaItem.order !== order) {
+            playlistMediaItem.update({
+              order
+            })
+          }
+          order++
+        }
+      }
+
+      // If playlist is now empty then remove it
+      const jsonExpanded = await playlist.getOldJsonExpanded()
+      if (!numMediaItems) {
+        Logger.info(`[ApiRouter] Playlist "${playlist.name}" has no more items - removing it`)
+        await playlist.destroy()
+        SocketAuthority.clientEmitter(playlist.userId, 'playlist_removed', jsonExpanded)
+      } else {
+        SocketAuthority.clientEmitter(playlist.userId, 'playlist_updated', jsonExpanded)
+      }
+    }
   }
 
   /**

--- a/server/routers/ApiRouter.js
+++ b/server/routers/ApiRouter.js
@@ -361,36 +361,7 @@ class ApiRouter {
     }
 
     // remove item from playlists
-    const playlistsWithItem = await Database.playlistModel.getPlaylistsForMediaItemIds(mediaItemIds)
-    for (const playlist of playlistsWithItem) {
-      let numMediaItems = playlist.playlistMediaItems.length
-
-      let order = 1
-      // Remove items in playlist and re-order
-      for (const playlistMediaItem of playlist.playlistMediaItems) {
-        if (mediaItemIds.includes(playlistMediaItem.mediaItemId)) {
-          await playlistMediaItem.destroy()
-          numMediaItems--
-        } else {
-          if (playlistMediaItem.order !== order) {
-            playlistMediaItem.update({
-              order
-            })
-          }
-          order++
-        }
-      }
-
-      // If playlist is now empty then remove it
-      const jsonExpanded = await playlist.getOldJsonExpanded()
-      if (!numMediaItems) {
-        Logger.info(`[ApiRouter] Playlist "${playlist.name}" has no more items - removing it`)
-        await playlist.destroy()
-        SocketAuthority.clientEmitter(playlist.userId, 'playlist_removed', jsonExpanded)
-      } else {
-        SocketAuthority.clientEmitter(playlist.userId, 'playlist_updated', jsonExpanded)
-      }
-    }
+    await Database.playlistModel.removeMediaItemsFromPlaylists(mediaItemIds)
 
     // Close rss feed - remove from db and emit socket event
     await RssFeedManager.closeFeedForEntityId(libraryItemId)


### PR DESCRIPTION
## Brief summary

Deleting an audio file for a podcast episode from the library files table will remove the associated podcast episode.
When removing an episode in that way the playlist media item was not getting removed.
This caused a crash when querying for that playlist.

## Which issue is fixed?

Fixes https://github.com/advplyr/audiobookshelf/issues/3784

## In-depth Description

To solve the crash the `cleanDatabase` startup function will remove any `playlistMediaItem` records with no associated media item.
In fixing the underlying issue I also added a missing check to remove `mediaProgress` records for that episode.

## How have you tested this?

Tested with both podcast and book playlists deleting the episode/book both from the UI and manually from the database.
