### PR TITLE
Fix server crash when quick match all updates series sequence #3961

### DIFF
--- a/server/models/LibraryItem.js
+++ b/server/models/LibraryItem.js
@@ -103,7 +103,7 @@ class LibraryItem extends Model {
             {
               model: this.sequelize.models.series,
               through: {
-                attributes: ['sequence', 'createdAt']
+                attributes: ['id', 'sequence', 'createdAt']
               }
             }
           ]

--- a/server/scanner/Scanner.js
+++ b/server/scanner/Scanner.js
@@ -48,13 +48,7 @@ class Scanner {
     let updatePayload = {}
     let hasUpdated = false
 
-    let existingAuthors = [] // Used for checking if authors or series are now empty
-    let existingSeries = []
-
     if (libraryItem.isBook) {
-      existingAuthors = libraryItem.media.authors.map((a) => a.id)
-      existingSeries = libraryItem.media.series.map((s) => s.id)
-
       const searchISBN = options.isbn || libraryItem.media.isbn
       const searchASIN = options.asin || libraryItem.media.asin
 


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

When using the library option quick match all the server will crash if it detects an existing series sequence needs to be updated.

## Which issue is fixed?

Fixes #3961

## In-depth Description

To reproduce this:
1. Find a book that quick matches with a series and sequence.
2. Change the series sequence number
3. Trigger quick match all in the more menu dropdown of the library

The issue is when querying for the library items the `id` of the `bookSeries` isn't being pulled.
