### PR TITLE
Re-sort title-sorted bookshelf after title change

### DIFF
--- a/client/components/app/LazyBookshelf.vue
+++ b/client/components/app/LazyBookshelf.vue
@@ -419,7 +419,7 @@ export default {
 
       this.postScrollTimeout = setTimeout(this.postScroll, 500)
     },
-    async resetEntities() {
+    async resetEntities(scrollPositionToRestore) {
       if (this.isFetchingEntities) {
         this.pendingReset = true
         return
@@ -437,6 +437,12 @@ export default {
       await this.loadPage(0)
       var lastBookIndex = Math.min(this.totalEntities, this.shelvesPerPage * this.entitiesPerShelf)
       this.mountEntities(0, lastBookIndex)
+
+      if (scrollPositionToRestore) {
+        if (window.bookshelf) {
+          window.bookshelf.scrollTop = scrollPositionToRestore
+        }
+      }
     },
     async rebuild() {
       this.initSizeData()
@@ -444,9 +450,8 @@ export default {
       var lastBookIndex = Math.min(this.totalEntities, this.booksPerFetch)
       this.destroyEntityComponents()
       await this.loadPage(0)
-      var bookshelfEl = document.getElementById('bookshelf')
-      if (bookshelfEl) {
-        bookshelfEl.scrollTop = 0
+      if (window.bookshelf) {
+        window.bookshelf.scrollTop = 0
       }
       this.mountEntities(0, lastBookIndex)
     },
@@ -552,7 +557,7 @@ export default {
             const newTitle = libraryItem.media.metadata?.title
             if (curTitle != newTitle) {
               console.log('Title changed. Re-sorting...')
-              this.resetEntities()
+              this.resetEntities(this.currScrollTop)
               return
             }
           }

--- a/client/components/app/LazyBookshelf.vue
+++ b/client/components/app/LazyBookshelf.vue
@@ -547,6 +547,15 @@ export default {
       if (this.entityName === 'items' || this.entityName === 'series-books') {
         var indexOf = this.entities.findIndex((ent) => ent && ent.id === libraryItem.id)
         if (indexOf >= 0) {
+          if (this.entityName === 'items' && this.orderBy === 'media.metadata.title') {
+            const curTitle = this.entities[indexOf].media.metadata?.title
+            const newTitle = libraryItem.media.metadata?.title
+            if (curTitle != newTitle) {
+              console.log('Title changed. Re-sorting...')
+              this.resetEntities()
+              return
+            }
+          }
           this.entities[indexOf] = libraryItem
           if (this.entityComponentRefs[indexOf]) {
             this.entityComponentRefs[indexOf].setEntity(libraryItem)


### PR DESCRIPTION
## Brief summary

When a bookshelf is sorted by title and the title of a book/podcast changes (e.g. after being edited), the bookshelf is rebuilt so the book appears at its proper position (based on its new title)

## Which issue is fixed?

Fixes #3998

## In-depth Description

Up until now, when `LazyBookshelf` got an `item_updated` message from the server, it only replaced the old entity with the updated entity. With this change, if the current sort order is by title, and a change of title is detected, `resetEntities()` is called, and the item is moved to its new position.

## How have you tested this?

Changed title of books/podcasts and verified that after saving the change, the book/podcast moved to its new position.
