### PR TITLE
recommend using $http_host for ngnix

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -111,8 +111,8 @@ server {
 
    location / {
       proxy_set_header X-Forwarded-For    $proxy_add_x_forwarded_for;
-      proxy_set_header  X-Forwarded-Proto $scheme;
-      proxy_set_header  Host              $host;
+      proxy_set_header X-Forwarded-Proto  $scheme;
+      proxy_set_header Host               $http_host;
       proxy_set_header Upgrade            $http_upgrade;
       proxy_set_header Connection         "upgrade";
 


### PR DESCRIPTION
## Brief summary

Changes our recommendation for Nginx reverse proxy setup to set the `Host` header to `$http_host` instead of `$host`

## Which issue is fixed?

This helped in fixing #3809, which turned out to be caused by Ngnix misconfiguration.

## In-depth Description

In Ngnix, `$host` and `$http_host` are usually the same, except when Nginx is configured to a non-standard HTTP port (i.e. not 80 or 443). When Nginx uses a non-standard HTTP port, `$host` is just the hostname without the port, while `$http_host` is the actual 
`Host` header from the original request, which has both hostname and port.

Since ABS now uses the host to construct RSS feed entries dynamically, it's important to get the actual host from the original request, so that feed links are properly constructed.

## How have you tested this?

Changing the config solved the issue for #3809 reporter.