### PR TITLE
Add bookSeries id attribute to findAllExpandedWhere

### DIFF
--- a/server/models/LibraryItem.js
+++ b/server/models/LibraryItem.js
@@ -155,7 +155,7 @@ class LibraryItem extends Model {
             {
               model: this.sequelize.models.series,
               through: {
-                attributes: ['sequence']
+                attributes: ['id', 'sequence']
               }
             }
           ]


### PR DESCRIPTION
## Brief summary

Adds `bookSeries.id` attribute to the sequelize query in `LibraryItem.findAllExpandedWhere`.

## Which issue is fixed?

Fixes #3883

## In-depth Description

The bookSeries id is required for the `bookSeries.destroy()` call [here](https://github.com/advplyr/audiobookshelf/blob/e096da1b4d0dfeab02f7a6702cf56237e12e04e8/server/scanner/Scanner.js#L338), without it, the `destory()` call throws an exception since it doesn't have the id in order to construct the deletion query.

_Note_: this only happens in batch quick match, which calls `findAllExpandedWhere()`

## How have you tested this?

Batch quick match which crashed the server before now completes successfuly.