### PR TITLE
Allow number types for payload metadata when updating books.

### DIFF
--- a/server/models/Book.js
+++ b/server/models/Book.js
@@ -374,8 +374,10 @@ class Book extends Model {
     if (payload.metadata) {
       const metadataStringKeys = ['title', 'subtitle', 'publishedYear', 'publishedDate', 'publisher', 'description', 'isbn', 'asin', 'language']
       metadataStringKeys.forEach((key) => {
-        if (typeof payload.metadata[key] == 'number')
+        if (typeof payload.metadata[key] == 'number') {
           payload.metadata[key] = String(payload.metadata[key])
+        }
+          
         if ((typeof payload.metadata[key] === 'string' || payload.metadata[key] === null) && this[key] !== payload.metadata[key]) {
           this[key] = payload.metadata[key] || null
 

--- a/server/models/Book.js
+++ b/server/models/Book.js
@@ -374,7 +374,7 @@ class Book extends Model {
     if (payload.metadata) {
       const metadataStringKeys = ['title', 'subtitle', 'publishedYear', 'publishedDate', 'publisher', 'description', 'isbn', 'asin', 'language']
       metadataStringKeys.forEach((key) => {
-        if ((typeof payload.metadata[key] === 'string' || payload.metadata[key] === null) && this[key] !== payload.metadata[key]) {
+        if ((typeof payload.metadata[key] === 'string' || typeof payload.metadata[key] === 'number' || payload.metadata[key] === null) && this[key] !== payload.metadata[key]) {
           this[key] = payload.metadata[key] || null
 
           if (key === 'title') {

--- a/server/models/Book.js
+++ b/server/models/Book.js
@@ -374,7 +374,9 @@ class Book extends Model {
     if (payload.metadata) {
       const metadataStringKeys = ['title', 'subtitle', 'publishedYear', 'publishedDate', 'publisher', 'description', 'isbn', 'asin', 'language']
       metadataStringKeys.forEach((key) => {
-        if ((typeof payload.metadata[key] === 'string' || typeof payload.metadata[key] === 'number' || payload.metadata[key] === null) && this[key] !== payload.metadata[key]) {
+        if (typeof payload.metadata[key] == 'number')
+          payload.metadata[key] = String(payload.metadata[key])
+        if ((typeof payload.metadata[key] === 'string' || payload.metadata[key] === null) && this[key] !== payload.metadata[key]) {
           this[key] = payload.metadata[key] || null
 
           if (key === 'title') {


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

<!-- Please provide a brief summary of what your PR attempts to achieve. -->

Allow number types for payload metadata when updating books.

## Which issue is fixed?

[4114](https://github.com/advplyr/audiobookshelf/issues/4114)

<!-- Which issue number does this PR fix? Ex: "Fixes #1234" -->

## In-depth Description

Allow the use of number types for payload metadata when updating books.

OpenLibrary uses numbers instead of strings to update the published year, so this PR attempts to fix this issue by allowing number types for payload metadata. 

<!--
Describe your solution in more depth.
How does it work? Why is this the best solution?
Does it solve a problem that affects multiple users or is this an edge case for your setup?
-->

## How have you tested this?

I have replicated issue [4114](https://github.com/advplyr/audiobookshelf/issues/4114) locally and tested the change effects. 

<!-- Please describe in detail with reproducible steps how you tested your changes. -->

## Screenshots

<!-- If your PR includes any changes to the web client, please include screenshots or a short video from before and after your changes. -->
