### PR TITLE
Update opf parser to support refines meta elements

### DIFF
--- a/server/scanner/OpfFileScanner.js
+++ b/server/scanner/OpfFileScanner.js
@@ -2,24 +2,26 @@ const { parseOpfMetadataXML } = require('../utils/parsers/parseOpfMetadata')
 const { readTextFile } = require('../utils/fileUtils')
 
 class OpfFileScanner {
-  constructor() { }
+  constructor() {}
 
   /**
    * Parse metadata from .opf file found in library scan and update bookMetadata
-   * 
-   * @param {import('../models/LibraryItem').LibraryFileObject} opfLibraryFileObj 
-   * @param {Object} bookMetadata 
+   *
+   * @param {import('../models/LibraryItem').LibraryFileObject} opfLibraryFileObj
+   * @param {Object} bookMetadata
    */
   async scanBookOpfFile(opfLibraryFileObj, bookMetadata) {
     const xmlText = await readTextFile(opfLibraryFileObj.metadata.path)
     const opfMetadata = xmlText ? await parseOpfMetadataXML(xmlText) : null
     if (opfMetadata) {
       for (const key in opfMetadata) {
-        if (key === 'tags') { // Add tags only if tags are empty
+        if (key === 'tags') {
+          // Add tags only if tags are empty
           if (opfMetadata.tags.length) {
             bookMetadata.tags = opfMetadata.tags
           }
-        } else if (key === 'genres') { // Add genres only if genres are empty
+        } else if (key === 'genres') {
+          // Add genres only if genres are empty
           if (opfMetadata.genres.length) {
             bookMetadata.genres = opfMetadata.genres
           }

--- a/test/server/utils/parsers/parseOpfMetadata.test.js
+++ b/test/server/utils/parsers/parseOpfMetadata.test.js
@@ -3,8 +3,8 @@ const expect = chai.expect
 const { parseOpfMetadataXML } = require('../../../../server/utils/parsers/parseOpfMetadata')
 
 describe('parseOpfMetadata - test series', async () => {
-    it('test one series', async () => {
-        const opf = `
+  it('test one series', async () => {
+    const opf = `
             <?xml version='1.0' encoding='UTF-8'?>
             <package xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:opf="http://www.idpf.org/2007/opf" xml:lang="en" version="3.0" unique-identifier="bookid">
               <metadata>
@@ -13,12 +13,12 @@ describe('parseOpfMetadata - test series', async () => {
               </metadata>
             </package>
         `
-        const parsedOpf = await parseOpfMetadataXML(opf)
-        expect(parsedOpf.series).to.deep.equal([{ "name": "Serie", "sequence": "1" }])
-    })
+    const parsedOpf = await parseOpfMetadataXML(opf)
+    expect(parsedOpf.series).to.deep.equal([{ name: 'Serie', sequence: '1' }])
+  })
 
-    it('test more then 1 series - in correct order', async () => {
-        const opf = `
+  it('test more then 1 series - in correct order', async () => {
+    const opf = `
             <?xml version='1.0' encoding='UTF-8'?>
             <package xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:opf="http://www.idpf.org/2007/opf" xml:lang="en" version="3.0" unique-identifier="bookid">
               <metadata>
@@ -31,16 +31,16 @@ describe('parseOpfMetadata - test series', async () => {
               </metadata>
             </package>
         `
-        const parsedOpf = await parseOpfMetadataXML(opf)
-        expect(parsedOpf.series).to.deep.equal([
-            { "name": "Serie 1", "sequence": "1" },
-            { "name": "Serie 2", "sequence": "2" },
-            { "name": "Serie 3", "sequence": "3" },
-        ])
-    })
+    const parsedOpf = await parseOpfMetadataXML(opf)
+    expect(parsedOpf.series).to.deep.equal([
+      { name: 'Serie 1', sequence: '1' },
+      { name: 'Serie 2', sequence: '2' },
+      { name: 'Serie 3', sequence: '3' }
+    ])
+  })
 
-    it('test messed order of series content and index', async () => {
-        const opf = `
+  it('test messed order of series content and index', async () => {
+    const opf = `
             <?xml version='1.0' encoding='UTF-8'?>
             <package xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:opf="http://www.idpf.org/2007/opf" xml:lang="en" version="3.0" unique-identifier="bookid">
               <metadata>
@@ -52,15 +52,15 @@ describe('parseOpfMetadata - test series', async () => {
               </metadata>
             </package>
         `
-        const parsedOpf = await parseOpfMetadataXML(opf)
-        expect(parsedOpf.series).to.deep.equal([
-            { "name": "Serie 1", "sequence": "1" },
-            { "name": "Serie 3", "sequence": null },
-        ])
-    })
+    const parsedOpf = await parseOpfMetadataXML(opf)
+    expect(parsedOpf.series).to.deep.equal([
+      { name: 'Serie 1', sequence: '1' },
+      { name: 'Serie 3', sequence: null }
+    ])
+  })
 
-    it('test different values of series content and index', async () => {
-        const opf = `
+  it('test different values of series content and index', async () => {
+    const opf = `
             <?xml version='1.0' encoding='UTF-8'?>
             <package xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:opf="http://www.idpf.org/2007/opf" xml:lang="en" version="3.0" unique-identifier="bookid">
               <metadata>
@@ -73,16 +73,16 @@ describe('parseOpfMetadata - test series', async () => {
               </metadata>
             </package>
         `
-        const parsedOpf = await parseOpfMetadataXML(opf)
-        expect(parsedOpf.series).to.deep.equal([
-            { "name": "Serie 1", "sequence": null },
-            { "name": "Serie 2", "sequence": "abc" },
-            { "name": "Serie 3", "sequence": null },
-        ])
-    })
+    const parsedOpf = await parseOpfMetadataXML(opf)
+    expect(parsedOpf.series).to.deep.equal([
+      { name: 'Serie 1', sequence: null },
+      { name: 'Serie 2', sequence: 'abc' },
+      { name: 'Serie 3', sequence: null }
+    ])
+  })
 
-    it('test empty series content', async () => {
-        const opf = `
+  it('test empty series content', async () => {
+    const opf = `
             <?xml version='1.0' encoding='UTF-8'?>
             <package xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:opf="http://www.idpf.org/2007/opf" xml:lang="en" version="3.0" unique-identifier="bookid">
               <metadata>
@@ -91,12 +91,12 @@ describe('parseOpfMetadata - test series', async () => {
               </metadata>
             </package>
         `
-        const parsedOpf = await parseOpfMetadataXML(opf)
-        expect(parsedOpf.series).to.deep.equal([])
-    })
+    const parsedOpf = await parseOpfMetadataXML(opf)
+    expect(parsedOpf.series).to.deep.equal([])
+  })
 
-    it('test series and index using an xml namespace', async () => {
-        const opf = `
+  it('test series and index using an xml namespace', async () => {
+    const opf = `
             <?xml version='1.0' encoding='UTF-8'?>
             <ns0:package xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:opf="http://www.idpf.org/2007/opf" xml:lang="en" version="3.0" unique-identifier="bookid">
               <ns0:metadata>
@@ -105,14 +105,12 @@ describe('parseOpfMetadata - test series', async () => {
               </ns0:metadata>
             </ns0:package>
         `
-        const parsedOpf = await parseOpfMetadataXML(opf)
-        expect(parsedOpf.series).to.deep.equal([
-            { "name": "Serie 1", "sequence": null }
-        ])
-    })
+    const parsedOpf = await parseOpfMetadataXML(opf)
+    expect(parsedOpf.series).to.deep.equal([{ name: 'Serie 1', sequence: null }])
+  })
 
-    it('test series and series index not directly underneath', async () => {
-        const opf = `
+  it('test series and series index not directly underneath', async () => {
+    const opf = `
             <?xml version='1.0' encoding='UTF-8'?>
             <package xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:opf="http://www.idpf.org/2007/opf" xml:lang="en" version="3.0" unique-identifier="bookid">
               <metadata>
@@ -122,9 +120,21 @@ describe('parseOpfMetadata - test series', async () => {
               </metadata>
             </package>
         `
-        const parsedOpf = await parseOpfMetadataXML(opf)
-        expect(parsedOpf.series).to.deep.equal([
-            { "name": "Serie 1", "sequence": "1" }
-        ])
-    })
+    const parsedOpf = await parseOpfMetadataXML(opf)
+    expect(parsedOpf.series).to.deep.equal([{ name: 'Serie 1', sequence: '1' }])
+  })
+
+  it('test author is parsed from refines meta', async () => {
+    const opf = `
+        <package version="3.0" unique-identifier="uuid_id" prefix="rendition: http://www.idpf.org/vocab/rendition/#" xmlns="http://www.idpf.org/2007/opf">
+          <metadata>
+            <dc:creator id="create1">Nevil Shute</dc:creator>
+            <meta refines="#create1" property="role" scheme="marc:relators">aut</meta>
+            <meta refines="#create1" property="file-as">Shute, Nevil</meta>
+          </metadata>
+        </package>
+      `
+    const parsedOpf = await parseOpfMetadataXML(opf)
+    expect(parsedOpf.authors).to.deep.equal(['Nevil Shute'])
+  })
 })


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

Parse OPF v3
See https://github.com/advplyr/audiobookshelf/discussions/4109

## Which issue is fixed?

None

## In-depth Description

In OPF v3 [meta elements](https://www.w3.org/TR/epub-33/#sec-meta-elem) can have a `refines` attribute that is an ID of another element it is describing.

In this example the role of the `dc:creator` element is in the refines meta element.
```xml
<package version="3.0" unique-identifier="uuid_id" prefix="rendition: http://www.idpf.org/vocab/rendition/#" xmlns="http://www.idpf.org/2007/opf">
  <metadata>
    <dc:creator id="create1">Nevil Shute</dc:creator>
    <meta refines="#create1" property="role" scheme="marc:relators">aut</meta>
    <meta refines="#create1" property="file-as">Shute, Nevil</meta>
  </metadata>
</package>
```

## How have you tested this?

Added test case
