### PR TITLE
Updates to generated RSS feed & Fix series/collection feeds

### DIFF
--- a/server/models/FeedEpisode.js
+++ b/server/models/FeedEpisode.js
@@ -308,7 +308,6 @@ class FeedEpisode extends Model {
     const customElements = [
       { 'itunes:author': this.author || null },
       { 'itunes:duration': Math.round(Number(this.duration)) },
-      { 'itunes:summary': this.description || null },
       {
         'itunes:explicit': !!this.explicit
       },
@@ -319,6 +318,9 @@ class FeedEpisode extends Model {
       // Remove empty custom elements
       return Object.values(element)[0] !== null
     })
+    if (this.description) {
+      customElements.push({ 'itunes:summary': { _cdata: this.description } })
+    }
 
     return {
       title: this.title,

--- a/server/models/FeedEpisode.js
+++ b/server/models/FeedEpisode.js
@@ -305,6 +305,21 @@ class FeedEpisode extends Model {
    * @param {string} hostPrefix
    */
   getRSSData(hostPrefix) {
+    const customElements = [
+      { 'itunes:author': this.author || null },
+      { 'itunes:duration': Math.round(Number(this.duration)) },
+      { 'itunes:summary': this.description || null },
+      {
+        'itunes:explicit': !!this.explicit
+      },
+      { 'itunes:episodeType': this.episodeType || null },
+      { 'itunes:season': this.season || null },
+      { 'itunes:episode': this.episode || null }
+    ].filter((element) => {
+      // Remove empty custom elements
+      return Object.values(element)[0] !== null
+    })
+
     return {
       title: this.title,
       description: this.description || '',
@@ -317,17 +332,7 @@ class FeedEpisode extends Model {
         type: this.enclosureType,
         size: this.enclosureSize
       },
-      custom_elements: [
-        { 'itunes:author': this.author },
-        { 'itunes:duration': secondsToTimestamp(this.duration) },
-        { 'itunes:summary': this.description || '' },
-        {
-          'itunes:explicit': !!this.explicit
-        },
-        { 'itunes:episodeType': this.episodeType },
-        { 'itunes:season': this.season },
-        { 'itunes:episode': this.episode }
-      ]
+      custom_elements: customElements
     }
   }
 }

--- a/server/models/FeedEpisode.js
+++ b/server/models/FeedEpisode.js
@@ -220,7 +220,7 @@ class FeedEpisode extends Model {
     const feedEpisodeObjs = []
     let numExisting = 0
     for (const book of books) {
-      const trackList = book.libraryItem.getTrackList()
+      const trackList = book.getTracklist(book.libraryItem.id)
       const useChapterTitles = this.checkUseChapterTitlesForEpisodes(trackList, book)
       for (const track of trackList) {
         // Check for existing episode by filepath

--- a/server/utils/index.js
+++ b/server/utils/index.js
@@ -112,7 +112,7 @@ function secondsToTimestamp(seconds, includeMs = false, alwaysIncludeHours = fal
   var ms = _seconds - Math.floor(seconds)
   _seconds = Math.floor(_seconds)
 
-  var msString = '.' + (includeMs ? ms.toFixed(3) : '0.0').split('.')[1]
+  const msString = includeMs ? '.' + ms.toFixed(3).split('.')[1] : ''
   if (alwaysIncludeHours) {
     return `${_hours.toString().padStart(2, '0')}:${_minutes.toString().padStart(2, '0')}:${_seconds.toString().padStart(2, '0')}${msString}`
   }


### PR DESCRIPTION
## Brief summary

A few adjustments to fix/improve the generated RSS feed.
Series & collection feeds were broken due to the `getTrackList` request returning an empty array.

## Which issue is fixed?

Fixes #3866
Although these are likely not the actual issue the user is having in that issue it points to some things this PR addresses.

## In-depth Description

The following updates were made:
1. Feeds no longer include empty tags. For example, previously an empty season would include `<itunes:season/>`.
2. `itunes:summary` value is wrapped in `<![CDATA[ .... ]]>` because podcast episode descriptions include HTML
3. `itunes:description` value is an integer of seconds
4. Removed unnecessary podlove namespace
5. Fixes an issue with series and collection feeds where the episode list is empty

## How have you tested this?

Tested opening feeds of all variety