### PR TITLE
Fix: Load epub covers via cover-image property

### DIFF
--- a/server/utils/parsers/parseEpubMetadata.js
+++ b/server/utils/parsers/parseEpubMetadata.js
@@ -107,7 +107,8 @@ async function parse(ebookFile) {
 
   // Attempt to find filepath to cover image:
   // Metadata may include <meta name="cover" content="id"/> where content is the id of the cover image in the manifest
-  //  Otherwise the first image in the manifest is used as the cover image
+  //  Otherwise find image in the manifest with cover-image property set
+  //  As a fallback the first image in the manifest is used as the cover image
   let packageMetadata = packageJson.package?.metadata
   if (Array.isArray(packageMetadata)) {
     packageMetadata = packageMetadata[0]
@@ -117,6 +118,9 @@ async function parse(ebookFile) {
   let manifestFirstImage = null
   if (metaCoverId) {
     manifestFirstImage = packageJson.package?.manifest?.[0]?.item?.find((item) => item.$?.id === metaCoverId)
+  }
+  if (!manifestFirstImage) {
+    manifestFirstImage = packageJson.package?.manifest?.[0]?.item?.find((item) => item.$?.['properties']?.split(' ')?.includes('cover-image'))
   }
   if (!manifestFirstImage) {
     manifestFirstImage = packageJson.package?.manifest?.[0]?.item?.find((item) => item.$?.['media-type']?.startsWith('image/'))


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

<!-- Please provide a brief summary of what your PR attempts to achieve. -->

Adds ability to load epub covers via [cover-image property](https://www.w3.org/TR/epub-33/#sec-cover-image) in manifest if the cover meta entry is missing.

## Which issue is fixed?

<!-- Which issue number does this PR fix? Ex: "Fixes #1234" -->

Fixes #4105

## In-depth Description

<!--
Describe your solution in more depth.
How does it work? Why is this the best solution?
Does it solve a problem that affects multiple users or is this an edge case for your setup?
-->

The implementation respects the [EPUB 3.3 spec](https://www.w3.org/TR/epub-33/#attrdef-item-properties), and loads `property="cover-image maybe-other-props"` tagged manifest items as cover image, in case the cover metadata entry is missing. Fallback to the first image is still present if neither metadata entry, nor property can be found.

## How have you tested this?

<!-- Please describe in detail with reproducible steps how you tested your changes. -->

I've used this [epub](https://github.com/IDPF/epub3-samples/releases/download/20230704/epub30-spec.epub) as example where this can help. Simply importing this into ABS will have the wrong cover before this change, but the good one after reimporting it with the change. (Same cover as Calibre loads)

## Screenshots

Before: 
![image](https://github.com/user-attachments/assets/bd3b4275-e3cb-4d48-8283-a42c87fd6a9f)

After:
![image](https://github.com/user-attachments/assets/c6f7fe86-0b5c-40c9-9016-290407c784c2)

Calibre:
![image](https://github.com/user-attachments/assets/7ba3abc7-f816-483b-9ed1-bfa73c8670d8)
