### PR TITLE
Improves Year in Review display logic

### DIFF
--- a/client/components/stats/YearInReviewBanner.vue
+++ b/client/components/stats/YearInReviewBanner.vue
@@ -164,14 +164,15 @@ export default {
   beforeMount() {
     this.yearInReviewYear = new Date().getFullYear()
 
-    // When not December show previous year
-    if (new Date().getMonth() < 11) {
+    this.availableYears = this.getAvailableYears()
+    const availableYearValues = this.availableYears.map((y) => y.value)
+
+    // When not December show previous year if data is available
+    if (new Date().getMonth() < 11 && availableYearValues.includes(this.yearInReviewYear - 1)) {
       this.yearInReviewYear--
     }
   },
   mounted() {
-    this.availableYears = this.getAvailableYears()
-
     if (typeof navigator.share !== 'undefined' && navigator.share) {
       this.showShareButton = true
     } else {


### PR DESCRIPTION
## Brief summary

<!-- Please provide a brief summary of what your PR attempts to achieve. -->
Allows users created in the same year to see some stats on the "Year in Review" page.

## Which issue is fixed?

<!-- Which issue number does this PR fix? Ex: "Fixes #1234" -->
I could not find an issue regarding this. I could have maybe created one but just decided to fix it. 

## In-depth Description

<!--
Describe your solution in more depth.
How does it work? Why is this the best solution?
Does it solve a problem that affects multiple users or is this an edge case for your setup?
-->
I just started using AudiobookShelf and noticed that the stats page defaults to the previous year. It looks like there is some logic to allow users to select the current year but that is only if they have more than 1 available year.

I opted to keep that logic and only show previous year stats if those stats exist. In December users with more than one year will start to see their current year recap. New users will see previous year by default as soon as they pass into a new year after their account was created. 

## How have you tested this?

<!-- Please describe in detail with reproducible steps how you tested your changes. -->
I loaded the page for "Your Stats" with my user createdAt timestamp set with a year in 2025 to verify that it would default to the current year .  (First image)

I then modified the DB for my user to have a createdAt timestamp from 2024. My stats page then pulled up with the default of the previous year with a drop down to select 2025. (Second image).

## Screenshots
![image](https://github.com/user-attachments/assets/624b7673-6e26-4517-aa8f-6bb15cb9543f)

![image](https://github.com/user-attachments/assets/1d0bf5fa-e779-4578-9466-7d0ae1abba9e)


<!-- If your PR includes any changes to the web client, please include screenshots or a short video from before and after your changes. -->

Before the issue was fixed, this was the behavior for users that did not have any data from last year (they were created in the current year):
![image](https://github.com/user-attachments/assets/76bcba17-20bf-46d4-beb5-8f19f93e20de)

