### PR TITLE
Adding support for 'minified' parameter when fetching a library's items

### DIFF
--- a/server/controllers/LibraryController.js
+++ b/server/controllers/LibraryController.js
@@ -619,6 +619,7 @@ class LibraryController {
       filterBy: req.query.filter,
       mediaType: req.library.mediaType,
       minified: req.query.minified === '1',
+      expanded: req.query.expanded === '1',
       collapseseries: req.query.collapseseries === '1',
       include: include.join(',')
     }

--- a/server/models/LibraryItem.js
+++ b/server/models/LibraryItem.js
@@ -297,65 +297,43 @@ class LibraryItem extends Model {
     const { libraryItems, count } = await libraryFilters.getFilteredLibraryItems(library.id, user, options)
     Logger.debug(`Loaded ${libraryItems.length} of ${count} items for libary page in ${((Date.now() - start) / 1000).toFixed(2)}s`)
 
-    let items = []
-    if (minified) {
-      items = libraryItems.map((li) => {
-        const oldLibraryItem = li.toOldJSONMinified()
-        if (li.collapsedSeries) {
-          oldLibraryItem.collapsedSeries = li.collapsedSeries
-        }
-        if (li.series) {
-          oldLibraryItem.media.metadata.series = li.series
-        }
-        if (li.rssFeed) {
-          oldLibraryItem.rssFeed = li.rssFeed.toOldJSONMinified()
-        }
-        if (li.media.numEpisodes) {
-          oldLibraryItem.media.numEpisodes = li.media.numEpisodes
-        }
-        if (li.size && !oldLibraryItem.media.size) {
-          oldLibraryItem.media.size = li.size
-        }
-        if (li.numEpisodesIncomplete) {
-          oldLibraryItem.numEpisodesIncomplete = li.numEpisodesIncomplete
-        }
-        if (li.mediaItemShare) {
-          oldLibraryItem.mediaItemShare = li.mediaItemShare
-        }
-
-        return oldLibraryItem
-      })
-    } else {
-      items = libraryItems.map((li) => {
-        const oldLibraryItem = li.toOldJSONExpanded()
-        if (li.collapsedSeries) {
-          oldLibraryItem.collapsedSeries = li.collapsedSeries
-        }
-        if (li.series) {
-          oldLibraryItem.media.metadata.series = li.series
-        }
-        if (li.rssFeed) {
-          oldLibraryItem.rssFeed = li.rssFeed.toOldJSON()
-        }
-        if (li.media.numEpisodes) {
-          oldLibraryItem.media.numEpisodes = li.media.numEpisodes
-        }
-        if (li.size && !oldLibraryItem.media.size) {
-          oldLibraryItem.media.size = li.size
-        }
-        if (li.numEpisodesIncomplete) {
-          oldLibraryItem.numEpisodesIncomplete = li.numEpisodesIncomplete
-        }
-        if (li.mediaItemShare) {
-          oldLibraryItem.mediaItemShare = li.mediaItemShare
-        }
-
-        return oldLibraryItem
-      })
-    }
-
     return {
-      libraryItems: items,
+      libraryItems: libraryItems.map((li) => {
+        let oldLibraryItem = {}
+        if (minified) {
+          oldLibraryItem = li.toOldJSONMinified()
+        } else {
+          oldLibraryItem = li.toOldJSONExpanded()
+        }
+  
+        if (li.collapsedSeries) {
+          oldLibraryItem.collapsedSeries = li.collapsedSeries
+        }
+        if (li.series) {
+          oldLibraryItem.media.metadata.series = li.series
+        }
+        if (li.rssFeed) {
+          if (minified) {
+            oldLibraryItem.rssFeed = li.rssFeed.toOldJSONMinified()
+          } else {
+            oldLibraryItem.rssFeed = li.rssFeed.toOldJSON()
+          }
+        }
+        if (li.media.numEpisodes) {
+          oldLibraryItem.media.numEpisodes = li.media.numEpisodes
+        }
+        if (li.size && !oldLibraryItem.media.size) {
+          oldLibraryItem.media.size = li.size
+        }
+        if (li.numEpisodesIncomplete) {
+          oldLibraryItem.numEpisodesIncomplete = li.numEpisodesIncomplete
+        }
+        if (li.mediaItemShare) {
+          oldLibraryItem.mediaItemShare = li.mediaItemShare
+        }
+  
+        return oldLibraryItem
+      }),
       count
     }
   }

--- a/server/models/LibraryItem.js
+++ b/server/models/LibraryItem.js
@@ -293,19 +293,19 @@ class LibraryItem extends Model {
    */
   static async getByFilterAndSort(library, user, options) {
     let start = Date.now()
-    const { minified } = options
+    const { expanded } = options
     const { libraryItems, count } = await libraryFilters.getFilteredLibraryItems(library.id, user, options)
     Logger.debug(`Loaded ${libraryItems.length} of ${count} items for libary page in ${((Date.now() - start) / 1000).toFixed(2)}s`)
 
     return {
       libraryItems: libraryItems.map((li) => {
         let oldLibraryItem = {}
-        if (minified) {
-          oldLibraryItem = li.toOldJSONMinified()
-        } else {
+        if (expanded) {
           oldLibraryItem = li.toOldJSONExpanded()
+        } else {
+          oldLibraryItem = li.toOldJSONMinified()
         }
-  
+
         if (li.collapsedSeries) {
           oldLibraryItem.collapsedSeries = li.collapsedSeries
         }
@@ -313,10 +313,10 @@ class LibraryItem extends Model {
           oldLibraryItem.media.metadata.series = li.series
         }
         if (li.rssFeed) {
-          if (minified) {
-            oldLibraryItem.rssFeed = li.rssFeed.toOldJSONMinified()
+          if (expanded) {
+            oldLibraryItem.rssFeed = li.rssFeed.toOldJSONExpanded()
           } else {
-            oldLibraryItem.rssFeed = li.rssFeed.toOldJSON()
+            oldLibraryItem.rssFeed = li.rssFeed.toOldJSONMinified()
           }
         }
         if (li.media.numEpisodes) {
@@ -331,7 +331,7 @@ class LibraryItem extends Model {
         if (li.mediaItemShare) {
           oldLibraryItem.mediaItemShare = li.mediaItemShare
         }
-  
+
         return oldLibraryItem
       }),
       count


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

<!-- Please provide a brief summary of what your PR attempts to achieve. -->

This PR attempts to fix the issue where the `/api/libraries/<id>/items` endpoint only returns minified library items.

## Which issue is fixed?

<!-- Which issue number does this PR fix? Ex: "Fixes #1234" -->
Fixes #2123 

## In-depth Description

<!--
Describe your solution in more depth.
How does it work? Why is this the best solution?
Does it solve a problem that affects multiple users or is this an edge case for your setup?
-->

This endpoint currently just maps all library items `toOldJSONMinified()` regardless of the `minified` parameter sent in the request. This change checks the parameter and maps to either the minified, or the `toOldJSONExpanded()`.

## How have you tested this?

<!-- Please describe in detail with reproducible steps how you tested your changes. -->

Tested by running locally through API test client with both response prior, and response after (with `minified=1`) and then with `minified=0`.

Also verified that change didn't affect web / mobile clients

## Screenshots

<!-- If your PR includes any changes to the web client, please include screenshots or a short video from before and after your changes. -->

n/a
