### PR TITLE
Fix broken component tests

### DIFF
--- a/.github/workflows/component-tests.yml
+++ b/.github/workflows/component-tests.yml
@@ -1,0 +1,48 @@
+name: Run Component Tests
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Branch/Tag/SHA to test'
+        required: true
+  pull_request:
+    paths:
+      - 'client/**'
+      - '.github/workflows/component-tests.yml'
+  push:
+    paths:
+      - 'client/**'
+      - '.github/workflows/component-tests.yml'
+
+jobs:
+  run-component-tests:
+    name: Run Component Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout (push/pull request)
+        uses: actions/checkout@v4
+        if: github.event_name != 'workflow_dispatch'
+
+      - name: Checkout (workflow_dispatch)
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+        if: github.event_name == 'workflow_dispatch'
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: |
+          cd client
+          npm ci
+
+      - name: Run tests
+        run: |
+          cd client
+          npm test

--- a/client/cypress/tests/components/cards/AuthorCard.cy.js
+++ b/client/cypress/tests/components/cards/AuthorCard.cy.js
@@ -19,7 +19,9 @@ describe('AuthorCard', () => {
   const mocks = {
     $strings: {
       LabelBooks: 'Books',
-      ButtonQuickMatch: 'Quick Match'
+      ButtonQuickMatch: 'Quick Match',
+      ToastAuthorUpdateSuccess: 'Author updated',
+      ToastAuthorUpdateSuccessNoImageFound: 'Author updated (no image found)'
     },
     $store: {
       getters: {
@@ -167,7 +169,7 @@ describe('AuthorCard', () => {
     cy.get('&match').click()
 
     cy.get('&spinner').should('be.hidden')
-    cy.get('@success').should('have.been.calledOnceWithExactly', 'Author John Doe was updated (no image found)')
+    cy.get('@success').should('have.been.calledOnceWithExactly', 'Author updated (no image found)')
     cy.get('@error').should('not.have.been.called')
     cy.get('@info').should('not.have.been.called')
   })
@@ -189,7 +191,7 @@ describe('AuthorCard', () => {
     cy.get('&match').click()
 
     cy.get('&spinner').should('be.hidden')
-    cy.get('@success').should('have.been.calledOnceWithExactly', 'Author John Doe was updated')
+    cy.get('@success').should('have.been.calledOnceWithExactly', 'Author updated')
     cy.get('@error').should('not.have.been.called')
     cy.get('@info').should('not.have.been.called')
   })

--- a/client/cypress/tests/components/cards/LazyBookCard.cy.js
+++ b/client/cypress/tests/components/cards/LazyBookCard.cy.js
@@ -172,6 +172,7 @@ describe('LazyBookCard', () => {
   })
 
   it('shows titleImageNotReady and sets opacity 0 on coverImage when image not ready', () => {
+    mountOptions.mocks.$store.getters['globals/getLibraryItemCoverSrc'] = () => 'https://my.server.com/notfound.jpg'
     cy.mount(LazyBookCard, mountOptions)
 
     cy.get('&titleImageNotReady').should('be.visible')
@@ -257,7 +258,7 @@ describe('LazyBookCard', () => {
       cy.get('#book-card-0').trigger('mouseover')
 
       cy.get('&titleImageNotReady').should('be.hidden')
-      cy.get('&seriesNameOverlay').should('be.visible').and('have.text', 'Middle Earth Chronicles')
+      cy.get('&seriesNameOverlay').should('be.visible').and('have.text', 'The Lord of the Rings')
     })
 
     it('shows the seriesSequenceList when collapsed series has a sequence list', () => {

--- a/client/cypress/tests/components/cards/LazySeriesCard.cy.js
+++ b/client/cypress/tests/components/cards/LazySeriesCard.cy.js
@@ -30,6 +30,14 @@ describe('LazySeriesCard', () => {
   }
 
   const mocks = {
+    $getString: (id, args) => {
+      switch (id) {
+        case 'LabelAddedDate':
+          return `Added ${args[0]}`
+        default:
+          return null
+      }
+    },
     $store: {
       getters: {
         'user/getUserCanUpdate': true,


### PR DESCRIPTION
## Brief summary

This fixes some broken client component tests

## Which issue is fixed?

No issue.

## In-depth Description

Unfortunately, we don't run component tests automatically, so they break from time to time.
This fixes them to run with the current code.

If it's OK with you, I'll add these to the push procedure using a Github workflow (like unit tests).

## How have you tested this?

All existing tests run.