### PR TITLE
Update watcher to re-scan library items for non-media file only updates

### DIFF
--- a/server/models/LibraryItem.js
+++ b/server/models/LibraryItem.js
@@ -246,7 +246,6 @@ class LibraryItem extends Model {
       include
     })
     if (!libraryItem) {
-      Logger.error(`[LibraryItem] Library item not found`)
       return null
     }
 

--- a/server/scanner/LibraryScanner.js
+++ b/server/scanner/LibraryScanner.js
@@ -407,7 +407,7 @@ class LibraryScanner {
       const folder = library.libraryFolders[0]
 
       const filePathItems = folderGroups[folderId].fileUpdates.map((fileUpdate) => fileUtils.getFilePathItemFromFileUpdate(fileUpdate))
-      const fileUpdateGroup = scanUtils.groupFileItemsIntoLibraryItemDirs(library.mediaType, filePathItems, !!library.settings?.audiobooksOnly)
+      const fileUpdateGroup = scanUtils.groupFileItemsIntoLibraryItemDirs(library.mediaType, filePathItems, !!library.settings?.audiobooksOnly, true)
 
       if (!Object.keys(fileUpdateGroup).length) {
         Logger.info(`[LibraryScanner] No important changes to scan for in folder "${folderId}"`)


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

This update improves the watcher to support, for example, adding a cover image to an existing library item folder and triggering a re-scan for that item.

## Which issue is fixed?

Fixes #4245

## In-depth Description

When the watcher detects files added/removed in a library folder it groups the files into potential library item paths. That grouping process distinguishes between media files and other files for the purpose of ignoring folders that only have non-media files. Other files are included in the grouping only if there is a media file in that potential library item group.

Note: These groups are "potential" library items because at that stage it is not confirmed whether those paths are existing library items.

This update changes that to allow for "scannable" non-media files (e.g. txt, nfo, png, json) to be included in the library item grouping even if it is the only file.

## How have you tested this?

1. Create a new folder with a single audio file and ensure it is added to the library with no cover image.
2. Add a cover image to the folder
3. Observe the watcher is triggered and the cover image is applied to the library item
