### PR TITLE
Reduce final docker image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 ### STAGE 0: Build client ###
-FROM node:20-alpine AS build
+FROM node:20-alpine AS build-client
 WORKDIR /client
 COPY /client /client
 RUN npm ci && npm cache clean --force
 RUN npm run generate
 
 ### STAGE 1: Build server ###
-FROM node:20-alpine
+FROM node:20-alpine AS build-server
 
 ENV NODE_ENV=production
 
@@ -21,9 +21,9 @@ RUN apk update && \
   tini \
   unzip
 
-COPY --from=build /client/dist /client/dist
-COPY index.js package* /
-COPY server server
+WORKDIR /server
+COPY index.js package* /server
+COPY /server /server/server
 
 ARG TARGETPLATFORM
 
@@ -42,7 +42,20 @@ RUN case "$TARGETPLATFORM" in \
 
 RUN npm ci --only=production
 
-RUN apk del make python3 g++
+### STAGE 2: Create minimal runtime image ###
+FROM node:20-alpine
+
+# Install only runtime dependencies
+RUN apk add --no-cache \
+  tzdata \
+  ffmpeg \
+  tini
+
+WORKDIR /app
+
+# Copy compiled frontend and server from build stages
+COPY --from=build-client /client/dist /app/client/dist
+COPY --from=build-server /server /app
 
 EXPOSE 80
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,15 +10,11 @@ FROM node:20-alpine AS build-server
 
 ENV NODE_ENV=production
 
-RUN apk update && \
-  apk add --no-cache --update \
+RUN apk add --no-cache --update \
   curl \
-  tzdata \
-  ffmpeg \
   make \
   python3 \
   g++ \
-  tini \
   unzip
 
 WORKDIR /server
@@ -46,7 +42,7 @@ RUN npm ci --only=production
 FROM node:20-alpine
 
 # Install only runtime dependencies
-RUN apk add --no-cache \
+RUN apk add --no-cache --update \
   tzdata \
   ffmpeg \
   tini


### PR DESCRIPTION
## Brief summary
Reduces the final docker image size

## Which issue is fixed?

no issue open

## In-depth Description
this adds a third stage to the build, copying the required files only from the previous stages, this reduces the final image size from 600MB+ down to ~320MB

## How have you tested this?
I tried the image after the build and it seems to be working, is there a test suite to run?

