### PR TITLE
Use multiplication symbol instead of letter x

### DIFF
--- a/client/components/controls/PlaybackSpeedControl.vue
+++ b/client/components/controls/PlaybackSpeedControl.vue
@@ -1,7 +1,7 @@
 <template>
   <div ref="wrapper" class="relative ml-4 sm:ml-8" v-click-outside="clickOutside">
     <div class="flex items-center justify-center text-gray-300 cursor-pointer h-full" @mousedown.prevent @mouseup.prevent @click="setShowMenu(true)">
-      <span class="text-gray-200 text-sm sm:text-base">{{ playbackRateDisplay }}<span class="text-base">x</span></span>
+      <span class="text-gray-200 text-sm sm:text-base">×&#8239;{{ playbackRateDisplay }}</span>
     </div>
     <div v-show="showMenu" class="absolute -top-[5.5rem] z-20 bg-bg border-black-200 border shadow-xl rounded-lg" :style="{ left: menuLeft + 'px' }">
       <div class="absolute -bottom-1.5 right-0 w-full flex justify-center" :style="{ left: arrowLeft + 'px' }">
@@ -11,7 +11,7 @@
         <template v-for="rate in rates">
           <div :key="rate" class="h-full border-black-300 w-11 cursor-pointer border rounded-sm" :class="value === rate ? 'bg-black-100' : 'hover:bg-black hover:bg-opacity-10'" style="min-width: 44px; max-width: 44px" @click="set(rate)">
             <div class="w-full h-full flex justify-center items-center">
-              <p class="text-xs text-center">{{ rate }}<span class="text-sm">x</span></p>
+              <p class="text-xs text-center">×&#8239;{{ rate }}</p>
             </div>
           </div>
         </template>
@@ -19,7 +19,7 @@
       <div class="w-full py-1 px-1">
         <div class="flex items-center justify-between">
           <ui-icon-btn :disabled="!canDecrement" icon="remove" @click="decrement" />
-          <p class="px-2 text-2xl sm:text-3xl">{{ playbackRateDisplay }}<span class="text-2xl">x</span></p>
+          <p class="px-2 text-2xl sm:text-3xl"><span class="text-2xl">×&#8239;</span>{{ playbackRateDisplay }}</p>
           <ui-icon-btn :disabled="!canIncrement" icon="add" @click="increment" />
         </div>
       </div>


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

Use the proper multiplication symbol (×) for the playback speed.

<!-- Please provide a brief summary of what your PR attempts to achieve. -->

## Which issue is fixed?

Minor polish.

<!-- Which issue number does this PR fix? Ex: "Fixes #1234" -->

## In-depth Description

In the playback speed popup, the letter "x" is switched out for the multiplication symbol "×". The order of the number and symbol is reversed so it is read "times 1.0" instead of "1.0 times" (or previously "1.0 x"). Between the symbol and the number, a narrow no-break space (`&#8239;`) is added for proper spacing. The classes of some spans are removed for better alignment.

<!--
Describe your solution in more depth.
How does it work? Why is this the best solution?
Does it solve a problem that affects multiple users or is this an edge case for your setup?
-->

## How have you tested this?

I have generated the client and ran the server to make sure the changes had no unintended side effects. The playback speed controls still work as usual.

<!-- Please describe in detail with reproducible steps how you tested your changes. -->

## Screenshots

| Before | After |
| --- | --- |
| ![bild](https://github.com/user-attachments/assets/63852d87-5b3d-422e-93f0-53de4dc9ccc1) | ![Skärmbild från 2025-03-11 12-56-13](https://github.com/user-attachments/assets/2e4c6a79-92a0-415e-972c-6718944b3858) |


<!-- If your PR includes any changes to the web client, please include screenshots or a short video from before and after your changes. -->
