### PR TITLE
Create new StatsController and move year in review stats endpoint

### DIFF
--- a/server/controllers/StatsController.js
+++ b/server/controllers/StatsController.js
@@ -1,0 +1,75 @@
+const { Request, Response, NextFunction } = require('express')
+const Logger = require('../Logger')
+
+const adminStats = require('../utils/queries/adminStats')
+
+/**
+ * @typedef RequestUserObject
+ * @property {import('../models/User')} user
+ *
+ * @typedef {Request & RequestUserObject} RequestWithUser
+ */
+
+class StatsController {
+  constructor() {}
+
+  /**
+   * GET: /api/stats/server
+   * Currently not in use
+   *
+   * @param {RequestWithUser} req
+   * @param {Response} res
+   */
+  async getServerStats(req, res) {
+    Logger.debug('[StatsController] getServerStats')
+    const totalSize = await adminStats.getTotalSize()
+    const numAudioFiles = await adminStats.getNumAudioFiles()
+
+    res.json({
+      books: {
+        ...totalSize.books,
+        numAudioFiles: numAudioFiles.numBookAudioFiles
+      },
+      podcasts: {
+        ...totalSize.podcasts,
+        numAudioFiles: numAudioFiles.numPodcastAudioFiles
+      },
+      total: {
+        ...totalSize.total,
+        numAudioFiles: numAudioFiles.numAudioFiles
+      }
+    })
+  }
+
+  /**
+   * GET: /api/stats/year/:year
+   *
+   * @param {RequestWithUser} req
+   * @param {Response} res
+   */
+  async getAdminStatsForYear(req, res) {
+    const year = Number(req.params.year)
+    if (isNaN(year) || year < 2000 || year > 9999) {
+      Logger.error(`[StatsController] Invalid year "${year}"`)
+      return res.status(400).send('Invalid year')
+    }
+    const stats = await adminStats.getStatsForYear(year)
+    res.json(stats)
+  }
+
+  /**
+   *
+   * @param {RequestWithUser} req
+   * @param {Response} res
+   * @param {NextFunction} next
+   */
+  async middleware(req, res, next) {
+    if (!req.user.isAdminOrUp) {
+      Logger.error(`[StatsController] Non-root user "${req.user.username}" attempted to access stats route`)
+      return res.sendStatus(403)
+    }
+
+    next()
+  }
+}
+module.exports = new StatsController()

--- a/server/controllers/StatsController.js
+++ b/server/controllers/StatsController.js
@@ -65,7 +65,7 @@ class StatsController {
    */
   async middleware(req, res, next) {
     if (!req.user.isAdminOrUp) {
-      Logger.error(`[StatsController] Non-root user "${req.user.username}" attempted to access stats route`)
+      Logger.error(`[StatsController] Non-admin user "${req.user.username}" attempted to access stats route`)
       return res.sendStatus(403)
     }
 

--- a/server/routers/ApiRouter.js
+++ b/server/routers/ApiRouter.js
@@ -322,8 +322,8 @@ class ApiRouter {
     //
     // Stats Routes
     //
-    this.router.get('/stats/year/:year', StatsController.getAdminStatsForYear.bind(this))
-    this.router.get('/stats/server', StatsController.getServerStats.bind(this))
+    this.router.get('/stats/year/:year', StatsController.middleware.bind(this), StatsController.getAdminStatsForYear.bind(this))
+    this.router.get('/stats/server', StatsController.middleware.bind(this), StatsController.getServerStats.bind(this))
 
     //
     // Misc Routes

--- a/server/routers/ApiRouter.js
+++ b/server/routers/ApiRouter.js
@@ -33,8 +33,7 @@ const RSSFeedController = require('../controllers/RSSFeedController')
 const CustomMetadataProviderController = require('../controllers/CustomMetadataProviderController')
 const MiscController = require('../controllers/MiscController')
 const ShareController = require('../controllers/ShareController')
-
-const { getTitleIgnorePrefix } = require('../utils/index')
+const StatsController = require('../controllers/StatsController')
 
 class ApiRouter {
   constructor(Server) {
@@ -321,6 +320,12 @@ class ApiRouter {
     this.router.delete('/share/mediaitem/:id', ShareController.deleteMediaItemShare.bind(this))
 
     //
+    // Stats Routes
+    //
+    this.router.get('/stats/year/:year', StatsController.getAdminStatsForYear.bind(this))
+    this.router.get('/stats/server', StatsController.getServerStats.bind(this))
+
+    //
     // Misc Routes
     //
     this.router.post('/upload', MiscController.handleUpload.bind(this))
@@ -338,7 +343,6 @@ class ApiRouter {
     this.router.get('/auth-settings', MiscController.getAuthSettings.bind(this))
     this.router.patch('/auth-settings', MiscController.updateAuthSettings.bind(this))
     this.router.post('/watcher/update', MiscController.updateWatchedPath.bind(this))
-    this.router.get('/stats/year/:year', MiscController.getAdminStatsForYear.bind(this))
     this.router.get('/logger-data', MiscController.getLoggerData.bind(this))
   }
 


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

Create StatsController in preparation for new server stats page. Moves existing year in review stats endpoint to StatsController.

## Which issue is fixed?

None

## In-depth Description

This also sets up a server stats endpoint at `/api/stats/server` that returns the following data so far.

```json
{
  "books": {
    "totalSize": 46370467418,
    "numItems": 221,
    "numAudioFiles": 2586
  },
  "podcasts": {
    "totalSize": 9962023922,
    "numItems": 70,
    "numAudioFiles": 80
  },
  "total": {
    "totalSize": 56332491340,
    "numItems": 291,
    "numAudioFiles": 2666
  }
}
```

This will likely change as the server stats page gets realized.
