### PR TITLE
fix(auth): Add admin-level auth to LibraryController 'delete', 'update' and 'delete items with issues'

### DIFF
--- a/server/controllers/LibraryController.js
+++ b/server/controllers/LibraryController.js
@@ -254,6 +254,11 @@ class LibraryController {
    * @param {Response} res
    */
   async update(req, res) {
+    if (!req.user.isAdminOrUp) {
+      Logger.error(`[LibraryController] Non-admin user "${req.user.username}" attempted to update library`)
+      return res.sendStatus(403)
+    }
+
     // Validation
     const updatePayload = {}
     const keysToCheck = ['name', 'provider', 'mediaType', 'icon']
@@ -519,6 +524,11 @@ class LibraryController {
    * @param {Response} res
    */
   async delete(req, res) {
+    if (!req.user.isAdminOrUp) {
+      Logger.error(`[LibraryController] Non-admin user "${req.user.username}" attempted to delete library`)
+      return res.sendStatus(403)
+    }
+    
     // Remove library watcher
     Watcher.removeLibrary(req.library)
 
@@ -639,6 +649,11 @@ class LibraryController {
    * @param {Response} res
    */
   async removeLibraryItemsWithIssues(req, res) {
+    if (!req.user.isAdminOrUp) {
+      Logger.error(`[LibraryController] Non-admin user "${req.user.username}" attempted to delete library items missing or invalid`)
+      return res.sendStatus(403)
+    }
+
     const libraryItemsWithIssues = await Database.libraryItemModel.findAll({
       where: {
         libraryId: req.library.id,


### PR DESCRIPTION
## Brief summary

This PR addresses a security vulnerability in the LibraryController by enforcing admin-level authorization for critical endpoints that were previously accessible to non-admin users. Specifically, it restricts access to library settings updates, library issue removal, and **library deletion** to only admin users.

## Which issue is fixed?

No issue reported (security fix).

## In-depth Description

This PR implements admin-level authorization checks in the `LibraryController` for the following methods:

*   **`PATCH /api/libraries/:id` (update method):**  Previously, any authenticated user could potentially modify library settings. This change adds a check at the beginning of the `update` method to ensure that only users with `isAdminOrUp` privileges can proceed with updating library settings.
*   **`DELETE /api/libraries/:id/issues` (removeLibraryItemsWithIssues method):**  Similarly, this endpoint for removing library items with issues was not properly protected. This PR adds an `isAdminOrUp` check at the start of the `removeLibraryItemsWithIssues` method to restrict its use to administrators.
*   **`DELETE /api/libraries/:id` (delete method):**  This PR also adds an `isAdminOrUp` check to the `delete` method to ensure that only admin users can delete libraries. Deleting a library is a highly sensitive operation that should be restricted to administrators.

These changes ensure that sensitive library management operations are only accessible to authorized admin users, enhancing the overall security and access control of the application.

## How have you tested this?

**Test Steps:**

1.  **Manual testing was performed using `curl` commands** to directly interact with the API endpoints.
2.  **For each endpoint, tests were executed using two types of JWTs:**
    *   **Admin JWT:** A valid JWT for a user with administrator privileges.
    *   **Non-Admin JWT:** A valid JWT for a standard user (without administrator privileges).
3.  **The following endpoints were specifically tested to verify authorization:**
    *   `PATCH /api/libraries/:id`:  `curl` commands were used with both Admin and Non-Admin JWTs to attempt updating library settings.
    *   `DELETE /api/libraries/:id/issues`: `curl` commands were used with both Admin and Non-Admin JWTs to attempt removing library issues.
    *   `DELETE /api/libraries/:id`: `curl` commands were used with both Admin and Non-Admin JWTs to attempt deleting a library.
