### PR TITLE
Adds the option to download selected books

### DIFF
--- a/client/components/app/Appbar.vue
+++ b/client/components/app/Appbar.vue
@@ -182,7 +182,7 @@ export default {
 
       // The limit of 50 is introduced because of the URL length. Each id has 36 chars, so 36 * 40 = 1440
       // + 40 , separators = 1480 chars + base path 280 chars = 1760 chars. This keeps the URL under 2000 chars even with longer domains
-      if(this.selectedMediaItems.length <= 40) {
+      if (this.selectedMediaItems.length <= 40) {
         options.push({
           text: this.$strings.LabelDownload,
           action: 'download'
@@ -255,7 +255,7 @@ export default {
     async batchDownload() {
       const libraryItemIds = this.selectedMediaItems.map((i) => i.id)
       console.log('Downloading library items', libraryItemIds)
-      this.$downloadFile(`/api/libraries/${this.$store.state.libraries.currentLibraryId}/download?token=${this.$store.getters['user/getToken']}&ids=${libraryItemIds.join(',')}`, null, true)
+      this.$downloadFile(`/api/libraries/${this.$store.state.libraries.currentLibraryId}/download?token=${this.$store.getters['user/getToken']}&ids=${libraryItemIds.join(',')}`)
     },
     async playSelectedItems() {
       this.$store.commit('setProcessingBatch', true)

--- a/client/components/app/Appbar.vue
+++ b/client/components/app/Appbar.vue
@@ -180,6 +180,15 @@ export default {
         action: 'rescan'
       })
 
+      // The limit of 50 is introduced because of the URL length. Each id has 36 chars, so 36 * 40 = 1440
+      // + 40 , separators = 1480 chars + base path 280 chars = 1760 chars. This keeps the URL under 2000 chars even with longer domains
+      if(this.selectedMediaItems.length <= 40) {
+        options.push({
+          text: this.$strings.LabelDownload,
+          action: 'download'
+        })
+      }
+
       return options
     }
   },
@@ -215,6 +224,8 @@ export default {
         this.batchAutoMatchClick()
       } else if (action === 'rescan') {
         this.batchRescan()
+      } else if (action === 'download') {
+        this.batchDownload()
       }
     },
     async batchRescan() {
@@ -240,6 +251,11 @@ export default {
         type: 'yesNo'
       }
       this.$store.commit('globals/setConfirmPrompt', payload)
+    },
+    async batchDownload() {
+      const libraryItemIds = this.selectedMediaItems.map((i) => i.id)
+      console.log('Downloading library items', libraryItemIds)
+      this.$downloadFile(`/api/libraries/${this.$store.state.libraries.currentLibraryId}/download?token=${this.$store.getters['user/getToken']}&ids=${libraryItemIds.join(',')}`, null, true)
     },
     async playSelectedItems() {
       this.$store.commit('setProcessingBatch', true)

--- a/server/controllers/LibraryController.js
+++ b/server/controllers/LibraryController.js
@@ -1452,15 +1452,24 @@ class LibraryController {
 
     const filename = `LibraryItems-${Date.now()}.zip`
     const libraryItemPaths = libraryItems.map((li) => li.path)
-
-    console.log(libraryItemPaths)
+    
 
     try {
       await zipHelpers.zipDirectoriesPipe(libraryItemPaths, filename, res)
       Logger.info(`[LibraryItemController] Downloaded item "${filename}" at "${libraryItemPaths}"`)
     } catch (error) {
       Logger.error(`[LibraryItemController] Download failed for item "${filename}" at "${libraryItemPaths}"`, error)
-      //LibraryItemController.handleDownloadError(error, res)
+      LibraryController.handleDownloadError(error, res)
+    }
+  }
+
+  static handleDownloadError(error, res) {
+    if (!res.headersSent) {
+      if (error.code === 'ENOENT') {
+        return res.status(404).send('File not found')
+      } else {
+        return res.status(500).send('Download failed')
+      }
     }
   }
 

--- a/server/controllers/LibraryController.js
+++ b/server/controllers/LibraryController.js
@@ -1424,7 +1424,7 @@ class LibraryController {
    * GET: /api/library/:id/download
    * Downloads multiple library items
    *
-   * @param {LibraryItemControllerRequest} req
+   * @param {LibraryControllerRequest} req
    * @param {Response} res
    */
   async downloadMultiple(req, res) {
@@ -1433,8 +1433,9 @@ class LibraryController {
       return res.sendStatus(403)
     }
 
-    if(req.query.ids === undefined || req.query.ids === '') {
-      res.status(400).send('Library items not found')
+    if (!req.query.ids || typeof req.query.ids !== 'string') {
+      res.status(400).send('Invalid request. ids must be a string')
+      return
     }
 
     const itemIds = req.query.ids.split(',')
@@ -1466,7 +1467,6 @@ class LibraryController {
       zipHelpers.handleDownloadError(error, res)
     }
   }
-
 
   /**
    *

--- a/server/routers/ApiRouter.js
+++ b/server/routers/ApiRouter.js
@@ -94,6 +94,7 @@ class ApiRouter {
     this.router.post('/libraries/order', LibraryController.reorder.bind(this))
     this.router.post('/libraries/:id/remove-metadata', LibraryController.middleware.bind(this), LibraryController.removeAllMetadataFiles.bind(this))
     this.router.get('/libraries/:id/podcast-titles', LibraryController.middleware.bind(this), LibraryController.getPodcastTitles.bind(this))
+    this.router.get('/libraries/:id/download', LibraryController.middleware.bind(this), LibraryController.downloadMultiple.bind(this))
 
     //
     // Item Routes

--- a/server/utils/zipHelpers.js
+++ b/server/utils/zipHelpers.js
@@ -123,3 +123,20 @@ module.exports.zipDirectoriesPipe = (paths, filename, res) => {
     archive.finalize()
   })
 }
+
+/**
+ * Handles errors that occur during the download process.
+ *
+ * @param error
+ * @param res
+ * @returns {*}
+ */
+module.exports.handleDownloadError = (error, res) => {
+  if (!res.headersSent) {
+    if (error.code === 'ENOENT') {
+      return res.status(404).send('File not found')
+    } else {
+      return res.status(500).send('Download failed')
+    }
+  }
+}

--- a/server/utils/zipHelpers.js
+++ b/server/utils/zipHelpers.js
@@ -1,5 +1,6 @@
 const Logger = require('../Logger')
 const archiver = require('../libs/archiver')
+const { lstatSync } = require('node:fs')
 
 module.exports.zipDirectoryPipe = (path, filename, res) => {
   return new Promise((resolve, reject) => {
@@ -46,6 +47,78 @@ module.exports.zipDirectoryPipe = (path, filename, res) => {
     archive.pipe(res)
 
     archive.directory(path, false)
+
+    archive.finalize()
+  })
+}
+
+/**
+ * Creates a zip archive containing multiple directories and streams it to the response.
+ *
+ * @param {string[]} paths - Array of directory paths to include in the zip archive.
+ * @param {string} filename - Name of the zip file to be sent as attachment.
+ * @param {object} res - Response object to pipe the archive data to.
+ * @returns {Promise<void>} - Promise that resolves when the zip operation completes.
+ */
+module.exports.zipDirectoriesPipe = (paths, filename, res) => {
+  return new Promise((resolve, reject) => {
+    // create a file to stream archive data to
+    res.attachment(filename)
+
+    const archive = archiver('zip', {
+      zlib: { level: 0 } // Sets the compression level.
+    })
+
+    // listen for all archive data to be written
+    // 'close' event is fired only when a file descriptor is involved
+    res.on('close', () => {
+      Logger.info(archive.pointer() + ' total bytes')
+      Logger.debug('archiver has been finalized and the output file descriptor has closed.')
+      resolve()
+    })
+
+    // This event is fired when the data source is drained no matter what was the data source.
+    // It is not part of this library but rather from the NodeJS Stream API.
+    // @see: https://nodejs.org/api/stream.html#stream_event_end
+    res.on('end', () => {
+      Logger.debug('Data has been drained')
+    })
+
+    // good practice to catch warnings (ie stat failures and other non-blocking errors)
+    archive.on('warning', function (err) {
+      if (err.code === 'ENOENT') {
+        // log warning
+        Logger.warn(`[DownloadManager] Archiver warning: ${err.message}`)
+      } else {
+        // throw error
+        Logger.error(`[DownloadManager] Archiver error: ${err.message}`)
+        // throw err
+        reject(err)
+      }
+    })
+    archive.on('error', function (err) {
+      Logger.error(`[DownloadManager] Archiver error: ${err.message}`)
+      reject(err)
+    })
+
+    // pipe archive data to the file
+    archive.pipe(res)
+
+    // Add each path as a directory in the zip
+    paths.forEach(path => {
+
+      const paths = path.split('/')
+
+      // Check if path is file or directory
+      if (lstatSync(path).isDirectory()) {
+        const dirName = path.split('/').pop()
+
+        // Add the directory to the archive with its name as the root folder
+        archive.directory(path, dirName);
+      } else {
+        archive.file(path, { name: paths[paths.length - 1] });
+      }
+    });
 
     archive.finalize()
   })


### PR DESCRIPTION
## Brief summary

Adds a new endpoint that allows bulk downloading multiple library items and adds it to the frontend.

## Which issue is fixed?

None directly, I think. But it comes close to #3541 and I believe this is the better approach instead of implementing an endpoint for Collections, Series, Authors, Playlists, etc.

## In-depth Description

It fetches all the library items and their paths, puts them into one zip file.

Structure is like
```
ZIP
-- file.mp3
-- Book Folder Name/
---- file.mp3
---- file.epub
```

We are limited by GET to download the file as it has a 2000 character limit on most browsers. Since we can't send any request body, we have a limit of 40 IDs we can send to safely prevent any errors. Therefore, the download button is only shown for up to 40 books. But in theory, it would work with more.

## How have you tested this?

Using my own library. Files in root directory, but also in non-root directories.

## Screenshots

I don't have any with public domain works, but just imagine a download button under the three-dot menu when selecting multiple books in the library view. 