### PR TITLE
Dynamically calculate episode row height on LazyEpisodeTable init

### DIFF
--- a/client/components/tables/podcast/LazyEpisodesTable.vue
+++ b/client/components/tables/podcast/LazyEpisodesTable.vue
@@ -30,7 +30,7 @@
         <ui-text-input v-model="search" @input="inputUpdate" type="search" :placeholder="$strings.PlaceholderSearchEpisode" class="flex-grow mr-2 text-sm md:text-base" />
       </form>
     </div>
-    <div class="relative min-h-[176px]">
+    <div class="relative min-h-44">
       <template v-for="episode in totalEpisodes">
         <div :key="episode" :id="`episode-${episode - 1}`" class="w-full h-44 px-2 py-3 overflow-hidden relative border-b border-white/10">
           <!-- episode is mounted here -->
@@ -39,7 +39,7 @@
       <div v-if="isSearching" class="w-full h-full absolute inset-0 flex justify-center py-12" :class="{ 'bg-black/50': totalEpisodes }">
         <ui-loading-indicator />
       </div>
-      <div v-else-if="!totalEpisodes" class="h-44 flex items-center justify-center">
+      <div v-else-if="!totalEpisodes" id="no-episodes" class="h-44 flex items-center justify-center">
         <p class="text-lg">{{ $strings.MessageNoEpisodes }}</p>
       </div>
     </div>
@@ -80,7 +80,7 @@ export default {
       episodeComponentRefs: {},
       windowHeight: 0,
       episodesTableOffsetTop: 0,
-      episodeRowHeight: 176,
+      episodeRowHeight: 44 * 4, // h-44,
       currScrollTop: 0
     }
   },
@@ -538,9 +538,10 @@ export default {
       this.episodesTableOffsetTop = (lazyEpisodesTableEl?.offsetTop || 0) + 64
 
       this.windowHeight = window.innerHeight
-      this.episodesPerPage = Math.ceil(this.windowHeight / this.episodeRowHeight)
 
       this.$nextTick(() => {
+        this.recalcEpisodeRowHeight()
+        this.episodesPerPage = Math.ceil(this.windowHeight / this.episodeRowHeight)
         // Maybe update currScrollTop if items were removed
         const itemPageWrapper = document.getElementById('item-page-wrapper')
         const { scrollHeight, clientHeight } = itemPageWrapper
@@ -548,6 +549,13 @@ export default {
         this.currScrollTop = Math.min(this.currScrollTop, maxScrollTop)
         this.handleScroll()
       })
+    },
+    recalcEpisodeRowHeight() {
+      const episodeRowEl = document.getElementById('episode-0') || document.getElementById('no-episodes')
+      if (episodeRowEl) {
+        const height = getComputedStyle(episodeRowEl).height
+        this.episodeRowHeight = parseInt(height) || this.episodeRowHeight
+      }
     }
   },
   mounted() {


### PR DESCRIPTION
## Brief summary

Instead of using a fixed size for episodeRowHeight, it is given a default value but recalculated when the episode table is mounted.

## Which issue is fixed?

This fixes #3511. While this is marked as related to #3013, I believe they're not actually related.

## In-depth Description

The bug was reproduced by manually setting the root font-size to a larger value (I suspected that this might be reason, because the reporter mentioned system scale changes).

The original code hardcodes episodeRowHeight value to 176 px (which is indeed the row height when the root font size is the default 16px). episodeRowHeight is used to make scroll calculations to decide which episodes to mount, and when it is different from the actual value, it results in mounting incorrect episodes.

The fix determines episodeRowHeight from the actual dom element of the first episode (or from the "no-episodes" element, if no episodes exist), which fixes the issue above.

## How have you tested this?

Used Chrome settings to change the root font-size value, and ensured scrolling worked OK after reloading the page.

_note:_ this fix doesn't automatically react to changes in the root font-size - it only recalculates episodeRowHeight in the init() function. I can make it reactive, but it seems unnecessary, as this is not something that users play with frequently.