### PR TITLE
Consistent icons in stats page

### DIFF
--- a/client/pages/config/stats.vue
+++ b/client/pages/config/stats.vue
@@ -6,12 +6,9 @@
     <app-settings-content :header-text="$strings.HeaderYourStats" class="mb-4!">
       <div class="flex justify-center">
         <div class="flex p-2">
-          <svg class="hidden sm:block h-14 w-14 lg:h-18 lg:w-18" viewBox="0 0 24 24">
-            <path
-              fill="currentColor"
-              d="M19 1L14 6V17L19 12.5V1M21 5V18.5C19.9 18.15 18.7 18 17.5 18C15.8 18 13.35 18.65 12 19.5V6C10.55 4.9 8.45 4.5 6.5 4.5C4.55 4.5 2.45 4.9 1 6V20.65C1 20.9 1.25 21.15 1.5 21.15C1.6 21.15 1.65 21.1 1.75 21.1C3.1 20.45 5.05 20 6.5 20C8.45 20 10.55 20.4 12 21.5C13.35 20.65 15.8 20 17.5 20C19.15 20 20.85 20.3 22.25 21.05C22.35 21.1 22.4 21.1 22.5 21.1C22.75 21.1 23 20.85 23 20.6V6C22.4 5.55 21.75 5.25 21 5M10 18.41C8.75 18.09 7.5 18 6.5 18C5.44 18 4.18 18.19 3 18.5V7.13C3.91 6.73 5.14 6.5 6.5 6.5C7.86 6.5 9.09 6.73 10 7.13V18.41Z"
-            />
-          </svg>
+          <div class="hidden sm:block">
+            <span class="hidden sm:block material-symbols text-5xl lg:text-6xl">auto_stories</span>
+          </div>
           <div class="px-3">
             <p class="text-4xl md:text-5xl font-bold">{{ $formatNumber(userItemsFinished.length) }}</p>
             <p class="text-xs md:text-sm text-white/80">{{ $strings.LabelStatsItemsFinished }}</p>


### PR DESCRIPTION
## Brief summary

For "Items Finished" in stats page, replace SVG icon with equivalent Material Symbol ligature

## Which issue is fixed?

I did not open an issue for this

## In-depth Description

Replaces the inline SVG element for the "Items Finished" stat with the equivalent symbol from the Material Symbol font to be consistent with the other stats.
Noticed this while idly selecting random text on the page and noticing that this icon was not selectable.

## How have you tested this?

Manual edit in browser, did not actually build the program

## Screenshots

Before:
![image](https://github.com/user-attachments/assets/3290c53c-4375-403d-92b8-444a07109bdd)
After:
![image](https://github.com/user-attachments/assets/67613712-e81b-4fd9-b3b2-9b5244ff3a5a)
