### PR TITLE
Fixes search not returning results if description field is not provided by a custom provider

### DIFF
--- a/server/providers/CustomProviderAdapter.js
+++ b/server/providers/CustomProviderAdapter.js
@@ -78,7 +78,7 @@ class CustomProviderAdapter {
         narrator,
         publisher,
         publishedYear,
-        description: htmlSanitizer.sanitize(description),
+        description: typeof description === 'string' ? htmlSanitizer.sanitize(description) : description,
         cover,
         isbn,
         asin,


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

Checks if the type is string before passing it to sanitize, because sanitize throws an error if the type is not a string.

Another way would be to return null if the type is not a string instead of the current way to prevent this happening altogether in the sanitizer.

I am not sure if this is possible, but if the type would not be a string, then it would not go through the sanitizer. So if the type is somehow not a string, one could maybe include bad code. I am not that familiar with JavaScript's type system, so I don't know if it's possible that this variable could be something other than a string, null, or a number when numbers would be returned. 

## Which issue is fixed?

<!-- Which issue number does this PR fix? Ex: "Fixes #1234" -->

## In-depth Description

<!--
Describe your solution in more depth.
How does it work? Why is this the best solution?
Does it solve a problem that affects multiple users or is this an edge case for your setup?
-->

## How have you tested this?

<!-- Please describe in detail with reproducible steps how you tested your changes. -->

## Screenshots

<!-- If your PR includes any changes to the web client, please include screenshots or a short video from before and after your changes. -->
