### PR TITLE
Fix count cache by stringify Symbols #3979

### DIFF
--- a/server/utils/queries/libraryItemsBookFilters.js
+++ b/server/utils/queries/libraryItemsBookFilters.js
@@ -5,7 +5,7 @@ const authorFilters = require('./authorFilters')
 
 const ShareManager = require('../../managers/ShareManager')
 const { profile } = require('../profiler')
-
+const stringifySequelizeQuery = require('../stringifySequelizeQuery')
 const countCache = new Map()
 
 module.exports = {
@@ -345,7 +345,7 @@ module.exports = {
   },
 
   async findAndCountAll(findOptions, limit, offset) {
-    const findOptionsKey = JSON.stringify(findOptions)
+    const findOptionsKey = stringifySequelizeQuery(findOptions)
     Logger.debug(`[LibraryItemsBookFilters] findOptionsKey: ${findOptionsKey}`)
 
     findOptions.limit = limit || null
@@ -353,6 +353,7 @@ module.exports = {
 
     if (countCache.has(findOptionsKey)) {
       const rows = await Database.bookModel.findAll(findOptions)
+
       return { rows, count: countCache.get(findOptionsKey) }
     } else {
       const result = await Database.bookModel.findAndCountAll(findOptions)

--- a/server/utils/stringifySequelizeQuery.js
+++ b/server/utils/stringifySequelizeQuery.js
@@ -1,0 +1,34 @@
+function stringifySequelizeQuery(findOptions) {
+  // Helper function to handle symbols in nested objects
+  function handleSymbols(obj) {
+    if (!obj || typeof obj !== 'object') return obj
+
+    if (Array.isArray(obj)) {
+      return obj.map(handleSymbols)
+    }
+
+    const newObj = {}
+    for (const [key, value] of Object.entries(obj)) {
+      // Handle Symbol keys from Object.getOwnPropertySymbols
+      Object.getOwnPropertySymbols(obj).forEach((sym) => {
+        newObj[`__Op.${sym.toString()}`] = handleSymbols(obj[sym])
+      })
+
+      // Handle regular keys
+      if (typeof key === 'string') {
+        if (value && typeof value === 'object' && Object.getPrototypeOf(value) === Symbol.prototype) {
+          // Handle Symbol values
+          newObj[key] = `__Op.${value.toString()}`
+        } else {
+          // Recursively handle nested objects
+          newObj[key] = handleSymbols(value)
+        }
+      }
+    }
+    return newObj
+  }
+
+  const sanitizedOptions = handleSymbols(findOptions)
+  return JSON.stringify(sanitizedOptions)
+}
+module.exports = stringifySequelizeQuery


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

Book library queries are returning the incorrect count because the cached key is matching when it shouldn't. 

Sequelizes uses Symbols in the queries and JSON.stringify ignores these. This adds a separate function that sanitizes the query before Stringify.

## Which issue is fixed?

Fixes #3979

## In-depth Description

Reproduce by filtering by Issues and clearing the filter. Those 2 cache keys will be the same because the library item where option is not stringified.

