### PR TITLE
Fix chapter end sleep timer sometimes not stopping #3969

### DIFF
--- a/client/components/app/MediaPlayerContainer.vue
+++ b/client/components/app/MediaPlayerContainer.vue
@@ -85,7 +85,8 @@ export default {
       displayTitle: null,
       currentPlaybackRate: 1,
       syncFailedToast: null,
-      coverAspectRatio: 1
+      coverAspectRatio: 1,
+      lastChapterId: null
     }
   },
   computed: {
@@ -236,12 +237,16 @@ export default {
         }
       }, 1000)
     },
-    checkChapterEnd(time) {
+    checkChapterEnd() {
       if (!this.currentChapter) return
-      const chapterEndTime = this.currentChapter.end
-      const tolerance = 0.75
-      if (time >= chapterEndTime - tolerance) {
-        this.sleepTimerEnd()
+
+      // Track chapter transitions by comparing current chapter with last chapter
+      if (this.lastChapterId !== this.currentChapter.id) {
+        // Chapter changed - if we had a previous chapter, this means we crossed a boundary
+        if (this.lastChapterId) {
+          this.sleepTimerEnd()
+        }
+        this.lastChapterId = this.currentChapter.id
       }
     },
     sleepTimerEnd() {
@@ -301,7 +306,7 @@ export default {
       }
 
       if (this.sleepTimerType === this.$constants.SleepTimerTypes.CHAPTER && this.sleepTimerSet) {
-        this.checkChapterEnd(time)
+        this.checkChapterEnd()
       }
     },
     setDuration(duration) {


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

End of chapter sleep timer implemented in #2059 has an issue where the chapter can switch between function calls to `checkChapterEnd`.
It is easiest to test this bug by increasing the playback speed

## Which issue is fixed?

Fixes #3969

## In-depth Description

This is solved by storing the last chapter id and comparing the current chapter with the last. If they changed then stop the timer.

The difference from the previous implementation will be that if you change chapters while the EoC sleep timer is activated then it will end the sleep timer. I think that is normal
