### PR TITLE
Episode table refresh fixes

### DIFF
--- a/client/components/tables/podcast/LazyEpisodesTable.vue
+++ b/client/components/tables/podcast/LazyEpisodesTable.vue
@@ -80,7 +80,8 @@ export default {
       episodeComponentRefs: {},
       windowHeight: 0,
       episodesTableOffsetTop: 0,
-      episodeRowHeight: 176
+      episodeRowHeight: 176,
+      currScrollTop: 0
     }
   },
   watch: {
@@ -484,9 +485,8 @@ export default {
         }
       }
     },
-    scroll(evt) {
-      if (!evt?.target?.scrollTop) return
-      const scrollTop = Math.max(evt.target.scrollTop - this.episodesTableOffsetTop, 0)
+    handleScroll() {
+      const scrollTop = this.currScrollTop
       let firstEpisodeIndex = Math.floor(scrollTop / this.episodeRowHeight)
       let lastEpisodeIndex = Math.ceil((scrollTop + this.windowHeight) / this.episodeRowHeight)
       lastEpisodeIndex = Math.min(this.totalEpisodes - 1, lastEpisodeIndex)
@@ -500,6 +500,12 @@ export default {
         return true
       })
       this.mountEpisodes(firstEpisodeIndex, lastEpisodeIndex + 1)
+    },
+    scroll(evt) {
+      if (!evt?.target?.scrollTop) return
+      const scrollTop = Math.max(evt.target.scrollTop - this.episodesTableOffsetTop, 0)
+      this.currScrollTop = scrollTop
+      this.handleScroll()
     },
     initListeners() {
       const itemPageWrapper = document.getElementById('item-page-wrapper')
@@ -535,7 +541,12 @@ export default {
       this.episodesPerPage = Math.ceil(this.windowHeight / this.episodeRowHeight)
 
       this.$nextTick(() => {
-        this.mountEpisodes(0, Math.min(this.episodesPerPage, this.totalEpisodes))
+        // Maybe update currScrollTop if items were removed
+        const itemPageWrapper = document.getElementById('item-page-wrapper')
+        const { scrollHeight, clientHeight } = itemPageWrapper
+        const maxScrollTop = scrollHeight - clientHeight
+        this.currScrollTop = Math.min(this.currScrollTop, maxScrollTop)
+        this.handleScroll()
       })
     }
   },

--- a/server/controllers/PodcastController.js
+++ b/server/controllers/PodcastController.js
@@ -461,6 +461,9 @@ class PodcastController {
       return res.sendStatus(404)
     }
 
+    // Remove it from the podcastEpisodes array
+    req.libraryItem.media.podcastEpisodes = req.libraryItem.media.podcastEpisodes.filter((ep) => ep.id !== episodeId)
+
     if (hardDelete) {
       const audioFile = episode.audioFile
       // TODO: this will trigger the watcher. should maybe handle this gracefully


### PR DESCRIPTION
## Brief summary

This fixes a couple of issues in LazyEpisodeTable:
- When an episode is updated, the refresh doesn't account for the current scroll position
- When an episode is removed, it is not reflected in the table (a zombie episode remains)

## Which issue is fixed?

There is no open issue for these (came up over discord discussion).

## In-depth Description

There were two bugs fixed:
- On the client, when a podcast episode is updated, the `LazyEpisodeTable.refresh()` was called, but it always mounted the first few episodes in the table, with no regard for the current scroll position.
- On the server, when a podcast episode was removed, the episode was not removed from the libraryItem object return to the client, so a zombie episode was shown after the update.

## How have you tested this?

Updated, added and removed podcast episodes.