### PR TITLE
Add: log custom metadata provider to match other providers

### DIFF
--- a/server/providers/CustomProviderAdapter.js
+++ b/server/providers/CustomProviderAdapter.js
@@ -41,6 +41,9 @@ class CustomProviderAdapter {
     }
     const queryString = new URLSearchParams(queryObj).toString()
 
+    const url = `${provider.url}/search?${queryString}`
+    Logger.debug(`[CustomMetadataProvider] Search url: ${url}`)
+
     // Setup headers
     const axiosOptions = {
       timeout
@@ -52,7 +55,7 @@ class CustomProviderAdapter {
     }
 
     const matches = await axios
-      .get(`${provider.url}/search?${queryString}`, axiosOptions)
+      .get(url, axiosOptions)
       .then((res) => {
         if (!res?.data || !Array.isArray(res.data.matches)) return null
         return res.data.matches


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

This PR adds logging for the Custom Metadata Provider URL request to match other providers.

## Which issue is fixed?

Additional logging for https://github.com/advplyr/audiobookshelf/issues/4004

## In-depth Description

Moved URL creation with query string to be before the Axios request and added logging of the generated URL.

## How have you tested this?

Verified not crashing

## Screenshots

N/A