### PR TITLE
Fix server crash when updating excluded prefixes #4221

### DIFF
--- a/server/controllers/MiscController.js
+++ b/server/controllers/MiscController.js
@@ -222,7 +222,7 @@ class MiscController {
 
     // Update nameIgnorePrefix column on series
     const allSeries = await Database.seriesModel.findAll({
-      attributes: ['id', 'name', 'nameIgnorePrefix']
+      attributes: ['id', 'name', 'nameIgnorePrefix', 'libraryId']
     })
     const bulkUpdateSeries = []
     allSeries.forEach((series) => {
@@ -230,6 +230,8 @@ class MiscController {
       if (nameIgnorePrefix !== series.nameIgnorePrefix) {
         bulkUpdateSeries.push({
           id: series.id,
+          name: series.name,
+          libraryId: series.libraryId,
           nameIgnorePrefix
         })
       }


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

When updating the "Ignore prefixes when sorting" list in server settings, the server will crash when a series name has to be updated.

## Which issue is fixed?

Fixes #4221

## In-depth Description

When using the [updateOnDuplicate](https://sequelize.org/api/v7/interfaces/_sequelize_core.index.bulkcreateoptions#updateonduplicate) option to bulk update we have to pass in all key/values that have a unique constraint.

The unique constraint for `libraryId` and `name` was added in [v2.14.0](https://github.com/advplyr/audiobookshelf/releases/tag/v2.14.0) from PR #3417 

That was 8 months ago so I suspect this bug was actually introduced when updating to sqlite `v3.44.2` from `v3.41.1` for [v2.20.0](https://github.com/advplyr/audiobookshelf/releases/tag/v2.20.0). I wasn't able to find anything specific to this in the sqlite changelogs though.

