### PR TITLE
Fix server crash when a user requests the RSS feed of an empty collection

### DIFF
--- a/server/models/FeedEpisode.js
+++ b/server/models/FeedEpisode.js
@@ -215,9 +215,10 @@ class FeedEpisode extends Model {
    * @returns {Promise<FeedEpisode[]>}
    */
   static async createFromBooks(books, feed, slug, transaction) {
-    const earliestLibraryItemCreatedAt = books.reduce((earliest, book) => {
+    // This is never null unless the books array is empty, as this method is not invoked when no books. Reduce needs an initial item
+    const earliestLibraryItemCreatedAt = books.length > 0 ? books.reduce((earliest, book) => {
       return book.libraryItem.createdAt < earliest.libraryItem.createdAt ? book : earliest
-    }).libraryItem.createdAt
+    }).libraryItem.createdAt : null
 
     const feedEpisodeObjs = []
     let numExisting = 0

--- a/server/models/FeedEpisode.js
+++ b/server/models/FeedEpisode.js
@@ -216,9 +216,12 @@ class FeedEpisode extends Model {
    */
   static async createFromBooks(books, feed, slug, transaction) {
     // This is never null unless the books array is empty, as this method is not invoked when no books. Reduce needs an initial item
-    const earliestLibraryItemCreatedAt = books.length > 0 ? books.reduce((earliest, book) => {
-      return book.libraryItem.createdAt < earliest.libraryItem.createdAt ? book : earliest
-    }).libraryItem.createdAt : null
+    const earliestLibraryItemCreatedAt =
+      books.length > 0
+        ? books.reduce((earliest, book) => {
+            return book.libraryItem.createdAt < earliest.libraryItem.createdAt ? book : earliest
+          }).libraryItem.createdAt
+        : null
 
     const feedEpisodeObjs = []
     let numExisting = 0


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

Fix server crash when a user requests the RSS feed of an empty collection. 

## Which issue is fixed?

None/Discord

## In-depth Description
`reduce` needs at least one item in the array (or intial value). If the array is empty, it throws an error. Since the for loop is not called when `books` is empty, we can just make this null. The RSS feed will still be opened then. An alternative would be to close the RSS feed for any empty collection. I can imagine that this would not be a good solution, because if people remove an item and then instantly add one, it would be unexpected to have a closed RSS feed. 

## How have you tested this?

<!-- Please describe in detail with reproducible steps how you tested your changes. -->

## Screenshots

<!-- If your PR includes any changes to the web client, please include screenshots or a short video from before and after your changes. -->
