### PR TITLE
Allows setting of some pragma values through environment variables

### DIFF
--- a/server/Database.js
+++ b/server/Database.js
@@ -226,6 +226,28 @@ class Database {
 
     try {
       await this.sequelize.authenticate()
+
+      // Set SQLite pragmas from environment variables
+      const allowedPragmas = [
+        { name: 'mmap_size', env: 'SQLITE_MMAP_SIZE' },
+        { name: 'cache_size', env: 'SQLITE_CACHE_SIZE' },
+        { name: 'temp_store', env: 'SQLITE_TEMP_STORE' }
+      ]
+
+      for (const pragma of allowedPragmas) {
+        const value = process.env[pragma.env]
+        if (value !== undefined) {
+          try {
+            Logger.info(`[Database] Running "PRAGMA ${pragma.name} = ${value}"`)
+            await this.sequelize.query(`PRAGMA ${pragma.name} = ${value}`)
+            const [result] = await this.sequelize.query(`PRAGMA ${pragma.name}`)
+            Logger.debug(`[Database] "PRAGMA ${pragma.name}" query result:`, result)
+          } catch (error) {
+            Logger.error(`[Database] Failed to set SQLite pragma ${pragma.name}`, error)
+          }
+        }
+      }
+
       if (process.env.NUSQLITE3_PATH) {
         await this.loadExtension(process.env.NUSQLITE3_PATH)
         Logger.info(`[Database] Db supports unaccent and unicode foldings`)


### PR DESCRIPTION
## Brief summary

Adds support for setting some whitelisted SQLite PRAGMA values through environment variables.

## Which issue is fixed?

Fixes #3750

## In-depth Description

A whitelist of allowed pragma settings is defined,  which currently contains `mmap_size`, `cache_size`, and `temp_store`.
Users can set the values for those pragmas, by setting the environment variable `SQLITE_<UPPERCASE_PRAGMA_NAME>` (e.g. SQLITE_MMAP_SIZE) to the requested value.

These helped the reporting user optimize their database, and could be used by us in the future to set reasonable default values.

## How have you tested this?

Set up all the supported pragmas through the corresponding env variables.