### PR TITLE
Fix all date constructors to Date(0) to prevent test flakiness

### DIFF
--- a/test/server/migrations/v2.15.0-series-column-unique.test.js
+++ b/test/server/migrations/v2.15.0-series-column-unique.test.js
@@ -91,9 +91,9 @@ describe('migration-v2.15.0-series-column-unique', () => {
     it('upgrade with no duplicate series', async () => {
       // Add some entries to the Series table using the UUID for the ids
       await queryInterface.bulkInsert('Series', [
-        { id: series1Id, name: 'Series 1', libraryId: library1Id, createdAt: new Date(), updatedAt: new Date() },
-        { id: series2Id, name: 'Series 2', libraryId: library2Id, createdAt: new Date(), updatedAt: new Date() },
-        { id: series3Id, name: 'Series 3', libraryId: library1Id, createdAt: new Date(), updatedAt: new Date() }
+        { id: series1Id, name: 'Series 1', libraryId: library1Id, createdAt: new Date(0), updatedAt: new Date(0) },
+        { id: series2Id, name: 'Series 2', libraryId: library2Id, createdAt: new Date(0), updatedAt: new Date(0) },
+        { id: series3Id, name: 'Series 3', libraryId: library1Id, createdAt: new Date(0), updatedAt: new Date(0) }
       ])
       // Add some entries to the BookSeries table
       await queryInterface.bulkInsert('BookSeries', [
@@ -126,9 +126,9 @@ describe('migration-v2.15.0-series-column-unique', () => {
     it('upgrade with duplicate series and no sequence', async () => {
       // Add some entries to the Series table using the UUID for the ids
       await queryInterface.bulkInsert('Series', [
-        { id: series1Id, name: 'Series 1', libraryId: library1Id, createdAt: new Date(), updatedAt: new Date() },
-        { id: series2Id, name: 'Series 2', libraryId: library2Id, createdAt: new Date(), updatedAt: new Date() },
-        { id: series3Id, name: 'Series 3', libraryId: library1Id, createdAt: new Date(), updatedAt: new Date() },
+        { id: series1Id, name: 'Series 1', libraryId: library1Id, createdAt: new Date(0), updatedAt: new Date(0) },
+        { id: series2Id, name: 'Series 2', libraryId: library2Id, createdAt: new Date(0), updatedAt: new Date(0) },
+        { id: series3Id, name: 'Series 3', libraryId: library1Id, createdAt: new Date(0), updatedAt: new Date(0) },
         { id: series1Id_dup, name: 'Series 1', libraryId: library1Id, createdAt: new Date(0), updatedAt: new Date(0) },
         { id: series3Id_dup, name: 'Series 3', libraryId: library1Id, createdAt: new Date(0), updatedAt: new Date(0) },
         { id: series1Id_dup2, name: 'Series 1', libraryId: library1Id, createdAt: new Date(0), updatedAt: new Date(0) }
@@ -172,8 +172,8 @@ describe('migration-v2.15.0-series-column-unique', () => {
     it('upgrade with same series name in different libraries', async () => {
       // Add some entries to the Series table using the UUID for the ids
       await queryInterface.bulkInsert('Series', [
-        { id: series1Id, name: 'Series 1', libraryId: library1Id, createdAt: new Date(), updatedAt: new Date() },
-        { id: series2Id, name: 'Series 1', libraryId: library2Id, createdAt: new Date(), updatedAt: new Date() }
+        { id: series1Id, name: 'Series 1', libraryId: library1Id, createdAt: new Date(0), updatedAt: new Date(0) },
+        { id: series2Id, name: 'Series 1', libraryId: library2Id, createdAt: new Date(0), updatedAt: new Date(0) }
       ])
       // Add some entries to the BookSeries table
       await queryInterface.bulkInsert('BookSeries', [
@@ -203,8 +203,8 @@ describe('migration-v2.15.0-series-column-unique', () => {
     it('upgrade with one book in two of the same series, both sequence are null', async () => {
       // Create two different series with the same name in the same library
       await queryInterface.bulkInsert('Series', [
-        { id: series1Id, name: 'Series 1', libraryId: library1Id, createdAt: new Date(), updatedAt: new Date() },
-        { id: series2Id, name: 'Series 1', libraryId: library1Id, createdAt: new Date(), updatedAt: new Date() }
+        { id: series1Id, name: 'Series 1', libraryId: library1Id, createdAt: new Date(0), updatedAt: new Date(0) },
+        { id: series2Id, name: 'Series 1', libraryId: library1Id, createdAt: new Date(0), updatedAt: new Date(0) }
       ])
       // Create a book that is in both series
       await queryInterface.bulkInsert('BookSeries', [
@@ -236,8 +236,8 @@ describe('migration-v2.15.0-series-column-unique', () => {
     it('upgrade with one book in two of the same series, one sequence is null', async () => {
       // Create two different series with the same name in the same library
       await queryInterface.bulkInsert('Series', [
-        { id: series1Id, name: 'Series 1', libraryId: library1Id, createdAt: new Date(), updatedAt: new Date() },
-        { id: series2Id, name: 'Series 1', libraryId: library1Id, createdAt: new Date(), updatedAt: new Date() }
+        { id: series1Id, name: 'Series 1', libraryId: library1Id, createdAt: new Date(0), updatedAt: new Date(0) },
+        { id: series2Id, name: 'Series 1', libraryId: library1Id, createdAt: new Date(0), updatedAt: new Date(0) }
       ])
       // Create a book that is in both series
       await queryInterface.bulkInsert('BookSeries', [
@@ -268,8 +268,8 @@ describe('migration-v2.15.0-series-column-unique', () => {
     it('upgrade with one book in two of the same series, both sequence are not null', async () => {
       // Create two different series with the same name in the same library
       await queryInterface.bulkInsert('Series', [
-        { id: series1Id, name: 'Series 1', libraryId: library1Id, createdAt: new Date(), updatedAt: new Date() },
-        { id: series2Id, name: 'Series 1', libraryId: library1Id, createdAt: new Date(), updatedAt: new Date() }
+        { id: series1Id, name: 'Series 1', libraryId: library1Id, createdAt: new Date(0), updatedAt: new Date(0) },
+        { id: series2Id, name: 'Series 1', libraryId: library1Id, createdAt: new Date(0), updatedAt: new Date(0) }
       ])
       // Create a book that is in both series
       await queryInterface.bulkInsert('BookSeries', [


### PR DESCRIPTION
## Brief summary

Fix Date constructors to Date(0) to provide stable dates and prevent test flakiness

## Which issue is fixed?

No issue.

## In-depth Description

Using just Date() caused the test input to be unstable, and caused sporadic test failures.

## How have you tested this?

Ran the test to make sure it still passes.