### PR TITLE
Fix: flaky 2.15.0 migration test

### DIFF
--- a/test/server/migrations/v2.15.0-series-column-unique.test.js
+++ b/test/server/migrations/v2.15.0-series-column-unique.test.js
@@ -126,9 +126,9 @@ describe('migration-v2.15.0-series-column-unique', () => {
     it('upgrade with duplicate series and no sequence', async () => {
       // Add some entries to the Series table using the UUID for the ids
       await queryInterface.bulkInsert('Series', [
-        { id: series1Id, name: 'Series 1', libraryId: library1Id, createdAt: new Date(), updatedAt: new Date() },
-        { id: series2Id, name: 'Series 2', libraryId: library2Id, createdAt: new Date(), updatedAt: new Date() },
-        { id: series3Id, name: 'Series 3', libraryId: library1Id, createdAt: new Date(), updatedAt: new Date() },
+        { id: series1Id, name: 'Series 1', libraryId: library1Id, createdAt: new Date(7), updatedAt: new Date(7) },
+        { id: series2Id, name: 'Series 2', libraryId: library2Id, createdAt: new Date(7), updatedAt: new Date(8) },
+        { id: series3Id, name: 'Series 3', libraryId: library1Id, createdAt: new Date(7), updatedAt: new Date(9) },
         { id: series1Id_dup, name: 'Series 1', libraryId: library1Id, createdAt: new Date(0), updatedAt: new Date(0) },
         { id: series3Id_dup, name: 'Series 3', libraryId: library1Id, createdAt: new Date(0), updatedAt: new Date(0) },
         { id: series1Id_dup2, name: 'Series 1', libraryId: library1Id, createdAt: new Date(0), updatedAt: new Date(0) }
@@ -203,8 +203,8 @@ describe('migration-v2.15.0-series-column-unique', () => {
     it('upgrade with one book in two of the same series, both sequence are null', async () => {
       // Create two different series with the same name in the same library
       await queryInterface.bulkInsert('Series', [
-        { id: series1Id, name: 'Series 1', libraryId: library1Id, createdAt: new Date(), updatedAt: new Date() },
-        { id: series2Id, name: 'Series 1', libraryId: library1Id, createdAt: new Date(), updatedAt: new Date() }
+        { id: series1Id, name: 'Series 1', libraryId: library1Id, createdAt: new Date(8), updatedAt: new Date(20) },
+        { id: series2Id, name: 'Series 1', libraryId: library1Id, createdAt: new Date(5), updatedAt: new Date(10) }
       ])
       // Create a book that is in both series
       await queryInterface.bulkInsert('BookSeries', [
@@ -236,8 +236,8 @@ describe('migration-v2.15.0-series-column-unique', () => {
     it('upgrade with one book in two of the same series, one sequence is null', async () => {
       // Create two different series with the same name in the same library
       await queryInterface.bulkInsert('Series', [
-        { id: series1Id, name: 'Series 1', libraryId: library1Id, createdAt: new Date(), updatedAt: new Date() },
-        { id: series2Id, name: 'Series 1', libraryId: library1Id, createdAt: new Date(), updatedAt: new Date() }
+        { id: series1Id, name: 'Series 1', libraryId: library1Id, createdAt: new Date(5), updatedAt: new Date(9) },
+        { id: series2Id, name: 'Series 1', libraryId: library1Id, createdAt: new Date(5), updatedAt: new Date(7) }
       ])
       // Create a book that is in both series
       await queryInterface.bulkInsert('BookSeries', [
@@ -268,8 +268,8 @@ describe('migration-v2.15.0-series-column-unique', () => {
     it('upgrade with one book in two of the same series, both sequence are not null', async () => {
       // Create two different series with the same name in the same library
       await queryInterface.bulkInsert('Series', [
-        { id: series1Id, name: 'Series 1', libraryId: library1Id, createdAt: new Date(), updatedAt: new Date() },
-        { id: series2Id, name: 'Series 1', libraryId: library1Id, createdAt: new Date(), updatedAt: new Date() }
+        { id: series1Id, name: 'Series 1', libraryId: library1Id, createdAt: new Date(1), updatedAt: new Date(3) },
+        { id: series2Id, name: 'Series 1', libraryId: library1Id, createdAt: new Date(2), updatedAt: new Date(2) }
       ])
       // Create a book that is in both series
       await queryInterface.bulkInsert('BookSeries', [


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

This PR fixes the flaky test for the 2.15.0 migration test.

## Which issue is fixed?

Same as https://github.com/advplyr/audiobookshelf/pull/4010

## In-depth Description

Each test now uses a fixed Date object for creation to ensure the test is no longer flaky.

During testing, I found that `LibraryAuthorController` tests are flaky and will usually fail within around 40-70 runs. The longest I saw was 84 runs before failing. Switching to running these tests in isolation (deleted all other tests because I am not sure how to disable them) still had errors at the same approximate frequency, so I think the `LibraryAuthorController` failure is not due to interactions with other tests.

## How have you tested this?

Created a bash script which continuously runs `npm run test` until any test fails. The test ran successfully (without LibraryAuthorController tests) over 300 times in this loop before manually stopping.

## Screenshots

N/A