### PR TITLE
fix stringifySequelizeQuery and add tests

### DIFF
--- a/test/server/utils/stringifySequeslizeQuery.test.js
+++ b/test/server/utils/stringifySequeslizeQuery.test.js
@@ -1,0 +1,52 @@
+const { expect } = require('chai')
+const stringifySequelizeQuery = require('../../../server/utils/stringifySequelizeQuery')
+const Sequelize = require('sequelize')
+
+class DummyClass {}
+
+describe('stringifySequelizeQuery', () => {
+  it('should stringify a sequelize query containing an op', () => {
+    const query = {
+      where: {
+        name: 'John',
+        age: {
+          [Sequelize.Op.gt]: 20
+        }
+      }
+    }
+
+    const result = stringifySequelizeQuery(query)
+    expect(result).to.equal('{"where":{"name":"John","age":{"Symbol(gt)":20}}}')
+  })
+
+  it('should stringify a sequelize query containing a literal', () => {
+    const query = {
+      order: [[Sequelize.literal('libraryItem.title'), 'ASC']]
+    }
+
+    const result = stringifySequelizeQuery(query)
+    expect(result).to.equal('{"order":{"0":{"0":{"val":"libraryItem.title"},"1":"ASC"}}}')
+  })
+
+  it('should stringify a sequelize query containing a class', () => {
+    const query = {
+      include: [
+        {
+          model: DummyClass
+        }
+      ]
+    }
+
+    const result = stringifySequelizeQuery(query)
+    expect(result).to.equal('{"include":{"0":{"model":"DummyClass"}}}')
+  })
+
+  it('should ignore non-class functions', () => {
+    const query = {
+      logging: (query) => console.log(query)
+    }
+
+    const result = stringifySequelizeQuery(query)
+    expect(result).to.equal('{}')
+  })
+})


### PR DESCRIPTION
## Brief summary

I believe the implementation of stringifySequelizeQuery in PR #3980 was buggy (it didn't pass the test I wrote).

## Which issue is fixed?

Same as PR #3980

## In-depth Description

I wrote a slightly simpler implementation using by implementing a `replacer` function which you can pass to `JSON.stringify`
The replacer function deals with two values that are ignored by JSON.stringify by default:
- Symbols
- Classes (mostly for e.g. `model: Database.libraryItemModel`)

## How have you tested this?

Wrote a unit test, and made sure the correct key is generated for real queries in the code.