### PR TITLE
Improve book library page query performance on title, titleIgnorePrefix, and addedAt sort orders.

### DIFF
--- a/server/migrations/changelog.md
+++ b/server/migrations/changelog.md
@@ -13,3 +13,4 @@ Please add a record of every database migration that you create to this file. Th
 | v2.17.5        | v2.17.5-remove-host-from-feed-urls           | removes the host (serverAddress) from URL columns in the feeds and feedEpisodes tables                        |
 | v2.17.6        | v2.17.6-share-add-isdownloadable             | Adds the isDownloadable column to the mediaItemShares table                                                   |
 | v2.17.7        | v2.17.7-add-indices                          | Adds indices to the libraryItems and books tables to reduce query times                                       |
+| v2.19.1        | v2.19.1-copy-title-to-library-items          | Copies title and titleIgnorePrefix to the libraryItems table, creates update triggers and indices             |

--- a/server/migrations/v2.19.1-copy-title-to-library-items.js
+++ b/server/migrations/v2.19.1-copy-title-to-library-items.js
@@ -1,0 +1,156 @@
+const util = require('util')
+
+/**
+ * @typedef MigrationContext
+ * @property {import('sequelize').QueryInterface} queryInterface - a suquelize QueryInterface object.
+ * @property {import('../Logger')} logger - a Logger object.
+ *
+ * @typedef MigrationOptions
+ * @property {MigrationContext} context - an object containing the migration context.
+ */
+
+const migrationVersion = '2.19.1'
+const migrationName = `${migrationVersion}-copy-title-to-library-items`
+const loggerPrefix = `[${migrationVersion} migration]`
+
+/**
+ * This upward migration adds a title column to the libraryItems table, copies the title from the book to the libraryItem,
+ * and creates a new index on the title column. In addition it sets a trigger on the books table to update the title column
+ * in the libraryItems table when a book is updated.
+ *
+ * @param {MigrationOptions} options - an object containing the migration context.
+ * @returns {Promise<void>} - A promise that resolves when the migration is complete.
+ */
+async function up({ context: { queryInterface, logger } }) {
+  // Upwards migration script
+  logger.info(`${loggerPrefix} UPGRADE BEGIN: ${migrationName}`)
+
+  await addColumn(queryInterface, logger, 'libraryItems', 'title', { type: queryInterface.sequelize.Sequelize.STRING, allowNull: true })
+  await copyColumn(queryInterface, logger, 'books', 'title', 'id', 'libraryItems', 'title', 'mediaId')
+  await addTrigger(queryInterface, logger, 'books', 'title', 'id', 'libraryItems', 'title', 'mediaId')
+  await addIndex(queryInterface, logger, 'libraryItems', ['libraryId', 'mediaType', { name: 'title', collate: 'NOCASE' }])
+
+  await addColumn(queryInterface, logger, 'libraryItems', 'titleIgnorePrefix', { type: queryInterface.sequelize.Sequelize.STRING, allowNull: true })
+  await copyColumn(queryInterface, logger, 'books', 'titleIgnorePrefix', 'id', 'libraryItems', 'titleIgnorePrefix', 'mediaId')
+  await addTrigger(queryInterface, logger, 'books', 'titleIgnorePrefix', 'id', 'libraryItems', 'titleIgnorePrefix', 'mediaId')
+  await addIndex(queryInterface, logger, 'libraryItems', ['libraryId', 'mediaType', { name: 'titleIgnorePrefix', collate: 'NOCASE' }])
+
+  await addIndex(queryInterface, logger, 'libraryItems', ['libraryId', 'mediaType', 'createdAt'])
+
+  logger.info(`${loggerPrefix} UPGRADE END: ${migrationName}`)
+}
+
+/**
+ * This downward migration script removes the title column from the libraryItems table, removes the trigger on the books table,
+ * and removes the index on the title column.
+ *
+ * @param {MigrationOptions} options - an object containing the migration context.
+ * @returns {Promise<void>} - A promise that resolves when the migration is complete.
+ */
+async function down({ context: { queryInterface, logger } }) {
+  // Downward migration script
+  logger.info(`${loggerPrefix} DOWNGRADE BEGIN: ${migrationName}`)
+
+  await removeIndex(queryInterface, logger, 'libraryItems', ['libraryId', 'mediaType', 'title'])
+  await removeTrigger(queryInterface, logger, 'libraryItems', 'title')
+  await removeColumn(queryInterface, logger, 'libraryItems', 'title')
+
+  await removeIndex(queryInterface, logger, 'libraryItems', ['libraryId', 'mediaType', 'titleIgnorePrefix'])
+  await removeTrigger(queryInterface, logger, 'libraryItems', 'titleIgnorePrefix')
+  await removeColumn(queryInterface, logger, 'libraryItems', 'titleIgnorePrefix')
+
+  await removeIndex(queryInterface, logger, 'libraryItems', ['libraryId', 'mediaType', 'createdAt'])
+
+  logger.info(`${loggerPrefix} DOWNGRADE END: ${migrationName}`)
+}
+
+/**
+ * Utility function to add an index to a table. If the index already z`exists, it logs a message and continues.
+ *
+ * @param {import('sequelize').QueryInterface} queryInterface
+ * @param {import ('../Logger')} logger
+ * @param {string} tableName
+ * @param {string[]} columns
+ */
+async function addIndex(queryInterface, logger, tableName, columns) {
+  const columnString = columns.map((column) => util.inspect(column)).join(', ')
+  const indexName = convertToSnakeCase(`${tableName}_${columns.map((column) => (typeof column === 'string' ? column : column.name)).join('_')}`)
+  try {
+    logger.info(`${loggerPrefix} adding index on [${columnString}] to table ${tableName}. index name: ${indexName}"`)
+    await queryInterface.addIndex(tableName, columns)
+    logger.info(`${loggerPrefix} added index on [${columnString}] to table ${tableName}. index name: ${indexName}"`)
+  } catch (error) {
+    if (error.name === 'SequelizeDatabaseError' && error.message.includes('already exists')) {
+      logger.info(`${loggerPrefix} index [${columnString}] for table "${tableName}" already exists`)
+    } else {
+      throw error
+    }
+  }
+}
+
+/**
+ * Utility function to remove an index from a table.
+ * Sequelize implemets it using DROP INDEX IF EXISTS, so it won't throw an error if the index doesn't exist.
+ *
+ * @param {import('sequelize').QueryInterface} queryInterface
+ * @param {import ('../Logger')} logger
+ * @param {string} tableName
+ * @param {string[]} columns
+ */
+async function removeIndex(queryInterface, logger, tableName, columns) {
+  logger.info(`${loggerPrefix} removing index [${columns.join(', ')}] from table "${tableName}"`)
+  await queryInterface.removeIndex(tableName, columns)
+  logger.info(`${loggerPrefix} removed index [${columns.join(', ')}] from table "${tableName}"`)
+}
+
+async function addColumn(queryInterface, logger, table, column, options) {
+  logger.info(`${loggerPrefix} adding column "${column}" to table "${table}"`)
+  await queryInterface.addColumn(table, column, options)
+  logger.info(`${loggerPrefix} added column "${column}" to table "${table}"`)
+}
+
+async function removeColumn(queryInterface, logger, table, column) {
+  logger.info(`${loggerPrefix} removing column "${column}" from table "${table}"`)
+  await queryInterface.removeColumn(table, column)
+  logger.info(`${loggerPrefix} removed column "${column}" from table "${table}"`)
+}
+
+async function copyColumn(queryInterface, logger, sourceTable, sourceColumn, sourceIdColumn, targetTable, targetColumn, targetIdColumn) {
+  logger.info(`${loggerPrefix} copying column "${sourceColumn}" from table "${sourceTable}" to table "${targetTable}"`)
+  await queryInterface.sequelize.query(`
+    UPDATE ${targetTable}
+    SET ${targetColumn} = ${sourceTable}.${sourceColumn}
+    FROM ${sourceTable}
+    WHERE ${targetTable}.${targetIdColumn} = ${sourceTable}.${sourceIdColumn}
+  `)
+  logger.info(`${loggerPrefix} copied column "${sourceColumn}" from table "${sourceTable}" to table "${targetTable}"`)
+}
+
+async function addTrigger(queryInterface, logger, sourceTable, sourceColumn, sourceIdColumn, targetTable, targetColumn, targetIdColumn) {
+  logger.info(`${loggerPrefix} adding trigger to update ${targetTable}.${targetColumn} when ${sourceTable}.${sourceColumn} is updated`)
+  const triggerName = convertToSnakeCase(`update_${targetTable}_${targetColumn}`)
+  await queryInterface.sequelize.query(`
+    CREATE TRIGGER ${triggerName}
+      AFTER UPDATE OF ${sourceColumn} ON ${sourceTable}
+      FOR EACH ROW
+      BEGIN
+        UPDATE ${targetTable}
+          SET ${targetColumn} = NEW.${sourceColumn}
+        WHERE ${targetTable}.${targetIdColumn} = NEW.${sourceIdColumn};
+      END;
+  `)
+  logger.info(`${loggerPrefix} added trigger to update ${targetTable}.${targetColumn} when ${sourceTable}.${sourceColumn} is updated`)
+}
+
+async function removeTrigger(queryInterface, logger, targetTable, targetColumn) {
+  logger.info(`${loggerPrefix} removing trigger to update ${targetTable}.${targetColumn}`)
+  const triggerName = convertToSnakeCase(`update_${targetTable}_${targetColumn}`)
+  await queryInterface.sequelize.query(`DROP TRIGGER IF EXISTS ${triggerName}`)
+  logger.info(`${loggerPrefix} removed trigger to update ${targetTable}.${targetColumn}`)
+}
+
+function convertToSnakeCase(str) {
+  return str.replace(/([A-Z])/g, '_$1').toLowerCase()
+}
+
+module.exports = { up, down }

--- a/server/models/Book.js
+++ b/server/models/Book.js
@@ -3,6 +3,7 @@ const Logger = require('../Logger')
 const { getTitlePrefixAtEnd, getTitleIgnorePrefix } = require('../utils')
 const parseNameString = require('../utils/parsers/parseNameString')
 const htmlSanitizer = require('../utils/htmlSanitizer')
+const libraryItemsBookFilters = require('../utils/queries/libraryItemsBookFilters')
 
 /**
  * @typedef EBookFileObject
@@ -192,6 +193,14 @@ class Book extends Model {
         ]
       }
     )
+
+    Book.addHook('afterDestroy', async (instance) => {
+      libraryItemsBookFilters.clearCountCache('afterDestroy ')
+    })
+
+    Book.addHook('afterCreate', async (instance) => {
+      libraryItemsBookFilters.clearCountCache('afterCreate')
+    })
   }
 
   /**

--- a/server/models/Book.js
+++ b/server/models/Book.js
@@ -195,7 +195,7 @@ class Book extends Model {
     )
 
     Book.addHook('afterDestroy', async (instance) => {
-      libraryItemsBookFilters.clearCountCache('afterDestroy ')
+      libraryItemsBookFilters.clearCountCache('afterDestroy')
     })
 
     Book.addHook('afterCreate', async (instance) => {

--- a/server/models/LibraryItem.js
+++ b/server/models/LibraryItem.js
@@ -702,6 +702,9 @@ class LibraryItem extends Model {
             fields: ['libraryId', 'mediaType', 'size']
           },
           {
+            fields: ['libraryId', 'mediaType', 'createdAt']
+          },
+          {
             fields: ['libraryId', 'mediaType', { name: 'title', collate: 'NOCASE' }]
           },
           {

--- a/server/models/LibraryItem.js
+++ b/server/models/LibraryItem.js
@@ -73,6 +73,10 @@ class LibraryItem extends Model {
 
     /** @type {Book.BookExpanded|Podcast.PodcastExpanded} - only set when expanded */
     this.media
+    /** @type {string} */
+    this.title // Only used for sorting
+    /** @type {string} */
+    this.titleIgnorePrefix // Only used for sorting
   }
 
   /**
@@ -677,7 +681,9 @@ class LibraryItem extends Model {
         lastScan: DataTypes.DATE,
         lastScanVersion: DataTypes.STRING,
         libraryFiles: DataTypes.JSON,
-        extraData: DataTypes.JSON
+        extraData: DataTypes.JSON,
+        title: DataTypes.STRING,
+        titleIgnorePrefix: DataTypes.STRING
       },
       {
         sequelize,
@@ -694,6 +700,12 @@ class LibraryItem extends Model {
           },
           {
             fields: ['libraryId', 'mediaType', 'size']
+          },
+          {
+            fields: ['libraryId', 'mediaType', { name: 'title', collate: 'NOCASE' }]
+          },
+          {
+            fields: ['libraryId', 'mediaType', { name: 'titleIgnorePrefix', collate: 'NOCASE' }]
           },
           {
             fields: ['libraryId', 'mediaId', 'mediaType']

--- a/server/scanner/BookScanner.js
+++ b/server/scanner/BookScanner.js
@@ -521,6 +521,8 @@ class BookScanner {
     libraryItemObj.isMissing = false
     libraryItemObj.isInvalid = false
     libraryItemObj.extraData = {}
+    libraryItemObj.title = bookMetadata.title
+    libraryItemObj.titleIgnorePrefix = getTitleIgnorePrefix(bookMetadata.title)
 
     // Set isSupplementary flag on ebook library files
     for (const libraryFile of libraryItemObj.libraryFiles) {

--- a/server/utils/profiler.js
+++ b/server/utils/profiler.js
@@ -1,0 +1,41 @@
+const { performance, createHistogram } = require('perf_hooks')
+const util = require('util')
+const Logger = require('../Logger')
+
+const histograms = new Map()
+
+function profile(asyncFunc, isFindQuery = true, funcName = asyncFunc.name) {
+  if (!histograms.has(funcName)) {
+    const histogram = createHistogram()
+    histogram.values = []
+    histograms.set(funcName, histogram)
+  }
+  const histogram = histograms.get(funcName)
+
+  return async (...args) => {
+    if (isFindQuery) {
+      const findOptions = args[0]
+      Logger.info(`[${funcName}] findOptions:`, util.inspect(findOptions, { depth: null }))
+      findOptions.logging = (query, time) => Logger.info(`[${funcName}] ${query} Elapsed time: ${time}ms`)
+      findOptions.benchmark = true
+    }
+    const start = performance.now()
+    try {
+      const result = await asyncFunc(...args)
+      return result
+    } catch (error) {
+      Logger.error(`[${funcName}] failed`)
+      throw error
+    } finally {
+      const end = performance.now()
+      const duration = Math.round(end - start)
+      histogram.record(duration)
+      histogram.values.push(duration)
+      Logger.info(`[${funcName}] duration: ${duration}ms`)
+      Logger.info(`[${funcName}] histogram values:`, histogram.values)
+      Logger.info(`[${funcName}] histogram:`, histogram)
+    }
+  }
+}
+
+module.exports = { profile }

--- a/test/server/migrations/v2.19.1-copy-title-to-library-items.test.js
+++ b/test/server/migrations/v2.19.1-copy-title-to-library-items.test.js
@@ -1,0 +1,148 @@
+const chai = require('chai')
+const sinon = require('sinon')
+const { expect } = chai
+
+const { DataTypes, Sequelize } = require('sequelize')
+const Logger = require('../../../server/Logger')
+
+const { up, down } = require('../../../server/migrations/v2.19.1-copy-title-to-library-items')
+
+describe('Migration v2.19.1-copy-title-to-library-items', () => {
+  let sequelize
+  let queryInterface
+  let loggerInfoStub
+
+  beforeEach(async () => {
+    sequelize = new Sequelize({ dialect: 'sqlite', storage: ':memory:', logging: false })
+    queryInterface = sequelize.getQueryInterface()
+    loggerInfoStub = sinon.stub(Logger, 'info')
+
+    await queryInterface.createTable('books', {
+      id: { type: DataTypes.INTEGER, allowNull: false, primaryKey: true, unique: true },
+      title: { type: DataTypes.STRING, allowNull: true },
+      titleIgnorePrefix: { type: DataTypes.STRING, allowNull: true }
+    })
+
+    await queryInterface.createTable('libraryItems', {
+      id: { type: DataTypes.INTEGER, allowNull: false, primaryKey: true, unique: true },
+      libraryId: { type: DataTypes.INTEGER, allowNull: false },
+      mediaType: { type: DataTypes.STRING, allowNull: false },
+      mediaId: { type: DataTypes.INTEGER, allowNull: false },
+      createdAt: { type: DataTypes.DATE, allowNull: false }
+    })
+
+    await queryInterface.bulkInsert('books', [
+      { id: 1, title: 'The Book 1', titleIgnorePrefix: 'Book 1, The' },
+      { id: 2, title: 'Book 2', titleIgnorePrefix: 'Book 2' }
+    ])
+
+    await queryInterface.bulkInsert('libraryItems', [
+      { id: 1, libraryId: 1, mediaType: 'book', mediaId: 1, createdAt: '2025-01-01 00:00:00.000 +00:00' },
+      { id: 2, libraryId: 2, mediaType: 'book', mediaId: 2, createdAt: '2025-01-02 00:00:00.000 +00:00' }
+    ])
+  })
+
+  afterEach(() => {
+    sinon.restore()
+  })
+
+  describe('up', () => {
+    it('should copy title and titleIgnorePrefix to libraryItems', async () => {
+      await up({ context: { queryInterface, logger: Logger } })
+
+      const [libraryItems] = await queryInterface.sequelize.query('SELECT * FROM libraryItems')
+      expect(libraryItems).to.deep.equal([
+        { id: 1, libraryId: 1, mediaType: 'book', mediaId: 1, title: 'The Book 1', titleIgnorePrefix: 'Book 1, The', createdAt: '2025-01-01 00:00:00.000 +00:00' },
+        { id: 2, libraryId: 2, mediaType: 'book', mediaId: 2, title: 'Book 2', titleIgnorePrefix: 'Book 2', createdAt: '2025-01-02 00:00:00.000 +00:00' }
+      ])
+    })
+
+    it('should add index on title to libraryItems', async () => {
+      await up({ context: { queryInterface, logger: Logger } })
+
+      const [[{ count }]] = await queryInterface.sequelize.query(`SELECT COUNT(*) as count FROM sqlite_master WHERE type='index' AND name='library_items_library_id_media_type_title_ignore_prefix'`)
+      expect(count).to.equal(1)
+    })
+
+    it('should add trigger to books.title to update libraryItems.title', async () => {
+      await up({ context: { queryInterface, logger: Logger } })
+
+      const [[{ count }]] = await queryInterface.sequelize.query(`SELECT COUNT(*) as count FROM sqlite_master WHERE type='trigger' AND name='update_library_items_title'`)
+      expect(count).to.equal(1)
+    })
+
+    it('should add index on titleIgnorePrefix to libraryItems', async () => {
+      await up({ context: { queryInterface, logger: Logger } })
+
+      const [[{ count }]] = await queryInterface.sequelize.query(`SELECT COUNT(*) as count FROM sqlite_master WHERE type='index' AND name='library_items_library_id_media_type_title_ignore_prefix'`)
+      expect(count).to.equal(1)
+    })
+
+    it('should add trigger to books.titleIgnorePrefix to update libraryItems.titleIgnorePrefix', async () => {
+      await up({ context: { queryInterface, logger: Logger } })
+
+      const [[{ count }]] = await queryInterface.sequelize.query(`SELECT COUNT(*) as count FROM sqlite_master WHERE type='trigger' AND name='update_library_items_title_ignore_prefix'`)
+      expect(count).to.equal(1)
+    })
+
+    it('should add index on createdAt to libraryItems', async () => {
+      await up({ context: { queryInterface, logger: Logger } })
+
+      const [[{ count }]] = await queryInterface.sequelize.query(`SELECT COUNT(*) as count FROM sqlite_master WHERE type='index' AND name='library_items_library_id_media_type_created_at'`)
+      expect(count).to.equal(1)
+    })
+  })
+
+  describe('down', () => {
+    it('should remove title and titleIgnorePrefix from libraryItems', async () => {
+      await up({ context: { queryInterface, logger: Logger } })
+      await down({ context: { queryInterface, logger: Logger } })
+
+      const [libraryItems] = await queryInterface.sequelize.query('SELECT * FROM libraryItems')
+      expect(libraryItems).to.deep.equal([
+        { id: 1, libraryId: 1, mediaType: 'book', mediaId: 1, createdAt: '2025-01-01 00:00:00.000 +00:00' },
+        { id: 2, libraryId: 2, mediaType: 'book', mediaId: 2, createdAt: '2025-01-02 00:00:00.000 +00:00' }
+      ])
+    })
+
+    it('should remove title trigger from books', async () => {
+      await up({ context: { queryInterface, logger: Logger } })
+      await down({ context: { queryInterface, logger: Logger } })
+
+      const [[{ count }]] = await queryInterface.sequelize.query(`SELECT COUNT(*) as count FROM sqlite_master WHERE type='trigger' AND name='update_library_items_title'`)
+      expect(count).to.equal(0)
+    })
+
+    it('should remove titleIgnorePrefix trigger from books', async () => {
+      await up({ context: { queryInterface, logger: Logger } })
+      await down({ context: { queryInterface, logger: Logger } })
+
+      const [[{ count }]] = await queryInterface.sequelize.query(`SELECT COUNT(*) as count FROM sqlite_master WHERE type='trigger' AND name='update_library_items_title_ignore_prefix'`)
+      expect(count).to.equal(0)
+    })
+
+    it('should remove index on titleIgnorePrefix from libraryItems', async () => {
+      await up({ context: { queryInterface, logger: Logger } })
+      await down({ context: { queryInterface, logger: Logger } })
+
+      const [[{ count }]] = await queryInterface.sequelize.query(`SELECT COUNT(*) as count FROM sqlite_master WHERE type='index' AND name='library_items_library_id_media_type_title_ignore_prefix'`)
+      expect(count).to.equal(0)
+    })
+
+    it('should remove index on title from libraryItems', async () => {
+      await up({ context: { queryInterface, logger: Logger } })
+      await down({ context: { queryInterface, logger: Logger } })
+
+      const [[{ count }]] = await queryInterface.sequelize.query(`SELECT COUNT(*) as count FROM sqlite_master WHERE type='index' AND name='library_items_library_id_media_type_title'`)
+      expect(count).to.equal(0)
+    })
+
+    it('should remove index on createdAt from libraryItems', async () => {
+      await up({ context: { queryInterface, logger: Logger } })
+      await down({ context: { queryInterface, logger: Logger } })
+
+      const [[{ count }]] = await queryInterface.sequelize.query(`SELECT COUNT(*) as count FROM sqlite_master WHERE type='index' AND name='library_items_library_id_media_type_created_at'`)
+      expect(count).to.equal(0)
+    })
+  })
+})


### PR DESCRIPTION
## Brief summary

Significantly improves book library Sequelize page queries for the following sort orders:
- title (with or without ignorePrefix)
- addedAt

## Which issue is fixed?

This partially fixes #2073 (resolving the book library load times, but not the podcast library load times)

## In-depth Description

After digging more into the details of the issues people were complaining about in #2073 and doing additional performance analysis in Sequelize query to bring the page [here](https://github.com/advplyr/audiobookshelf/blob/25ae6dd59a06f9f6f62c97d98ead908b23d5bc37/server/utils/queries/libraryItemsBookFilters.js#L563), I made the following observations:
1. Due the the current architecture of the database (specifically, the separate libraryItems and books tables), SQLite cannot sort the results of the main query efficiently, even when an index on the sorted book column exists (more details below)
2. The main query performs a join with the feeds table, which somehat complicates the query (especialy if there are many feeds)
3. A query for the total count of results is run every time, even though it is usually unnecessary as the total count doesn't change during a scrolling over the library.

1 is by far the most serious problem, and also causes significant degradation in query performance as the offset becomes larger. 
When the main query is sorting by title:
```
SELECT book.*, libraryItem.*, [libraryItem->feeds].*
  FROM books AS book
       INNER JOIN
       libraryItems AS libraryItem ON book.id = libraryItem.mediaId AND 
                                      (libraryItem.libraryId = 'b3bf8580-edba-4d7d-90eb-3b54206d16c3' AND 
                                       libraryItem.mediaType = 'book') 
       LEFT OUTER JOIN
       feeds AS [libraryItem->feeds] ON libraryItem.id = [libraryItem->feeds].entityId AND 
                                        [libraryItem->feeds].entityType = 'libraryItem'
 ORDER BY book.title ASC
 LIMIT 0, 35;
```
it's evident in the query plan that the query engine cannot use the existing book.title index, and needs to build a temporary tree for sorting.
```
SEARCH libraryItem USING INDEX library_items_library_id_media_type_size (libraryId=? AND mediaType=?)
SEARCH book USING INDEX sqlite_autoindex_books_1 (id=?)
SCAN libraryItem->feeds LEFT-JOIN
USE TEMP B-TREE FOR ORDER BY
```

Even when you remove the `feeds` table join from the query:
```
SELECT book.*, libraryItem.*
  FROM books AS book
       INNER JOIN
       libraryItems AS libraryItem ON book.id = libraryItem.mediaId AND 
                                      (libraryItem.libraryId = 'b3bf8580-edba-4d7d-90eb-3b54206d16c3' AND 
                                       libraryItem.mediaType = 'book') 
 ORDER BY book.title ASC
 LIMIT 0, 35;
```
The query plan still doesn't make use of the book.title index:
```
SEARCH libraryItem USING INDEX library_items_library_id_media_type_size (libraryId=? AND mediaType=?)
SEARCH book USING INDEX sqlite_autoindex_books_1 (id=?)
USE TEMP B-TREE FOR ORDER BY
```

The significant boost in performance can come only if the title column is put in the libraryItems table, and an index on `(libraryId, mediaType, title)` is built. This way, filtering and sorting happens at the same time, and the index can be traveresed very quickly to reach the required offset without needing to look at the tables themselves.

So with a query like this:
```
SELECT book.*, libraryItem.*
  FROM books AS book
       INNER JOIN
       libraryItems AS libraryItem ON book.id = libraryItem.mediaId AND 
                                      (libraryItem.libraryId = 'b3bf8580-edba-4d7d-90eb-3b54206d16c3' AND 
                                       libraryItem.mediaType = 'book') 
 ORDER BY libraryItem.title ASC
 LIMIT 0, 35;
```
We get the following query plan:
```
SEARCH libraryItem USING INDEX library_items_library_id_media_type_title (libraryId=? AND mediaType=?)
SEARCH book USING INDEX sqlite_autoindex_books_1 (id=?)
```
Which is optimal! (or, to be more precise, optimal given the current architecture)


### Resolution
The following changes were made:
1. `title` and `titleIgnorePrefix` columns were added to `libraryItems`
2. Triggers were put in place to update the new column values whenever the corresponding values in `books` change.
3. The following Indices were added to `libraryItems`:
    - `(libraryId, mediaType, title)`
    - `(libraryId, mediaType, titleIgnorePrefix)`
    - `(libraryId, mediaType, createdAt)`
4. The feeds query was separated from the main query
5. A total count cache was introduced. 
    - If the count for a given query is found in the cache, `findAll` is called instead of `findAndCountAll`
    - The cache is invalidated whenever book records are added or removed.

## How have you tested this?

I tested on loading 72 consecutive page of 35 books each, on each of the above sorting orders, on an ABS docker container running on a Synology 920+ NAS (I wanted to test on a hardware that was much weaker than my dev machine).

### Results

All measurements are in ms.

**Summary**
Overall, we see a **94-95% drop** (!) in mean and median query time. 
Standard deviaion also reduces drastically from ~400 to ~10.

Note how the steady rise in query time (as the the requested offset grows) which is quite visible before, is not noticable after.

**Sorting by title - before:**
```
[2025-02-08 09:16:21.962] INFO: [bound findAndCountAll] histogram values: [
   191,  261,  257,  314,  296,  328,  336,  376,  398,
   453,  476,  535,  513,  594,  585,  618,  638,  672,
   666,  700,  736,  715,  745,  757,  810,  864,  863,
   849,  897,  898,  962,  985, 1003, 1063, 1086, 1084,
  1114, 1131, 1152, 1147, 1197, 1198, 1224, 1236, 1265,
  1318, 1345, 1216, 1313, 1315, 1284, 1302, 1309, 1353,
  1381, 1360, 1348, 1445, 1322, 1423, 1390, 1426, 1473,
  1550, 1512, 1513, 1495, 1539, 1550, 1573, 1614, 1629
]
[2025-02-08 09:16:21.962] INFO: [bound findAndCountAll] histogram: Histogram {
  min: 191,
  max: 1629,
  mean: 1006.75,
  exceeds: 0,
  stddev: 410.08172457856904,
  count: 72,
  percentiles: SafeMap(9) [Map] {
    0 => 191,
    50 => 1086,
    75 => 1345,
    87.5 => 1473,
    93.75 => 1550,
    96.875 => 1573,
    98.4375 => 1614,
    99.21875 => 1629,
    100 => 1629
  }
}
```
**Sorting by title - after:**
```
[2025-02-08 07:58:39.193] INFO: [findAndCountAll] histogram values: [
  87, 104, 70, 70, 51, 57, 77, 49, 54, 60, 57, 58,
  60,  47, 87, 47, 57, 68, 49, 66, 50, 55, 64, 45,
  48,  54, 67, 46, 65, 53, 79, 44, 72, 75, 85, 52,
  61,  65, 56, 60, 58, 67, 70, 63, 53, 52, 50, 55,
  53,  62, 54, 58, 50, 52, 67, 53, 58, 55, 65, 50,
  56,  57, 66, 75, 48, 57, 56, 52, 49, 75, 65, 87
]
[2025-02-08 07:58:39.193] INFO: [findAndCountAll] histogram: Histogram {
  min: 44,
  max: 104,
  mean: 60.541666666666664,
  exceeds: 0,
  stddev: 11.6665922616675,
  count: 72,
  percentiles: SafeMap(9) [Map] {
    0 => 44,
    50 => 57,
    75 => 66,
    87.5 => 75,
    93.75 => 85,
    96.875 => 87,
    98.4375 => 87,
    99.21875 => 104,
    100 => 104
  }
}
```
**Sorting by titleIgnorePrefix - before:**
```
[2025-02-08 09:28:31.290] INFO: [bound findAndCountAll] histogram values: [
   191,  257,  286,  297,  321,  357,  382,  432,  405,
   470,  513,  516,  560,  543,  609,  639,  646,  748,
   670,  757,  819,  790,  814,  866,  899,  969,  970,
  1033, 1033, 1026, 1073, 1109, 1099, 1120, 1165, 1203,
  1184, 1317, 1280, 1270, 1305, 1355, 1336, 1329, 1367,
  1413, 1401, 1406, 1441, 1520, 1433, 1471, 1569, 1455,
  1495, 1509, 1519, 1513, 1527, 1539, 1568, 1559, 1605,
  1561, 1627, 1637, 1642, 1670, 1693, 1701, 1729, 1695
]
[2025-02-08 09:28:31.291] INFO: [bound findAndCountAll] histogram: Histogram {
  min: 191,
  max: 1729,
  mean: 1100.388888888889,
  exceeds: 0,
  stddev: 453.3125778200694,
  count: 72,
  percentiles: SafeMap(9) [Map] {
    0 => 191,
    50 => 1184,
    75 => 1509,
    87.5 => 1569,
    93.75 => 1670,
    96.875 => 1695,
    98.4375 => 1701,
    99.21875 => 1729,
    100 => 1729
  }
}
```
**Sorting by titleIgnorePrefix - after:**
```
[2025-02-08 08:21:02.593] INFO: [findAndCountAll] histogram values: [
   70, 83, 71, 51, 78, 77, 53, 59, 54, 49, 79, 49,
   48, 51, 64, 48, 48, 51, 54, 58, 50, 49, 59, 53,
  103, 58, 57, 59, 55, 56, 46, 49, 59, 67, 50, 53,
   87, 53, 56, 72, 57, 52, 56, 87, 66, 58, 83, 53,
   62, 59, 71, 53, 61, 57, 53, 61, 66, 49, 65, 52,
   63, 54, 58, 64, 74, 74, 70, 72, 53, 67, 88, 62
]
[2025-02-08 08:21:02.593] INFO: [findAndCountAll] histogram: Histogram {
  min: 46,
  max: 103,
  mean: 61.19444444444444,
  exceeds: 0,
  stddev: 11.67456743058851,
  count: 72,
  percentiles: SafeMap(9) [Map] {
    0 => 46,
    50 => 58,
    75 => 67,
    87.5 => 74,
    93.75 => 83,
    96.875 => 87,
    98.4375 => 88,
    99.21875 => 103,
    100 => 103
  }
}
```

**Sorting by addedAt - before:**
```
[2025-02-08 09:43:29.037] INFO: [bound findAndCountAll] histogram values: [
   277,  278,  305,  334,  368,  428,  464,  505,  503,
   581,  626,  636,  674,  694,  775,  771,  822,  829,
   859,  805,  858,  817,  941,  953,  985, 1021,  991,
  1029, 1111, 1094, 1131, 1130, 1169, 1216, 1225, 1166,
  1215, 1253, 1198, 1272, 1365, 1313, 1298, 1336, 1330,
  1407, 1382, 1406, 1496, 1420, 1578, 1551, 1429, 1403,
  1488, 1407, 1443, 1448, 1484, 1420, 1474, 1473, 1496,
  1478, 1476, 1518, 1514, 1520, 1568, 1577, 1554, 1579
]
[2025-02-08 09:43:29.038] INFO: [bound findAndCountAll] histogram: Histogram {
  min: 277,
  max: 1579,
  mean: 1110.2777777777778,
  exceeds: 0,
  stddev: 388.1921138868623,
  count: 72,
  percentiles: SafeMap(9) [Map] {
    0 => 277,
    50 => 1215,
    75 => 1443,
    87.5 => 1496,
    93.75 => 1554,
    96.875 => 1577,
    98.4375 => 1578,
    99.21875 => 1579,
    100 => 1579
  }
}
```
**Sorting by addedAt - after:**
```
[2025-02-08 08:07:23.636] INFO: [findAndCountAll] histogram values: [
  94, 83, 65, 70, 79, 51, 51, 61, 63, 63, 50, 76,
  48, 65, 59, 55, 73, 48, 63, 51, 56, 44, 59, 52,
  69, 56, 67, 55, 64, 54, 65, 54, 68, 62, 54, 72,
  53, 72, 49, 52, 69, 59, 55, 62, 56, 75, 48, 59,
  59, 50, 72, 44, 48, 47, 54, 65, 51, 65, 50, 47,
  85, 55, 49, 54, 45, 50, 49, 62, 60, 43, 53, 49
]
[2025-02-08 08:07:23.636] INFO: [findAndCountAll] histogram: Histogram {
  min: 43,
  max: 94,
  mean: 58.80555555555556,
  exceeds: 0,
  stddev: 10.483636573368477,
  count: 72,
  percentiles: SafeMap(9) [Map] {
    0 => 43,
    50 => 56,
    75 => 65,
    87.5 => 72,
    93.75 => 76,
    96.875 => 83,
    98.4375 => 85,
    99.21875 => 94,
    100 => 94
  }
}
```