### PR TITLE
Play first podcast episode in table

### DIFF
--- a/client/components/tables/podcast/LazyEpisodesTable.vue
+++ b/client/components/tables/podcast/LazyEpisodesTable.vue
@@ -89,6 +89,13 @@ export default {
       handler() {
         this.refresh()
       }
+    },
+    episodesList: {
+      handler(newList) {
+        const episodeIds = newList.map((ep) => ep.id)
+        this.$store.commit('setSortedEpisodeIds', episodeIds)
+      },
+      immediate: true
     }
   },
   computed: {

--- a/client/components/tables/podcast/LazyEpisodesTable.vue
+++ b/client/components/tables/podcast/LazyEpisodesTable.vue
@@ -89,13 +89,6 @@ export default {
       handler() {
         this.refresh()
       }
-    },
-    episodesList: {
-      handler(newList) {
-        const episodeIds = newList.map((ep) => ep.id)
-        this.$store.commit('setSortedEpisodeIds', episodeIds)
-      },
-      immediate: true
     }
   },
   computed: {
@@ -368,20 +361,20 @@ export default {
     playEpisode(episode) {
       const queueItems = []
 
-      const episodesInListeningOrder = this.episodesCopy.map((ep) => ({ ...ep })).sort((a, b) => String(a.publishedAt).localeCompare(String(b.publishedAt), undefined, { numeric: true, sensitivity: 'base' }))
+      const episodesInListeningOrder = this.episodesList
       const episodeIndex = episodesInListeningOrder.findIndex((e) => e.id === episode.id)
       for (let i = episodeIndex; i < episodesInListeningOrder.length; i++) {
-        const episode = episodesInListeningOrder[i]
-        const podcastProgress = this.$store.getters['user/getUserMediaProgress'](this.libraryItem.id, episode.id)
-        if (!podcastProgress || !podcastProgress.isFinished) {
+        const _episode = episodesInListeningOrder[i]
+        const podcastProgress = this.$store.getters['user/getUserMediaProgress'](this.libraryItem.id, _episode.id)
+        if (!podcastProgress?.isFinished || episode.id === _episode.id) {
           queueItems.push({
             libraryItemId: this.libraryItem.id,
             libraryId: this.libraryItem.libraryId,
-            episodeId: episode.id,
-            title: episode.title,
+            episodeId: _episode.id,
+            title: _episode.title,
             subtitle: this.mediaMetadata.title,
-            caption: episode.publishedAt ? this.$getString('LabelPublishedDate', [this.$formatDate(episode.publishedAt, this.dateFormat)]) : this.$strings.LabelUnknownPublishDate,
-            duration: episode.audioFile.duration || null,
+            caption: _episode.publishedAt ? this.$getString('LabelPublishedDate', [this.$formatDate(_episode.publishedAt, this.dateFormat)]) : this.$strings.LabelUnknownPublishDate,
+            duration: _episode.audioFile.duration || null,
             coverPath: this.media.coverPath || null
           })
         }

--- a/client/pages/item/_id/index.vue
+++ b/client/pages/item/_id/index.vue
@@ -132,7 +132,7 @@
 
           <tables-tracks-table v-if="tracks.length" :title="$strings.LabelStatsAudioTracks" :tracks="tracksWithAudioFile" :is-file="isFile" :library-item-id="libraryItemId" class="mt-6" />
 
-          <tables-podcast-lazy-episodes-table v-if="isPodcast" :library-item="libraryItem" />
+          <tables-podcast-lazy-episodes-table ref="episodesTable" v-if="isPodcast" :library-item="libraryItem" />
 
           <tables-ebook-files-table v-if="ebookFiles.length" :library-item="libraryItem" class="mt-6" />
 
@@ -266,9 +266,6 @@ export default {
     },
     podcastEpisodes() {
       return this.media.episodes || []
-    },
-    sortedEpisodeIds() {
-      return this.$store.getters.getSortedEpisodeIds
     },
     title() {
       return this.mediaMetadata.title || 'No Title'
@@ -537,8 +534,8 @@ export default {
       let episodeId = null
       const queueItems = []
       if (this.isPodcast) {
-        // Sort the episodes based on the sorting and filtering from the episode table component
-        const episodesInListeningOrder = this.sortedEpisodeIds.map((id) => this.podcastEpisodes.find((ep) => ep.id === id))
+        // Uses the sorting and filtering from the episode table component
+        const episodesInListeningOrder = this.$refs.episodesTable?.episodesList || []
 
         // Find the first unplayed episode from the table
         let episodeIndex = episodesInListeningOrder.findIndex((ep) => {

--- a/client/pages/item/_id/index.vue
+++ b/client/pages/item/_id/index.vue
@@ -537,14 +537,15 @@ export default {
       let episodeId = null
       const queueItems = []
       if (this.isPodcast) {
-        const episodesInListeningOrder = [...this.sortedEpisodeIds].reverse().map((id) => this.podcastEpisodes.find((ep) => ep.id === id))
-        console.log('Episodes in listening order', episodesInListeningOrder)
+        // Sort the episodes based on the sorting and filtering from the episode table component
+        const episodesInListeningOrder = this.sortedEpisodeIds.map((id) => this.podcastEpisodes.find((ep) => ep.id === id))
 
-        // Find most recent episode unplayed
-        let episodeIndex = episodesInListeningOrder.findLastIndex((ep) => {
+        // Find the first unplayed episode from the table
+        let episodeIndex = episodesInListeningOrder.findIndex((ep) => {
           const podcastProgress = this.$store.getters['user/getUserMediaProgress'](this.libraryItemId, ep.id)
           return !podcastProgress || !podcastProgress.isFinished
         })
+        // If all episodes are played, use the first episode
         if (episodeIndex < 0) episodeIndex = 0
 
         episodeId = episodesInListeningOrder[episodeIndex].id

--- a/client/pages/item/_id/index.vue
+++ b/client/pages/item/_id/index.vue
@@ -267,6 +267,9 @@ export default {
     podcastEpisodes() {
       return this.media.episodes || []
     },
+    sortedEpisodeIds() {
+      return this.$store.getters.getSortedEpisodeIds
+    },
     title() {
       return this.mediaMetadata.title || 'No Title'
     },
@@ -534,7 +537,8 @@ export default {
       let episodeId = null
       const queueItems = []
       if (this.isPodcast) {
-        const episodesInListeningOrder = this.podcastEpisodes.map((ep) => ({ ...ep })).sort((a, b) => String(a.publishedAt).localeCompare(String(b.publishedAt), undefined, { numeric: true, sensitivity: 'base' }))
+        const episodesInListeningOrder = [...this.sortedEpisodeIds].reverse().map((id) => this.podcastEpisodes.find((ep) => ep.id === id))
+        console.log('Episodes in listening order', episodesInListeningOrder)
 
         // Find most recent episode unplayed
         let episodeIndex = episodesInListeningOrder.findLastIndex((ep) => {

--- a/client/store/index.js
+++ b/client/store/index.js
@@ -25,7 +25,6 @@ export const state = () => ({
   previousPath: '/',
   bookshelfBookIds: [],
   episodeTableEpisodeIds: [],
-  sortedEpisodeIds: [],
   openModal: null,
   innerModalOpen: false,
   lastBookshelfScrollData: {},
@@ -62,9 +61,6 @@ export const getters = {
   getHomeBookshelfView: (state) => {
     if (!state.serverSettings || isNaN(state.serverSettings.homeBookshelfView)) return Constants.BookshelfView.STANDARD
     return state.serverSettings.homeBookshelfView
-  },
-  getSortedEpisodeIds: (state) => {
-    return state.sortedEpisodeIds || []
   }
 }
 
@@ -149,9 +145,6 @@ export const mutations = {
   },
   setEpisodeTableEpisodeIds(state, val) {
     state.episodeTableEpisodeIds = val || []
-  },
-  setSortedEpisodeIds(state, episodeIds) {
-    state.sortedEpisodeIds = episodeIds || []
   },
   setPreviousPath(state, val) {
     state.previousPath = val

--- a/client/store/index.js
+++ b/client/store/index.js
@@ -25,6 +25,7 @@ export const state = () => ({
   previousPath: '/',
   bookshelfBookIds: [],
   episodeTableEpisodeIds: [],
+  sortedEpisodeIds: [],
   openModal: null,
   innerModalOpen: false,
   lastBookshelfScrollData: {},
@@ -61,6 +62,9 @@ export const getters = {
   getHomeBookshelfView: (state) => {
     if (!state.serverSettings || isNaN(state.serverSettings.homeBookshelfView)) return Constants.BookshelfView.STANDARD
     return state.serverSettings.homeBookshelfView
+  },
+  getSortedEpisodeIds: (state) => {
+    return state.sortedEpisodeIds || []
   }
 }
 
@@ -145,6 +149,9 @@ export const mutations = {
   },
   setEpisodeTableEpisodeIds(state, val) {
     state.episodeTableEpisodeIds = val || []
+  },
+  setSortedEpisodeIds(state, episodeIds) {
+    state.sortedEpisodeIds = episodeIds || []
   },
   setPreviousPath(state, val) {
     state.previousPath = val


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

This PR changes the "Play" button on the podcast page to play the first incomplete episode in the table instead of the "newest published". The "first episode" is the top row, and is dependent on the sorting and filtering options.

## Which issue is fixed?

Related to https://github.com/advplyr/audiobookshelf/issues/1321.

## In-depth Description

This PR adds a new field to the Vuex store to track the podcast episode IDs in the `LazyEpisodesTable`. This takes the current sorting and filtering of the table into account. Then, when pressing the "Play" button, the uppermost incomplete episode is played instead of the most recently released incomplete episode.

This does not fully fix the issue as mentioned in https://github.com/advplyr/audiobookshelf/issues/1321#issuecomment-2492456282 because the sorting is applied to all podcasts instead of being remembered individually. No changes should need to be made for this logic once the sort order is podcast specific.

Commit overview:
1. Add the `sortedEpisodeIds` to the store, which stores the episode IDs of the sorted and filtered table.
2. Change the logic to use the first row of the table.
3. Update comments and remove double reverse of array

**Additional question** Should this just play the very first episode instead of the first incomplete episode? The filter defaults to "incomplete", so if a user has changed to show all episodes, I think it should play whatever is in the first row, regardless of the completion status.

## How have you tested this?

Added several podcasts (some serial and some episodic). Changed sort and filter options, navigating between podcasts to ensure that the state was being updated correctly and the first incomplete episode was correctly played.

## Screenshots

To illustrate what is happening, the episode in the red box is the episode which will be played when pressing the "Play" button above the description.

![Screenshot from 2025-02-22 21-59-02](https://github.com/user-attachments/assets/d4997072-d107-41cf-9d5a-3ab2cb34efec)

![Screenshot from 2025-02-22 21-59-39](https://github.com/user-attachments/assets/444d2e9e-9e38-4475-ae03-4aa19c860c55)
