### PR TITLE
Add: workflow to close blank issues

### DIFF
--- a/.github/workflows/close_blank_issues.yaml
+++ b/.github/workflows/close_blank_issues.yaml
@@ -1,0 +1,42 @@
+name: Close Issues not using a template
+
+on:
+  issues:
+    types:
+      - opened
+
+permissions:
+  issues: write
+
+jobs:
+  close_issue:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check issue headings
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const issueBody = context.payload.issue.body || "";
+            
+            // Match Markdown headings (e.g., # Heading, ## Heading)
+            const headingRegex = /^(#{1,6})\s.+/gm;
+            const headings = [...issueBody.matchAll(headingRegex)];
+
+            if (headings.length < 3) {
+              // Post a comment
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.issue.number,
+                body: "Thank you for opening an issue! To help us review your request efficiently, please use one of the provided issue templates. If you're seeking information or have a general question, consider opening a Discussion or joining the conversation on our Discord. Thanks!"
+              });
+
+              // Close the issue
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.issue.number,
+                state: "closed"
+              });
+            }


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

Adds a workflow to close issues which do not use the issue templates

## Which issue is fixed?

No issue number

## In-depth Description

To help encourage users to use the issue templates, this workflow closes any issues which are opened and have less than 3 headings in them. This does not prevent users from opening issues with their own headings, but should help prevent the blank issue template from being used.

## How have you tested this?

Tested with my issue templates repo

## Screenshots

![Screenshot from 2025-01-28 20-25-27](https://github.com/user-attachments/assets/b369defa-ac4f-4a20-9b4b-7b3adbadc973)

