### PR TITLE
Added AudiMeta - an extended Audible provider

### DIFF
--- a/client/store/scanners.js
+++ b/client/store/scanners.js
@@ -13,40 +13,80 @@ export const state = () => ({
       value: 'itunes'
     },
     {
+      text: 'AudiMeta.com (Audible)',
+      value: 'audimeta.us'
+    },
+    {
       text: 'Audible.com',
       value: 'audible'
+    },
+    {
+      text: 'AudiMeta.ca (Audible)',
+      value: 'audimeta.ca'
     },
     {
       text: 'Audible.ca',
       value: 'audible.ca'
     },
     {
+      text: 'AudiMeta.co.uk (Audible)',
+      value: 'audimeta.uk'
+    },
+    {
       text: 'Audible.co.uk',
       value: 'audible.uk'
+    },
+    {
+      text: 'AudiMeta.com.au (Audible)',
+      value: 'audimeta.au'
     },
     {
       text: 'Audible.com.au',
       value: 'audible.au'
     },
     {
+      text: 'AudiMeta.fr (Audible)',
+      value: 'audimeta.fr'
+    },
+    {
       text: 'Audible.fr',
       value: 'audible.fr'
+    },
+    {
+      text: 'AudiMeta.de (Audible)',
+      value: 'audimeta.de'
     },
     {
       text: 'Audible.de',
       value: 'audible.de'
     },
     {
+      text: 'AudiMeta.jp (Audible)',
+      value: 'audimeta.jp'
+    },
+    {
       text: 'Audible.co.jp',
       value: 'audible.jp'
+    },
+    {
+      text: 'AudiMeta.it (Audible)',
+      value: 'audimeta.it'
     },
     {
       text: 'Audible.it',
       value: 'audible.it'
     },
     {
+      text: 'AudiMeta.co.in (Audible)',
+      value: 'audimeta.in'
+    },
+    {
       text: 'Audible.co.in',
       value: 'audible.in'
+    },
+    {
+      text: 'AudiMeta.es (Audible)',
+      value: 'audimeta.es'
     },
     {
       text: 'Audible.es',

--- a/server/providers/AudiMeta.js
+++ b/server/providers/AudiMeta.js
@@ -1,0 +1,162 @@
+const axios = require('axios').default
+const Logger = require('../Logger')
+const { isValidASIN } = require('../utils/index')
+
+class AudiMeta {
+  #responseTimeout = 30000
+
+  constructor() {
+    this.regionMap = {
+      us: '.com',
+      ca: '.ca',
+      uk: '.co.uk',
+      au: '.com.au',
+      fr: '.fr',
+      de: '.de',
+      jp: '.co.jp',
+      it: '.it',
+      in: '.in',
+      es: '.es'
+    }
+  }
+
+  /**
+   * Audible will sometimes send sequences with "Book 1" or "2, Dramatized Adaptation"
+   * @see https://github.com/advplyr/audiobookshelf/issues/2380
+   * @see https://github.com/advplyr/audiobookshelf/issues/1339
+   *
+   * @param {string} seriesName
+   * @param {string} sequence
+   * @returns {string}
+   */
+  cleanSeriesSequence(seriesName, sequence) {
+    if (!sequence) return ''
+    // match any number with optional decimal (e.g, 1 or 1.5 or .5)
+    let numberFound = sequence.match(/\.\d+|\d+(?:\.\d+)?/)
+    let updatedSequence = numberFound ? numberFound[0] : sequence
+    if (sequence !== updatedSequence) {
+      Logger.debug(`[AudiMeta] Series "${seriesName}" sequence was cleaned from "${sequence}" to "${updatedSequence}"`)
+    }
+    return updatedSequence
+  }
+
+  cleanResult(item) {
+    const { title, subtitle, asin, authors, narrators, publisherName, summary, releaseDate, imageUrl, genres, series, language, lengthMinutes, bookFormat	} = item
+
+    const seriesList = []
+
+    series.forEach((s) => {
+      seriesList.push({
+        series: s.name,
+        sequence: this.cleanSeriesSequence(s.name, (s.position || '').toString())
+      })
+    });
+
+    // Tags and Genres are flipped for AudiMeta
+    const genresFiltered = genres ? genres.filter((g) => g.type == 'Tags').map((g) => g.name) : []
+    const tagsFiltered = genres ? genres.filter((g) => g.type == 'Genres').map((g) => g.name) : []
+
+    return {
+      title,
+      subtitle: subtitle || null,
+      author: authors ? authors.map(({ name }) => name).join(', ') : null,
+      narrator: narrators ? narrators.map(({ name }) => name).join(', ') : null,
+      publisher: publisherName,
+      publishedYear: releaseDate ? releaseDate.split('-')[0] : null,
+      description: summary || null,
+      cover: imageUrl,
+      asin,
+      genres: genresFiltered.length ? genresFiltered : null,
+      tags: tagsFiltered.length ? tagsFiltered.join(', ') : null,
+      series: seriesList.length ? seriesList : null,
+      language: language ? language.charAt(0).toUpperCase() + language.slice(1) : null,
+      duration: lengthMinutes && !isNaN(lengthMinutes) ? Number(lengthMinutes) : 0,
+      region: item.region || null,
+      rating: item.rating || null,
+      abridged: bookFormat === 'abridged'
+    }
+  }
+
+  /**
+   *
+   * @param {string} asin
+   * @param {string} region
+   * @param {number} [timeout] response timeout in ms
+   * @returns {Promise<Object>}
+   */
+  asinSearch(asin, region, timeout = this.#responseTimeout) {
+    if (!asin) return null
+    if (!timeout || isNaN(timeout)) timeout = this.#responseTimeout
+
+    asin = encodeURIComponent(asin.toUpperCase())
+    let regionQuery = region ? `?region=${region}` : ''
+    let url = `https://audimeta.de/book/${asin}${regionQuery}`
+    Logger.debug(`[AudiMeta] ASIN url: ${url}`)
+    return axios
+      .get(url, {
+        timeout
+      })
+      .then((res) => {
+        if (!res?.data?.asin) return null
+        return res.data
+      })
+      .catch((error) => {
+        Logger.error('[Audible] ASIN search error', error)
+        return null
+      })
+  }
+
+  /**
+   *
+   * @param {string} title
+   * @param {string} author
+   * @param {string} asin
+   * @param {string} region
+   * @param {number} [timeout] response timeout in ms
+   * @returns {Promise<Object[]>}
+   */
+  async search(title, author, asin, region, timeout = this.#responseTimeout) {
+    if (region && !this.regionMap[region]) {
+      Logger.error(`[AudiMeta] search: Invalid region ${region}`)
+      region = ''
+    }
+    if (!timeout || isNaN(timeout)) timeout = this.#responseTimeout
+
+    let items = []
+    if (asin && isValidASIN(asin.toUpperCase())) {
+      const item = await this.asinSearch(asin.toUpperCase(), region, timeout)
+      if (item) items.push(item)
+    }
+
+    if (!items.length && isValidASIN(title.toUpperCase())) {
+      const item = await this.asinSearch(title.toUpperCase(), region, timeout)
+      if (item) items.push(item)
+    }
+
+    if (!items.length) {
+      const queryObj = {
+        title: title,
+        region: region,
+        limit: '10'
+      }
+      if (author) queryObj.author = author
+      const queryString = new URLSearchParams(queryObj).toString()
+
+      const url = `https://audimeta.de/search?${queryString}`
+      Logger.debug(`[AudiMeta] Search url: ${url}`)
+      items = await axios
+        .get(url, {
+          timeout
+        }).then((res) => {
+          return res.data
+        })
+        .catch((error) => {
+          Logger.error('[AudiMeta] query search error', error)
+          return []
+        })
+    }
+    return items.filter(Boolean).map((item) => this.cleanResult(item)) || []
+  }
+}
+
+module.exports = AudiMeta


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
If you do not follow this template, the PR may be closed without review.
Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

This adds AudiMeta as a provider for Audible which has extended capabilities over Audnexus such as searching for asins in multiple regions and slightly higher rate limits. There are more features, discussed in the Discord channel. 

## Which issue is fixed?

While this PR does not fix it, the provider can be used for https://github.com/advplyr/audiobookshelf/pull/3839

## In-depth Description

I would vote to replace Audnexus (or at least not make it default for Audible) and replace it over the long term with AudiMeta.

Why?

Because Audnexus returns faulty response codes.

Because the dev does not seem to be really interested in continuing the project (Messages in Discord).

Very limited options regarding querying and we have to make many requests.

---

This is a first step to make this transition by making this provider accessible via the dropdown.

When this is implemented for some time I would plan to create a PR to redirect 1% of requests from Audnexus to AudiMeta, and increase this for each release until everything is working.

## How have you tested this?

Matched whole library.
