### PR TITLE
Fix RTL issue in LazyEpisodeRow

### DIFF
--- a/client/components/tables/podcast/LazyEpisodeRow.vue
+++ b/client/components/tables/podcast/LazyEpisodeRow.vue
@@ -8,7 +8,7 @@
         </div>
 
         <div class="h-10 flex items-center mt-1.5 mb-0.5 overflow-hidden">
-          <p class="text-sm text-gray-200 line-clamp-2" v-html="episodeSubtitle"></p>
+          <div dir="auto" class="text-sm text-gray-200 line-clamp-2" v-html="episodeSubtitle"></div>
         </div>
 
         <div class="h-8 flex items-center">


### PR DESCRIPTION
## Brief summary

Fix display of RTL description in Podcast episodes table.

## Which issue is fixed?

No issue.

## In-depth Description

A couple of small fixes in `LazyEpisodeRow` subtitle/description display:
- Change \<p> to \<div> (since description can now contain \<p> tags)
- Add `dir="auto"` attribute (this determines the direction based on the content)

## How have you tested this?

Loaded Hebrew (RTL) and English podcast pages
- Description now displayed correctly for Hebrew
- Unchanged for English

## Screenshots
Before:
<img width="670" alt="Screenshot 2025-03-07 212933" src="https://github.com/user-attachments/assets/22838c16-d4ab-4224-96e9-da75ac743ce7" />

After:
<img width="670" alt="Screenshot 2025-03-07 213628" src="https://github.com/user-attachments/assets/17341437-5be8-4c7c-8f57-e55826714ce0" />

