### PR TITLE
Enable subdirectory support by default

### DIFF
--- a/client/nuxt.config.js
+++ b/client/nuxt.config.js
@@ -1,6 +1,6 @@
 const pkg = require('./package.json')
 
-const routerBasePath = process.env.ROUTER_BASE_PATH || ''
+const routerBasePath = process.env.ROUTER_BASE_PATH || '/audiobookshelf'
 const serverHostUrl = process.env.NODE_ENV === 'production' ? '' : 'http://localhost:3333'
 const serverPaths = ['api/', 'public/', 'hls/', 'auth/', 'feed/', 'status', 'login', 'logout', 'init']
 const proxy = Object.fromEntries(serverPaths.map((path) => [`${routerBasePath}/${path}`, { target: process.env.NODE_ENV !== 'production' ? serverHostUrl : '/' }]))

--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ const CONFIG_PATH = inputConfig || process.env.CONFIG_PATH || Path.resolve('conf
 const METADATA_PATH = inputMetadata || process.env.METADATA_PATH || Path.resolve('metadata')
 const SOURCE = options.source || process.env.SOURCE || 'debian'
 
-const ROUTER_BASE_PATH = process.env.ROUTER_BASE_PATH || ''
+const ROUTER_BASE_PATH = process.env.ROUTER_BASE_PATH || '/audiobookshelf'
 
 console.log(`Running in ${process.env.NODE_ENV} mode.`)
 console.log(`Options: CONFIG_PATH=${CONFIG_PATH}, METADATA_PATH=${METADATA_PATH}, PORT=${PORT}, HOST=${HOST}, SOURCE=${SOURCE}, ROUTER_BASE_PATH=${ROUTER_BASE_PATH}`)

--- a/prod.js
+++ b/prod.js
@@ -25,7 +25,7 @@ const CONFIG_PATH = inputConfig || process.env.CONFIG_PATH || Path.resolve('conf
 const METADATA_PATH = inputMetadata || process.env.METADATA_PATH || Path.resolve('metadata')
 const SOURCE = options.source || process.env.SOURCE || 'debian'
 
-const ROUTER_BASE_PATH = process.env.ROUTER_BASE_PATH || ''
+const ROUTER_BASE_PATH = process.env.ROUTER_BASE_PATH || '/audiobookshelf'
 
 console.log(process.env.NODE_ENV, 'Config', CONFIG_PATH, METADATA_PATH)
 


### PR DESCRIPTION
## Brief summary

Switch to enabling subdirectory support with `/audiobookshelf` on the server and web client, according to the plan laid out in discussion #3535.

## Which issue is fixed?

This finally fixes #385

Users will now be able to set their reverse proxies to proxy `/audiobookshelf` subdirectory requests

## In-depth Description

This is the last step in supporting subdirectory with the existing static site generation approach. 

The plan is described in detail in #3535.

As a reminder, this will set a fixed subdirectory of `/audiobookshelf` on the web client (non-subdirectory paths will get rewritten by the server), and the server will support both subdirectory requests (with `/audiobookshelf` prefix) and non-subdirectory requests (with no prefix).

_Note_: Mobile app support for subdirectory is already implemented and checked in with audiobookshelf-app PR [#1417](https://github.com/advplyr/audiobookshelf-app/pull/1417), but is pending release of a new version. Other mobile clients that would like to support subdirectory access **will likely need to make some changes** in the spirit of that PR.

## How have you tested this?

This PR just switches the feature on by default. 

The many changes required to make this happen were previously tested in respective previous PRs, and were tested again to make sure they still worked now.

One thing I haven't tested properly is the reverse proxy part, since my reverse proxy (on my Synology NAS) doesn't support support subdirectory proxying. I am sure this works well once you set it up on a supporting reverse proxy (like NGINX), but haven't tested this myself.