### PR TITLE
Security fix for GHSA-pg8v-5jcv-wrvw

### DIFF
--- a/server/Auth.js
+++ b/server/Auth.js
@@ -10,6 +10,7 @@ const ExtractJwt = require('passport-jwt').ExtractJwt
 const OpenIDClient = require('openid-client')
 const Database = require('./Database')
 const Logger = require('./Logger')
+const { escapeRegExp } = require('./utils')
 
 /**
  * @class Class for handling all the authentication related functionality.
@@ -18,7 +19,11 @@ class Auth {
   constructor() {
     // Map of openId sessions indexed by oauth2 state-variable
     this.openIdAuthSession = new Map()
-    this.ignorePatterns = [/\/api\/items\/[^/]+\/cover/, /\/api\/authors\/[^/]+\/image/]
+    const escapedRouterBasePath = escapeRegExp(global.RouterBasePath)
+    this.ignorePatterns = [
+      new RegExp(`^(${escapedRouterBasePath}/api)?/items/[^/]+/cover$`), 
+      new RegExp(`^(${escapedRouterBasePath}/api)?/authors/[^/]+/image$`)
+    ]
   }
 
   /**
@@ -28,7 +33,7 @@ class Auth {
    * @private
    */
   authNotNeeded(req) {
-    return req.method === 'GET' && this.ignorePatterns.some((pattern) => pattern.test(req.originalUrl))
+    return req.method === 'GET' && this.ignorePatterns.some((pattern) => pattern.test(req.path))
   }
 
   ifAuthNeeded(middleware) {


### PR DESCRIPTION
## Brief summary

This fixes the security issue noted in the advisory below:
- it matches against anchored patterns
- it tests `req.path` against the patterns (instead of `req.originalUrl`)

## Which issue is fixed?

https://github.com/advplyr/audiobookshelf/security/advisories/GHSA-pg8v-5jcv-wrvw

## In-depth Description

Because we are now testing `req.path` against anchored patterns, the pattens needed to be changed a bit, since this code (which is called from the `ifAuthNeeded` middleware is used in two separate locations:
- at the app level, where `req.path` begins with `${global.RouterBasePath}/api`
- at the API router level, where `req.path` is already stripped of `${global.RouterBasePath}/api`

So the patterns need to change to:
```js
      new RegExp(`^(${escapedRouterBasePath}/api)?/items/[^/]+/cover$`), 
      new RegExp(`^(${escapedRouterBasePath}/api)?/authors/[^/]+/image$`)
```

In our case escapedRouterBasePath will be `/audiobookshelf`, so the patterns will accept the following examples:
```
/audiobookshelf/api/items/{itemid}/cover
/audiobookshelf/api/authors/{authorid}/image
/items/{itemid}/cover
/authors/{authorid}/image
```

## How have you tested this?

- Checked the patterns against all the malicious URLs mentioned in the advisory. They now match none of them.
- Checked that the ifAuthNeeded still identifies covers and author image requests as not requiring authentication, in both locations used.