### PR TITLE
Add resize to trix editor

### DIFF
--- a/client/components/ui/VueTrix.vue
+++ b/client/components/ui/VueTrix.vue
@@ -351,8 +351,10 @@ export default {
   background-color: white;
 }
 trix-editor {
-  max-height: calc(4 * 1lh);
+  height: calc(4 * 1lh);
+  min-height: calc(4 * 1lh);
   overflow-y: auto;
+  resize: vertical;
 }
 
 trix-editor * {


### PR DESCRIPTION
## Brief summary

Adds a resize handle to the rich text editor.

## Which issue is fixed?

Fixes #3928 

## In-depth Description

- Added `resize: vertical` to text-editor style
- Set `height` and `min-height` properties (instead of `max-height`)

## How have you tested this?

Resize handle now shows up where the rich text editor appears, and works as expected.