### PR TITLE
Fix `ROUTER_BASE_PATH` override for empty string

### DIFF
--- a/client/nuxt.config.js
+++ b/client/nuxt.config.js
@@ -1,6 +1,6 @@
 const pkg = require('./package.json')
 
-const routerBasePath = process.env.ROUTER_BASE_PATH || '/audiobookshelf'
+const routerBasePath = process.env.ROUTER_BASE_PATH ?? '/audiobookshelf'
 const serverHostUrl = process.env.NODE_ENV === 'production' ? '' : 'http://localhost:3333'
 const serverPaths = ['api/', 'public/', 'hls/', 'auth/', 'feed/', 'status', 'login', 'logout', 'init']
 const proxy = Object.fromEntries(serverPaths.map((path) => [`${routerBasePath}/${path}`, { target: process.env.NODE_ENV !== 'production' ? serverHostUrl : '/' }]))

--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ if (isDev) {
   if (devEnv.AllowIframe) process.env.ALLOW_IFRAME = '1'
   if (devEnv.BackupPath) process.env.BACKUP_PATH = devEnv.BackupPath
   process.env.SOURCE = 'local'
-  process.env.ROUTER_BASE_PATH = devEnv.RouterBasePath || ''
+  process.env.ROUTER_BASE_PATH = devEnv.RouterBasePath ?? ''
 }
 
 const inputConfig = options.config ? Path.resolve(options.config) : null
@@ -41,7 +41,7 @@ const CONFIG_PATH = inputConfig || process.env.CONFIG_PATH || Path.resolve('conf
 const METADATA_PATH = inputMetadata || process.env.METADATA_PATH || Path.resolve('metadata')
 const SOURCE = options.source || process.env.SOURCE || 'debian'
 
-const ROUTER_BASE_PATH = process.env.ROUTER_BASE_PATH || '/audiobookshelf'
+const ROUTER_BASE_PATH = process.env.ROUTER_BASE_PATH ?? '/audiobookshelf'
 
 console.log(`Running in ${process.env.NODE_ENV} mode.`)
 console.log(`Options: CONFIG_PATH=${CONFIG_PATH}, METADATA_PATH=${METADATA_PATH}, PORT=${PORT}, HOST=${HOST}, SOURCE=${SOURCE}, ROUTER_BASE_PATH=${ROUTER_BASE_PATH}`)

--- a/prod.js
+++ b/prod.js
@@ -25,7 +25,7 @@ const CONFIG_PATH = inputConfig || process.env.CONFIG_PATH || Path.resolve('conf
 const METADATA_PATH = inputMetadata || process.env.METADATA_PATH || Path.resolve('metadata')
 const SOURCE = options.source || process.env.SOURCE || 'debian'
 
-const ROUTER_BASE_PATH = process.env.ROUTER_BASE_PATH || '/audiobookshelf'
+const ROUTER_BASE_PATH = process.env.ROUTER_BASE_PATH ?? '/audiobookshelf'
 
 console.log(process.env.NODE_ENV, 'Config', CONFIG_PATH, METADATA_PATH)
 


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

When the `ROUTER_BASE_PATH` env variable is set to an empty string it's mistakenly overriden to `/audiobookshelf` instead.
The `/audiobookshelf` fallback should only be used when the `ROUTER_BASE_PATH` env variable is undefined, not just an empty string.

Regression introduced in https://github.com/advplyr/audiobookshelf/pull/3810
See also: https://github.com/advplyr/audiobookshelf/pull/3810#discussion_r1948790937

## Which issue is fixed?

Related: https://github.com/advplyr/audiobookshelf/issues/3874 (requires frontend recompilation to fix that one)

## How have you tested this?

Running the following before starting Audiobookshelf:

```shell
export ROUTER_BASE_PATH=''
```

## Screenshots

N/A
