### PR TITLE
fix: allow upgrading HTTP to HTTPS for redirects

### DIFF
--- a/server/utils/podcastUtils.js
+++ b/server/utils/podcastUtils.js
@@ -343,6 +343,14 @@ module.exports.getPodcastFeed = (feedUrl, excludeEpisodeMetadata = false) => {
       return payload.podcast
     })
     .catch((error) => {
+      // Check for failures due to redirecting from http to https. If original url was http, upgrade to https and try again
+      if (error.code === 'ERR_FR_REDIRECTION_FAILURE' && error.cause.code === 'ERR_INVALID_PROTOCOL') {
+        if (feedUrl.startsWith('http://') && error.request._options.protocol === 'https:') {
+          Logger.info('Redirection from http to https detected. Upgrading Request', error.request._options.href)
+          feedUrl = feedUrl.replace('http://', 'https://')
+          return this.getPodcastFeed(feedUrl, excludeEpisodeMetadata)
+        }
+      }
       Logger.error('[podcastUtils] getPodcastFeed Error', error)
       return null
     })


### PR DESCRIPTION
## Brief Summary
Allow adding podcasts where the server detects an `http` domain and redirects to an `https` domain. Currently, these fail with an error message that is not useful to the end user.

## Which Issue is Fixed?
Fixes #3142  
Fixes #3658  

## In-Depth Description
This error occurs for several mainstream podcasts, likely impacting multiple users. I lost some spouse approval points due to this issue. 😅

The root cause is that we are not allowing the Axios client to redirect between domains with different protocols. As a result, any feed URL detected as `http` that redirects to a different `https` domain would fail, leaving users without a clear resolution.  

### **The Fix**
- When a podcast feed request fails due to a redirection error caused by an invalid protocol, we check if the redirection is **from `http` to `https`**.
- If so, we upgrade the **original** URL to `https` and retry the request.
- If the original URL does not have a corresponding `https` version or another protocol change occurs (e.g., `https` → `http`), the request will still fail, ensuring we do not introduce security risks.

## How Have You Tested This?
I confirmed that the following podcasts were failing to add in the current version (`v2.19.2`) of Audiobookshelf.  

After making my changes, I was able to successfully add all three podcasts through the UI:  
- *D&D is for Nerds*  
- *The New Yorker: The Writer's Voice - New Fiction from The New Yorker*  
- *Radiolab*  
