### PR TITLE
new sort option for podcasts view (-> sort by filename)

### DIFF
--- a/client/components/tables/podcast/LazyEpisodeRow.vue
+++ b/client/components/tables/podcast/LazyEpisodeRow.vue
@@ -10,8 +10,13 @@
         <div class="h-10 flex items-center mt-1.5 mb-0.5 overflow-hidden">
           <p class="text-sm text-gray-200 line-clamp-2" v-html="episodeSubtitle"></p>
         </div>
+
         <div class="h-8 flex items-center">
-          <div class="w-full inline-flex justify-between max-w-xl">
+          <p v-if="sortKey === 'audioFile.metadata.filename'" class="text-sm text-gray-300 truncate font-light">
+            <strong className="font-bold">{{ $strings.LabelFilename }}</strong
+            >: {{ episode.audioFile.metadata.filename }}
+          </p>
+          <div v-else class="w-full inline-flex justify-between max-w-xl">
             <p v-if="episode?.season" class="text-sm text-gray-300">{{ $getString('LabelSeasonNumber', [episode.season]) }}</p>
             <p v-if="episode?.episode" class="text-sm text-gray-300">{{ $getString('LabelEpisodeNumber', [episode.episode]) }}</p>
             <p v-if="episode?.chapters?.length" class="text-sm text-gray-300">{{ $getString('LabelChapterCount', [episode.chapters.length]) }}</p>
@@ -65,7 +70,8 @@ export default {
     episode: {
       type: Object,
       default: () => null
-    }
+    },
+    sortKey: String
   },
   data() {
     return {

--- a/client/components/tables/podcast/LazyEpisodesTable.vue
+++ b/client/components/tables/podcast/LazyEpisodesTable.vue
@@ -1,3 +1,4 @@
+
 <template>
   <div id="lazy-episodes-table" class="w-full py-6">
     <div class="flex flex-wrap flex-col md:flex-row md:items-center mb-4">
@@ -123,6 +124,10 @@ export default {
         {
           text: this.$strings.LabelEpisode,
           value: 'episode'
+        },
+        {
+          text: this.$strings.LabelFilename,
+          value: 'audioFile.metadata.filename'
         }
       ]
     },
@@ -171,8 +176,17 @@ export default {
           return episodeProgress && !episodeProgress.isFinished
         })
         .sort((a, b) => {
-          let aValue = a[this.sortKey]
-          let bValue = b[this.sortKey]
+          let aValue
+          let bValue
+
+          if (this.sortKey.includes('.')) {
+            const getNestedValue = (ob, s) => s.split('.').reduce((o, k) => o?.[k], ob);
+            aValue = getNestedValue(a, this.sortKey)
+            bValue = getNestedValue(b, this.sortKey)
+          } else {
+            aValue = a[this.sortKey]
+            bValue = b[this.sortKey]
+          }
 
           // Sort episodes with no pub date as the oldest
           if (this.sortKey === 'publishedAt') {

--- a/client/components/tables/podcast/LazyEpisodesTable.vue
+++ b/client/components/tables/podcast/LazyEpisodesTable.vue
@@ -180,7 +180,7 @@ export default {
           let bValue
 
           if (this.sortKey.includes('.')) {
-            const getNestedValue = (ob, s) => s.split('.').reduce((o, k) => o?.[k], ob);
+            const getNestedValue = (ob, s) => s.split('.').reduce((o, k) => o?.[k], ob)
             aValue = getNestedValue(a, this.sortKey)
             bValue = getNestedValue(b, this.sortKey)
           } else {
@@ -454,7 +454,8 @@ export default {
           propsData: {
             index,
             libraryItemId: this.libraryItem.id,
-            episode: this.episodesList[index]
+            episode: this.episodesList[index],
+            sortKey: this.sortKey
           },
           created() {
             this.$on('selected', (payload) => {


### PR DESCRIPTION
## Brief summary

Adds a new sorting option (-> "Filename") to the podcasts view/table.

## Which issue is fixed?

Fixes #3637

## In-depth Description

Locally stored podcast files often don't contain proper meta-data ("published date", "episode number", etc.); which is needed for reasonable sorting.
 
However, files that contain suitable name-prefixes (e.g. "20250213-podcast-xyz.mp3") can provide the necessary information that way.

## How have you tested this?

Tested via dev-container setup.

## Screenshots

![image](https://github.com/user-attachments/assets/ed0db833-4857-4881-b3dd-9dbc98c3af8c)
