### PR TITLE
Merge files without encoding

### DIFF
--- a/client/strings/en-us.json
+++ b/client/strings/en-us.json
@@ -432,6 +432,7 @@
   "LabelMaxEpisodesToKeepHelp": "Value of 0 sets no max limit. After a new episode is auto-downloaded this will delete the oldest episode if you have more than X episodes. This will only delete 1 episode per new download.",
   "LabelMediaPlayer": "Media Player",
   "LabelMediaType": "Media Type",
+  "LabelMergeWithoutEncoding": "Merge files without encoding",
   "LabelMetaTag": "Meta Tag",
   "LabelMetaTags": "Meta Tags",
   "LabelMetadataOrderOfPrecedenceDescription": "Higher priority metadata sources will override lower priority metadata sources",


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

<!-- Please provide a brief summary of what your PR attempts to achieve. -->
If more than one file is available, show an extra option that automatically sets encoding to copy in order to merge the files, thereby disabling advanced options.

Also fixes a visual bug where, if a user cancels a task, the advanced button still appears clickable even though it is not actually clickable. 

---
This time I applied Prettier, but it did nothing (because it's a Vue file). When I used the official formatter for Vue.js, it even changed lines I did not edit. So, I guess this is not desired. If I should apply a formatter, please leave a comment. 

## Which issue is fixed?

#4169

## In-depth Description

N/A. See above

## How have you tested this?

Merging a few books

## Screenshots

![grafik](https://github.com/user-attachments/assets/dac9a84f-178d-4533-92aa-1ef0ed26e165)

