### PR TITLE
Fix API including basepath in tracks contentUrl

### DIFF
--- a/client/pages/audiobook/_id/chapters.vue
+++ b/client/pages/audiobook/_id/chapters.vue
@@ -414,11 +414,8 @@ export default {
 
       const audioEl = this.audioEl || document.createElement('audio')
       var src = audioTrack.contentUrl + `?token=${this.userToken}`
-      if (this.$isDev) {
-        src = `${process.env.serverUrl}${src}`
-      }
 
-      audioEl.src = src
+      audioEl.src = `${process.env.serverUrl}${src}`
       audioEl.id = 'chapter-audio'
       document.body.appendChild(audioEl)
 

--- a/client/players/AudioTrack.js
+++ b/client/players/AudioTrack.js
@@ -1,5 +1,5 @@
 export default class AudioTrack {
-  constructor(track, userToken) {
+  constructor(track, userToken, routerBasePath) {
     this.index = track.index || 0
     this.startOffset = track.startOffset || 0 // Total time of all previous tracks
     this.duration = track.duration || 0
@@ -9,20 +9,27 @@ export default class AudioTrack {
     this.metadata = track.metadata || {}
 
     this.userToken = userToken
+    this.routerBasePath = routerBasePath || ''
   }
 
+  /**
+   * Used for CastPlayer
+   */
   get fullContentUrl() {
     if (!this.contentUrl || this.contentUrl.startsWith('http')) return this.contentUrl
 
     if (process.env.NODE_ENV === 'development') {
       return `${process.env.serverUrl}${this.contentUrl}?token=${this.userToken}`
     }
-    return `${window.location.origin}${this.contentUrl}?token=${this.userToken}`
+    return `${window.location.origin}${this.routerBasePath}${this.contentUrl}?token=${this.userToken}`
   }
 
+  /**
+   * Used for LocalPlayer
+   */
   get relativeContentUrl() {
     if (!this.contentUrl || this.contentUrl.startsWith('http')) return this.contentUrl
 
-    return this.contentUrl + `?token=${this.userToken}`
+    return `${this.routerBasePath}${this.contentUrl}?token=${this.userToken}`
   }
 }

--- a/client/players/PlayerHandler.js
+++ b/client/players/PlayerHandler.js
@@ -226,7 +226,7 @@ export default class PlayerHandler {
 
     console.log('[PlayerHandler] Preparing Session', session)
 
-    var audioTracks = session.audioTracks.map((at) => new AudioTrack(at, this.userToken))
+    var audioTracks = session.audioTracks.map((at) => new AudioTrack(at, this.userToken, this.ctx.$config.routerBasePath))
 
     this.ctx.playerLoading = true
     this.isHlsTranscode = true

--- a/server/models/Book.js
+++ b/server/models/Book.js
@@ -286,7 +286,7 @@ class Book extends Model {
       const track = structuredClone(af)
       track.title = af.metadata.filename
       track.startOffset = startOffset
-      track.contentUrl = `${global.RouterBasePath}/api/items/${libraryItemId}/file/${track.ino}`
+      track.contentUrl = `/api/items/${libraryItemId}/file/${track.ino}`
       startOffset += track.duration
       return track
     })

--- a/server/models/PodcastEpisode.js
+++ b/server/models/PodcastEpisode.js
@@ -169,7 +169,7 @@ class PodcastEpisode extends Model {
     const track = structuredClone(this.audioFile)
     track.startOffset = 0
     track.title = this.audioFile.metadata.filename
-    track.contentUrl = `${global.RouterBasePath}/api/items/${libraryItemId}/file/${track.ino}`
+    track.contentUrl = `/api/items/${libraryItemId}/file/${track.ino}`
     return track
   }
 

--- a/server/objects/files/AudioTrack.js
+++ b/server/objects/files/AudioTrack.js
@@ -29,7 +29,7 @@ class AudioTrack {
     this.duration = audioFile.duration
     this.title = audioFile.metadata.filename || ''
 
-    this.contentUrl = `${global.RouterBasePath}/api/items/${itemId}/file/${audioFile.ino}`
+    this.contentUrl = `/api/items/${itemId}/file/${audioFile.ino}`
     this.mimeType = audioFile.mimeType
     this.codec = audioFile.codec || null
     this.metadata = audioFile.metadata.clone()


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

API endpoints that return expanded Books and PodcastEpisodes include AudioTrack objects that have a `contentUrl`. That `contentUrl` was incorrectly including the basepath (/audiobookshelf). This PR removes the basepath from the API responses and prepends the basepath in the web client.

## Which issue is fixed?

No issue

## In-depth Description

The mobile clients and 3rd party clients will be getting users server address and prepending it to the `contentUrl` returned from the API.
If the `contentUrl` includes the basepath and the user includes the basepath in the address then it will result in track urls with `/audiobookshelf/audiobookshelf/`.

The mobile apps are currently falling back to transcoding if the user includes the basepath. This PR fixes that issue with no additional changes on the mobile apps.

## How have you tested this?

Tested streaming on web client and mobile apps w/ subdir.
