### PR TITLE
Simplify log level determination

### DIFF
--- a/server/Logger.js
+++ b/server/Logger.js
@@ -21,12 +21,7 @@ class Logger {
   }
 
   get levelString() {
-    for (const key in LogLevel) {
-      if (LogLevel[key] === this.logLevel) {
-        return key
-      }
-    }
-    return 'UNKNOWN'
+    return this.getLogLevelString(this.logLevel)
   }
 
   /**

--- a/server/scanner/LibraryScan.js
+++ b/server/scanner/LibraryScan.js
@@ -4,7 +4,6 @@ const fs = require('../libs/fsExtra')
 const date = require('../libs/dateAndTime')
 
 const Logger = require('../Logger')
-const { LogLevel } = require('../utils/constants')
 const { secondsToTimestamp, elapsedPretty } = require('../utils/index')
 
 class LibraryScan {
@@ -109,20 +108,11 @@ class LibraryScan {
     this.elapsed = this.finishedAt - this.startedAt
   }
 
-  getLogLevelString(level) {
-    for (const key in LogLevel) {
-      if (LogLevel[key] === level) {
-        return key
-      }
-    }
-    return 'UNKNOWN'
-  }
-
   addLog(level, ...args) {
     const logObj = {
       timestamp: this.timestamp,
       message: args.join(' '),
-      levelName: this.getLogLevelString(level),
+      levelName: Logger.getLogLevelString(level),
       level
     }
 

--- a/server/scanner/ScanLogger.js
+++ b/server/scanner/ScanLogger.js
@@ -1,6 +1,5 @@
-const uuidv4 = require("uuid").v4
+const uuidv4 = require('uuid').v4
 const Logger = require('../Logger')
-const { LogLevel } = require('../utils/constants')
 
 class ScanLogger {
   constructor() {
@@ -44,20 +43,11 @@ class ScanLogger {
     this.elapsed = this.finishedAt - this.startedAt
   }
 
-  getLogLevelString(level) {
-    for (const key in LogLevel) {
-      if (LogLevel[key] === level) {
-        return key
-      }
-    }
-    return 'UNKNOWN'
-  }
-
   addLog(level, ...args) {
     const logObj = {
-      timestamp: (new Date()).toISOString(),
+      timestamp: new Date().toISOString(),
       message: args.join(' '),
-      levelName: this.getLogLevelString(level),
+      levelName: Logger.getLogLevelString(level),
       level
     }
 


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

Remove duplicate functions for logging.

## Which issue is fixed?

No issue

## In-depth Description

This PR removes the duplicate `getLogLevelString` function from the scan-related loggers. `Logger` is already included, so this just removes code duplication.

This also increases the total coverage of the `Logger.test.js` with no changes to the test code.

## How have you tested this?

Ran unit tests and a scan to ensure nothing broke.

## Screenshots

N/A