### PR TITLE
Fix missing texture image & epub ebook url for subdirectory support

### DIFF
--- a/client/assets/app.css
+++ b/client/assets/app.css
@@ -5,7 +5,7 @@
 @import './absicons.css';
 
 :root {
-  --bookshelf-texture-img: url(/textures/wood_default.jpg);
+  --bookshelf-texture-img: url(~static/textures/wood_default.jpg);
   --bookshelf-divider-bg: linear-gradient(180deg, rgba(149, 119, 90, 1) 0%, rgba(103, 70, 37, 1) 17%, rgba(103, 70, 37, 1) 88%, rgba(71, 48, 25, 1) 100%);
 }
 

--- a/client/components/readers/EpubReader.vue
+++ b/client/components/readers/EpubReader.vue
@@ -97,9 +97,9 @@ export default {
     },
     ebookUrl() {
       if (this.fileId) {
-        return `/api/items/${this.libraryItemId}/ebook/${this.fileId}`
+        return `${this.$config.routerBasePath}/api/items/${this.libraryItemId}/ebook/${this.fileId}`
       }
-      return `/api/items/${this.libraryItemId}/ebook`
+      return `${this.$config.routerBasePath}/api/items/${this.libraryItemId}/ebook`
     },
     themeRules() {
       const isDark = this.ereaderSettings.theme === 'dark'


### PR DESCRIPTION
## Brief summary

Fixes a missing texture image in the nuxt build.

## Which issue is fixed?

This addresses [this comment](https://github.com/advplyr/audiobookshelf/issues/385#issuecomment-2601167818) in #385

Fixes #3865

## In-depth Description

`assets/app.css` contained a direct url link to `/textures/wood_default.jpg`. This breaks subdirectory support. Changed this to `~static/textures/wood_default.jpg` so it is picked and served by _nuxt (like other urls in the .css files)

## How have you tested this?

Ran against a dev server. The texture image is now fetched successfully from `/audiobookshelf/_nuxt/img/wood_default.6d366e7.jpg` instead of  `/textures/wood_default.jpg`.