### PR TITLE
Fix spelling

### DIFF
--- a/client/strings/en-us.json
+++ b/client/strings/en-us.json
@@ -580,7 +580,7 @@
   "LabelSettingsOnlyShowLaterBooksInContinueSeries": "Skip earlier books in Continue Series",
   "LabelSettingsOnlyShowLaterBooksInContinueSeriesHelp": "The Continue Series home page shelf shows the first book not started in series that have at least one book finished and no books in progress. Enabling this setting will continue series from the furthest completed book instead of the first book not started.",
   "LabelSettingsParseSubtitles": "Parse subtitles",
-  "LabelSettingsParseSubtitlesHelp": "Extract subtitles from audiobook folder names.<br>Subtitle must be seperated by \" - \"<br>i.e. \"Book Title - A Subtitle Here\" has the subtitle \"A Subtitle Here\"",
+  "LabelSettingsParseSubtitlesHelp": "Extract subtitles from audiobook folder names.<br>Subtitle must be separated by \" - \"<br>i.e. \"Book Title - A Subtitle Here\" has the subtitle \"A Subtitle Here\"",
   "LabelSettingsPreferMatchedMetadata": "Prefer matched metadata",
   "LabelSettingsPreferMatchedMetadataHelp": "Matched data will override item details when using Quick Match. By default Quick Match will only fill in missing details.",
   "LabelSettingsSkipMatchingBooksWithASIN": "Skip matching books that already have an ASIN",

--- a/server/utils/scandir.js
+++ b/server/utils/scandir.js
@@ -44,7 +44,7 @@ function groupFileItemsIntoLibraryItemDirs(mediaType, fileItems, audiobooksOnly 
     return i.deep > 0 || (mediaType === 'book' && isMediaFile(mediaType, i.extension, audiobooksOnly))
   })
 
-  // Step 2: Seperate media files and other files
+  // Step 2: Separate media files and other files
   //     - Directories without a media file will not be included
   /** @type {import('./fileUtils').FilePathItem[]} */
   const mediaFileItems = []


### PR DESCRIPTION
## Brief summary

Fix spelling in 'Settings/Scanner/Parse subtitles' info bubble. Same fix in a comment in a different source file.

## Which issue is fixed?

## In-depth Description

n/a

## How have you tested this?

n/a

## Screenshots

n/a
