### PR TITLE
Fixes #3817 Correct rounding and carry of minutes in client/plugins/utils.js::$elapsedPrettyExtended

### DIFF
--- a/client/cypress/tests/utils/ElapsedPrettyExtended.cy.js
+++ b/client/cypress/tests/utils/ElapsedPrettyExtended.cy.js
@@ -1,0 +1,188 @@
+import Vue from 'vue'
+import '@/plugins/utils'
+
+// This is the actual function that is being tested
+const elapsedPrettyExtended = Vue.prototype.$elapsedPrettyExtended
+
+// Helper function to convert days, hours, minutes, seconds to total seconds
+function DHMStoSeconds(days, hours, minutes, seconds) {
+  return seconds + minutes * 60 + hours * 3600 + days * 86400
+}
+
+describe('$elapsedPrettyExtended', () => {
+  describe('function is on the Vue Prototype', () => {
+    it('exists as a function on Vue.prototype', () => {
+      expect(Vue.prototype.$elapsedPrettyExtended).to.exist
+      expect(Vue.prototype.$elapsedPrettyExtended).to.be.a('function')
+    })
+  })
+
+  describe('param default values', () => {
+    const testSeconds = DHMStoSeconds(0, 25, 1, 5) // 25h 1m 5s = 90065 seconds
+
+    it('uses useDays=true showSeconds=true by default', () => {
+      expect(elapsedPrettyExtended(testSeconds)).to.equal('1d 1h 1m 5s')
+    })
+
+    it('only useDays=false overrides useDays but keeps showSeconds=true', () => {
+      expect(elapsedPrettyExtended(testSeconds, false)).to.equal('25h 1m 5s')
+    })
+
+    it('explicit useDays=false showSeconds=false overrides both', () => {
+      expect(elapsedPrettyExtended(testSeconds, false, false)).to.equal('25h 1m')
+    })
+  })
+
+  describe('useDays=false showSeconds=true', () => {
+    const useDaysFalse = false
+    const showSecondsTrue = true
+    const testCases = [
+      [[0, 0, 0, 0], '', '0s -> ""'],
+      [[0, 1, 0, 1], '1h 1s', '1h 1s -> 1h 1s'],
+      [[0, 25, 0, 1], '25h 1s', '25h 1s -> 25h 1s']
+    ]
+
+    testCases.forEach(([dhms, expected, description]) => {
+      it(description, () => {
+        expect(elapsedPrettyExtended(DHMStoSeconds(...dhms), useDaysFalse, showSecondsTrue)).to.equal(expected)
+      })
+    })
+  })
+
+  describe('useDays=true showSeconds=true', () => {
+    const useDaysTrue = true
+    const showSecondsTrue = true
+    const testCases = [
+      [[0, 0, 0, 0], '', '0s -> ""'],
+      [[0, 1, 0, 1], '1h 1s', '1h 1s -> 1h 1s'],
+      [[0, 25, 0, 1], '1d 1h 1s', '25h 1s -> 1d 1h 1s']
+    ]
+
+    testCases.forEach(([dhms, expected, description]) => {
+      it(description, () => {
+        expect(elapsedPrettyExtended(DHMStoSeconds(...dhms), useDaysTrue, showSecondsTrue)).to.equal(expected)
+      })
+    })
+  })
+
+  describe('useDays=true showSeconds=false', () => {
+    const useDaysTrue = true
+    const showSecondsFalse = false
+    const testCases = [
+      [[0, 0, 0, 0], '', '0s -> ""'],
+      [[0, 1, 0, 0], '1h', '1h -> 1h'],
+      [[0, 1, 0, 1], '1h', '1h 1s -> 1h'],
+      [[0, 1, 1, 0], '1h 1m', '1h 1m -> 1h 1m'],
+      [[0, 25, 0, 0], '1d 1h', '25h -> 1d 1h'],
+      [[0, 25, 0, 1], '1d 1h', '25h 1s -> 1d 1h'],
+      [[2, 0, 0, 0], '2d', '2d -> 2d']
+    ]
+
+    testCases.forEach(([dhms, expected, description]) => {
+      it(description, () => {
+        expect(elapsedPrettyExtended(DHMStoSeconds(...dhms), useDaysTrue, showSecondsFalse)).to.equal(expected)
+      })
+    })
+  })
+
+  describe('rounding useDays=true showSeconds=true', () => {
+    const useDaysTrue = true
+    const showSecondsTrue = true
+    const testCases = [
+      // Seconds rounding
+      [[0, 0, 0, 1], '1s', '1s -> 1s'],
+      [[0, 0, 0, 29.9], '30s', '29.9s -> 30s'],
+      [[0, 0, 0, 30], '30s', '30s -> 30s'],
+      [[0, 0, 0, 30.1], '30s', '30.1s -> 30s'],
+      [[0, 0, 0, 59.4], '59s', '59.4s -> 59s'],
+      [[0, 0, 0, 59.5], '1m', '59.5s -> 1m'],
+
+      // Minutes rounding
+      [[0, 0, 59, 29], '59m 29s', '59m 29s -> 59m 29s'],
+      [[0, 0, 59, 30], '59m 30s', '59m 30s -> 59m 30s'],
+      [[0, 0, 59, 59.5], '1h', '59m 59.5s -> 1h'],
+
+      // Hours rounding
+      [[0, 23, 59, 29], '23h 59m 29s', '23h 59m 29s -> 23h 59m 29s'],
+      [[0, 23, 59, 30], '23h 59m 30s', '23h 59m 30s -> 23h 59m 30s'],
+      [[0, 23, 59, 59.5], '1d', '23h 59m 59.5s -> 1d'],
+
+      // The actual bug case
+      [[44, 23, 59, 30], '44d 23h 59m 30s', '44d 23h 59m 30s -> 44d 23h 59m 30s']
+    ]
+
+    testCases.forEach(([dhms, expected, description]) => {
+      it(description, () => {
+        expect(elapsedPrettyExtended(DHMStoSeconds(...dhms), useDaysTrue, showSecondsTrue)).to.equal(expected)
+      })
+    })
+  })
+
+  describe('rounding useDays=true showSeconds=false', () => {
+    const useDaysTrue = true
+    const showSecondsFalse = false
+    const testCases = [
+      // Seconds rounding - these cases changed behavior from original
+      [[0, 0, 0, 1], '', '1s -> ""'],
+      [[0, 0, 0, 29.9], '', '29.9s -> ""'],
+      [[0, 0, 0, 30], '', '30s -> ""'],
+      [[0, 0, 0, 30.1], '', '30.1s -> ""'],
+      [[0, 0, 0, 59.4], '', '59.4s -> ""'],
+      [[0, 0, 0, 59.5], '1m', '59.5s -> 1m'],
+      // This is unexpected behavior, but it's consistent with the original behavior
+      // We preserved the test case, to document the current behavior
+      // - with showSeconds=false,
+      // one might expect: 1m 29.5s --round(1.4901m)-> 1m
+      // actual implementation: 1h 29.5s --roundSeconds-> 1h 30s --roundMinutes-> 2m
+      // So because of the separate rounding of seconds, and then minutes, it returns 2m
+      [[0, 0, 1, 29.5], '2m', '1m 29.5s -> 2m'],
+
+      // Minutes carry - actual bug fixes below
+      [[0, 0, 59, 29], '59m', '59m 29s -> 59m'],
+      [[0, 0, 59, 30], '1h', '59m 30s -> 1h'], // This was an actual bug, used to return 60m
+      [[0, 0, 59, 59.5], '1h', '59m 59.5s -> 1h'],
+
+      // Hours carry
+      [[0, 23, 59, 29], '23h 59m', '23h 59m 29s -> 23h 59m'],
+      [[0, 23, 59, 30], '1d', '23h 59m 30s -> 1d'], // This was an actual bug, used to return 23h 60m
+      [[0, 23, 59, 59.5], '1d', '23h 59m 59.5s -> 1d'],
+
+      // The actual bug case
+      [[44, 23, 59, 30], '45d', '44d 23h 59m 30s -> 45d'] // This was an actual bug, used to return 44d 23h 60m
+    ]
+
+    testCases.forEach(([dhms, expected, description]) => {
+      it(description, () => {
+        expect(elapsedPrettyExtended(DHMStoSeconds(...dhms), useDaysTrue, showSecondsFalse)).to.equal(expected)
+      })
+    })
+  })
+
+  describe('empty values', () => {
+    const paramCombos = [
+      // useDays, showSeconds, description
+      [true, true, 'with days and seconds'],
+      [true, false, 'with days, no seconds'],
+      [false, true, 'no days, with seconds'],
+      [false, false, 'no days, no seconds']
+    ]
+
+    const emptyInputs = [
+      // input, description
+      [null, 'null input'],
+      [undefined, 'undefined input'],
+      [0, 'zero'],
+      [0.49, 'rounds to zero'] // Just under rounding threshold
+    ]
+
+    paramCombos.forEach(([useDays, showSeconds, paramDesc]) => {
+      describe(paramDesc, () => {
+        emptyInputs.forEach(([input, desc]) => {
+          it(desc, () => {
+            expect(elapsedPrettyExtended(input, useDays, showSeconds)).to.equal('')
+          })
+        })
+      })
+    })
+  })
+})

--- a/client/plugins/utils.js
+++ b/client/plugins/utils.js
@@ -69,15 +69,20 @@ Vue.prototype.$elapsedPrettyExtended = (seconds, useDays = true, showSeconds = t
   let hours = Math.floor(minutes / 60)
   minutes -= hours * 60
 
+  // Handle rollovers before days calculation
+  if (minutes && seconds && !showSeconds) {
+    if (seconds >= 30) minutes++
+    if (minutes >= 60) {
+      hours++ // Increment hours if minutes roll over
+      minutes -= 60 // adjust minutes
+    }
+  }
+
+  // Now calculate days with the final hours value
   let days = 0
   if (useDays || Math.floor(hours / 24) >= 100) {
     days = Math.floor(hours / 24)
     hours -= days * 24
-  }
-
-  // If not showing seconds then round minutes up
-  if (minutes && seconds && !showSeconds) {
-    if (seconds >= 30) minutes++
   }
 
   const strs = []


### PR DESCRIPTION
Correct rounding and carry of minutes in client/plugins/utils.js:: Vue.prototype.$elapsedPrettyExtended

-Add cypress tests for Vue.prototype.$elapsedPrettyExtended function

<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

Note: This is my first PR to the project, any feedback would be appreciated.

## Brief summary

In the Audiobookshelf Year In Review, there was a time at which the App reported
"Listening Time" as "44d23h60m", but it should have been "Listening Time" as "45d"

| Correct Display | Bug Display |
|:---------------:|:-----------:|
| <img src="https://github.com/user-attachments/assets/a883099f-5439-4f40-b3c2-3719241df498" width="200" alt="Year In Review OK"> | <img src="https://github.com/user-attachments/assets/bfa344a3-786d-4366-9eb0-0ccd88a274c7" width="200" alt="Year In Review BUG"> |

## Which issue is fixed?

Fixes #3817

## In-depth Description

<!--
Describe your solution in more depth.
How does it work? Why is this the best solution?
Does it solve a problem that affects multiple users or is this an edge case for your setup?
-->
In client/plugins/utils.js:: Vue.prototype.$elapsedPrettyExtended,
specifically when showSeconds=false, the code to round minutes *up* (when seconds>=30) did not account for the carry of minutes into hours.

The solution was to add a condition that if the rounded up minutes were now>=60, we should carry minutes into hours.
```js
if (minutes && seconds && !showSeconds) {
  if (seconds >= 30) minutes++
  // new condition
  if (minutes >= 60) {
    hours++ // Increment hours if minutes roll over
    minutes -= 60 // adjust minutes
  }
}
```
Furthermore, this rounding condition was moved up in the function, before the conditional days handling, to prevent this carry condition from needing to be propagated to days as well.

## How have you tested this?

I have added cypress tests (although these are pure functional/non-UI tests) to validate the current behavior of the `$elapsedPrettyExtended` function. 

- The specific test cases that fix this issue are identified.
- All tests, except these, were also passed by the original function

Given that the current (existing) cypress tests are _not all passing_, and do not seem to be run in any GitHub Action CI tasks,
this is how you can run _only_ the newly contributed tests:

```bash
cd client; npm ci; npm run generate
// normally just:
// npm test
// but to run only our new tests:
npm run compile-tailwind && npx cypress run --component --browser chrome --spec "cypress/tests/utils/ElapsedPrettyExtended.cy.js"
```

Test Results

```bash
  $elapsedPrettyExtended
    function is on the Vue Prototype
      ✓ exists as a function on Vue.prototype (9ms)
    param default values
      ✓ uses useDays=true showSeconds=true by default (8ms)
      ✓ only useDays=false overrides useDays but keeps showSeconds=true (4ms)
      ✓ explicit useDays=false showSeconds=false overrides both (3ms)
    useDays=false showSeconds=true
      ✓ 0s -> "" (3ms)
      ✓ 1h 1s -> 1h 1s (7ms)
      ✓ 25h 1s -> 25h 1s (4ms)
    useDays=true showSeconds=true
      ✓ 0s -> "" (4ms)
      ✓ 1h 1s -> 1h 1s (3ms)
      ✓ 25h 1s -> 1d 1h 1s (7ms)
    useDays=true showSeconds=false
      ✓ 0s -> "" (3ms)
      ✓ 1h -> 1h (3ms)
      ✓ 1h 1s -> 1h (3ms)
      ✓ 1h 1m -> 1h 1m (3ms)
      ✓ 25h -> 1d 1h (4ms)
      ✓ 25h 1s -> 1d 1h (3ms)
      ✓ 2d -> 2d (5ms)
    rounding useDays=true showSeconds=true
      ✓ 1s -> 1s (3ms)
      ✓ 29.9s -> 30s (3ms)
      ✓ 30s -> 30s (3ms)
      ✓ 30.1s -> 30s (6ms)
      ✓ 59.4s -> 59s (3ms)
      ✓ 59.5s -> 1m (3ms)
      ✓ 59m 29s -> 59m 29s (6ms)
      ✓ 59m 30s -> 59m 30s (2ms)
      ✓ 59m 59.5s -> 1h (3ms)
      ✓ 23h 59m 29s -> 23h 59m 29s (7ms)
      ✓ 23h 59m 30s -> 23h 59m 30s (3ms)
      ✓ 23h 59m 59.5s -> 1d (3ms)
      ✓ 44d 23h 59m 30s -> 44d 23h 59m 30s (5ms)
    rounding useDays=true showSeconds=false
      ✓ 1s -> "" (7ms)
      ✓ 29.9s -> "" (3ms)
      ✓ 30s -> "" (2ms)
      ✓ 30.1s -> "" (6ms)
      ✓ 59.4s -> "" (3ms)
      ✓ 59.5s -> 1m (3ms)
      ✓ 1m 29.5s -> 2m (3ms)
      ✓ 59m 29s -> 59m (3ms)
      ✓ 59m 30s -> 1h (3ms)
      ✓ 59m 59.5s -> 1h (6ms)
      ✓ 23h 59m 29s -> 23h 59m (3ms)
      ✓ 23h 59m 30s -> 1d (3ms)
      ✓ 23h 59m 59.5s -> 1d (6ms)
      ✓ 44d 23h 59m 30s -> 45d (2ms)
    empty values
      with days and seconds
        ✓ null input (6ms)
        ✓ undefined input (6ms)
        ✓ zero (3ms)
        ✓ rounds to zero (2ms)
      with days, no seconds
        ✓ null input (3ms)
        ✓ undefined input (2ms)
        ✓ zero (2ms)
        ✓ rounds to zero (3ms)
      no days, with seconds
        ✓ null input (4ms)
        ✓ undefined input (6ms)
        ✓ zero (3ms)
        ✓ rounds to zero (3ms)
      no days, no seconds
        ✓ null input (3ms)
        ✓ undefined input (3ms)
        ✓ zero (3ms)
        ✓ rounds to zero (3ms)


  60 passing (440ms)


  (Results)

  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ Tests:        60                                                                               │
  │ Passing:      60                                                                               │
  │ Failing:      0                                                                                │
  │ Pending:      0                                                                                │
  │ Skipped:      0                                                                                │
  │ Screenshots:  0                                                                                │
  │ Video:        false                                                                            │
  │ Duration:     0 seconds                                                                        │
  │ Spec Ran:     ElapsedPrettyExtended.cy.js                                                      │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘


====================================================================================================

  (Run Finished)


       Spec                                              Tests  Passing  Failing  Pending  Skipped  
  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ ✔  ElapsedPrettyExtended.cy.js              441ms       60       60        -        -        - │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘
    ✔  All specs passed!                        441ms       60       60        -        -        -  
```
I also ran a brute force test (not submitted) to guarantee that the corrected function did not change the function's behaviour for cases other than those identified in this bug fix. i.e. I compared the value of the original function vs the fixed version for all values of 'seconds' in `[0s, 101 days]` in increments of `0.5` seconds

## Screenshots

None