### PR TITLE
Fix Logger.fatal to ensure crash_logs.txt is written to

### DIFF
--- a/server/Logger.js
+++ b/server/Logger.js
@@ -117,7 +117,7 @@ class Logger {
     if (level < LogLevel.FATAL && level < this.logLevel) return
     const consoleMethod = Logger.ConsoleMethods[levelName]
     console[consoleMethod](`[${this.timestamp}] ${levelName}:`, ...args)
-    this.#logToFileAndListeners(level, levelName, args, source)
+    return this.#logToFileAndListeners(level, levelName, args, source)
   }
 
   trace(...args) {
@@ -141,7 +141,7 @@ class Logger {
   }
 
   fatal(...args) {
-    this.#log('FATAL', this.source, ...args)
+    return this.#log('FATAL', this.source, ...args)
   }
 
   note(...args) {


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

`Logger.fatal` is called before the server closes on uncaught exceptions. When it gets called the log is written to `crash_logs.txt`.

Logs weren't always being written to crash_logs.txt because `Logger.fatal` wasn't a promise and `process.exit` was called before it was done.

## Which issue is fixed?

No issue

## How have you tested this?

Threw some exceptions and ensured they were written to crash_logs.txt
