### PR TITLE
Add `Accept-Encoding` header to `getPodcastFeed()`

### DIFF
--- a/server/utils/podcastUtils.js
+++ b/server/utils/podcastUtils.js
@@ -311,6 +311,7 @@ module.exports.getPodcastFeed = (feedUrl, excludeEpisodeMetadata = false) => {
     responseType: 'arraybuffer',
     headers: {
       Accept: 'application/rss+xml, application/xhtml+xml, application/xml, */*;q=0.8',
+      'Accept-Encoding': 'gzip, compress, deflate',
       'User-Agent': userAgent
     },
     httpAgent: global.DisableSsrfRequestFilter?.(feedUrl) ? null : ssrfFilter(feedUrl),


### PR DESCRIPTION
## Brief summary

This commit adds the `Accept-Encoding` header to `getPodcastFeed()` with gzip, compress, and deflate support. This allows servers to send a compressed response that'll be decompressed by axios transparently.

## Which issue is fixed?

Fixes #3885 

## In-depth Description

Audiobookshelf is currently using axios v0.27.2, which [enables the `decompress` option by default](https://github.com/axios/axios/blob/v0.27.2/README.md?plain=1#L475). The `decompress` feature supports gzip, compress, and deflate algorithms (see [axios/lib/adapters/http.js](https://github.com/axios/axios/blob/v0.27.2/lib/adapters/http.js#L272)). axios v0.27.2 does not add the `Accept-Encoding` header to requests automatically, so that's the responsibility of the caller.

## How have you tested this?

I applied the change to my production Audiobookshelf container and was then able to fetch the problematic feed described in #3885. Fetching other feeds still worked as well.