### PR TITLE
Fix player track tooltip overflowing on share player

### DIFF
--- a/client/components/player/PlayerTrackBar.vue
+++ b/client/components/player/PlayerTrackBar.vue
@@ -74,6 +74,9 @@ export default {
     currentChapterStart() {
       if (!this.currentChapter) return 0
       return this.currentChapter.start
+    },
+    isMobile() {
+      return this.$store.state.globals.isMobile
     }
   },
   methods: {
@@ -145,6 +148,9 @@ export default {
       })
     },
     mousemoveTrack(e) {
+      if (this.isMobile) {
+        return
+      }
       const offsetX = e.offsetX
 
       const baseTime = this.useChapterTrack ? this.currentChapterStart : 0
@@ -198,6 +204,7 @@ export default {
     setTrackWidth() {
       if (this.$refs.track) {
         this.trackWidth = this.$refs.track.clientWidth
+        this.trackOffsetLeft = this.$refs.track.getBoundingClientRect().left
       } else {
         console.error('Track not loaded', this.$refs)
       }

--- a/client/pages/share/_slug.vue
+++ b/client/pages/share/_slug.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="w-full h-dvh max-h-dvh overflow-hidden" :style="{ backgroundColor: coverRgb }">
+  <div class="w-full max-w-full h-dvh max-h-dvh overflow-hidden" :style="{ backgroundColor: coverRgb }">
     <div class="w-screen h-screen absolute inset-0 pointer-events-none" style="background: linear-gradient(180deg, rgba(0, 0, 0, 0) 0%, rgba(38, 38, 38, 1) 80%)"></div>
     <div class="absolute inset-0 w-screen h-dvh flex items-center justify-center z-10">
       <div class="w-full p-2 sm:p-4 md:p-8">
@@ -335,8 +335,11 @@ export default {
       }
     },
     resize() {
-      this.windowWidth = window.innerWidth
-      this.windowHeight = window.innerHeight
+      setTimeout(() => {
+        this.windowWidth = window.innerWidth
+        this.windowHeight = window.innerHeight
+        this.$store.commit('globals/updateWindowSize', { width: window.innerWidth, height: window.innerHeight })
+      }, 100)
     },
     playerError(error) {
       console.error('Player error', error)


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

Share audio player track bar tooltip overflows the page causing a horizontal scroll bar.

## Which issue is fixed?

No issue

## In-depth Description

The track bar padding in the share player is larger than the regular player so the tooltip calculation was off.

This also disables the tooltip on mobile for both the share player and regular player. The tooltip should only be shown when hovering with the mouse.

## How have you tested this?

<!-- Please describe in detail with reproducible steps how you tested your changes. -->

## Screenshots

Overflow
![image](https://github.com/user-attachments/assets/8361491d-2c17-4dda-a30c-dd1915c6bb9d)

Fixed
![image](https://github.com/user-attachments/assets/e03c3e3c-b8df-42b1-8abc-3e96b68078ce)

