### PR TITLE
Add Narrators and Change Icons

### DIFF
--- a/client/components/app/MediaPlayerContainer.vue
+++ b/client/components/app/MediaPlayerContainer.vue
@@ -12,10 +12,15 @@
           <widgets-explicit-indicator v-if="isExplicit" />
         </div>
         <div class="text-gray-400 flex items-center w-1/2 sm:w-4/5 lg:w-2/5">
-          <span class="material-symbols text-sm">person</span>
+          <span class="material-symbols text-sm">person_edit</span>
           <div v-if="podcastAuthor" class="pl-1 sm:pl-1.5 text-xs sm:text-base">{{ podcastAuthor }}</div>
           <div v-else-if="authors.length" class="pl-1 sm:pl-1.5 text-xs sm:text-base truncate">
             <nuxt-link v-for="(author, index) in authors" :key="index" :to="`/author/${author.id}`" class="hover:underline">{{ author.name }}<span v-if="index < authors.length - 1">,&nbsp;</span></nuxt-link>
+          </div>
+          <div v-else class="text-xs sm:text-base cursor-pointer pl-1 sm:pl-1.5">{{ $strings.LabelUnknown }}</div>
+          <span class="material-symbols text-sm pl-1.5">record_voice_over</span>
+          <div v-if="narrators.length" class="pl-1 sm:pl-1.5 text-xs sm:text-base truncate">
+            <nuxt-link v-for="(narrator, index) in narrators" :key="index" :to="`/library/${streamLibraryItem.libraryId}/bookshelf?filter=narrators.${$encode(narrator)}`" class="hover:underline">{{ narrator }}<span v-if="index < narrators.length - 1">,&nbsp;</span></nuxt-link>
           </div>
           <div v-else class="text-xs sm:text-base cursor-pointer pl-1 sm:pl-1.5">{{ $strings.LabelUnknown }}</div>
         </div>
@@ -153,6 +158,9 @@ export default {
     },
     authors() {
       return this.mediaMetadata.authors || []
+    },
+    narrators() {
+      return this.mediaMetadata.narrators || []
     },
     libraryId() {
       return this.streamLibraryItem ? this.streamLibraryItem.libraryId : null


### PR DESCRIPTION
## Brief summary

<!-- Please provide a brief summary of what your PR attempts to achieve. -->

Adds narrators to the playback window, linked to their filtered library results. Changed icons to reflect authors vs narrators.

## Which issue is fixed?

https://github.com/advplyr/audiobookshelf/issues/3815

## In-depth Description

<!--
Describe your solution in more depth.
How does it work? Why is this the best solution?
Does it solve a problem that affects multiple users or is this an edge case for your setup?
-->

Added narrators to the playback window which links to filtered results of books that they narrate. Changed the existing author icon to a new one as well as added an icon for narrators.

## How have you tested this?

<!-- Please describe in detail with reproducible steps how you tested your changes. -->

Ran locally with dummy data.

## Screenshots

Original:

![Screenshot 2025-01-21 114130](https://github.com/user-attachments/assets/34d88533-4981-411f-b969-03c84e45c41b)

New:

![Screenshot 2025-01-21 113434](https://github.com/user-attachments/assets/3f589a90-ca4d-44c1-aece-ad8f719b47e9)
