### PR TITLE
Audiobook tools enhancements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ sw.*
 .DS_STORE
 .idea/*
 tailwind.compiled.css
+tailwind.config.js

--- a/client/components/ui/ToggleBtns.vue
+++ b/client/components/ui/ToggleBtns.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="inline-flex toggle-btn-wrapper shadow-md">
-    <button v-for="item in items" :key="item.value" type="button" class="toggle-btn outline-hidden relative border border-gray-600 px-4 py-1" :class="{ selected: item.value === value }" @click.stop="clickBtn(item.value)">
+    <button v-for="item in items" :key="item.value" type="button" :disabled="disabled" class="toggle-btn outline-hidden relative border border-gray-600 px-4 py-1" :class="{ selected: item.value === value }" @click.stop="clickBtn(item.value)">
       {{ item.text }}
     </button>
   </div>
@@ -9,13 +9,17 @@
 <script>
 export default {
   props: {
-    value: String,
+    value: [String, Number],
     /**
      * [{ "text", "", "value": "" }]
      */
     items: {
       type: Array,
       default: Object
+    },
+    disabled: {
+      type: Boolean,
+      default: false
     }
   },
   data() {
@@ -76,10 +80,19 @@ export default {
 .toggle-btn.selected {
   color: white;
 }
+.toggle-btn.selected:disabled {
+  color: white;
+}
 .toggle-btn.selected::before {
   background-color: rgba(255, 255, 255, 0.1);
 }
+button.toggle-btn.selected:disabled::before {
+  background-color: rgba(255, 255, 255, 0.05);
+}
 button.toggle-btn:disabled::before {
   background-color: rgba(0, 0, 0, 0.2);
+}
+button.toggle-btn:disabled {
+  cursor: not-allowed;
 }
 </style>

--- a/client/components/widgets/EncoderOptionsCard.vue
+++ b/client/components/widgets/EncoderOptionsCard.vue
@@ -1,0 +1,211 @@
+<template>
+  <div class="w-full py-2">
+    <div class="flex -mb-px">
+      <button type="button" :disabled="disabled" class="w-1/2 h-8 rounded-tl-md relative border border-black-200 flex items-center justify-center disabled:cursor-not-allowed" :class="!showAdvancedView ? 'text-white bg-bg hover:bg-bg/60 border-b-bg' : 'text-gray-400 hover:text-gray-300 bg-primary/70 hover:bg-primary/60'" @click="showAdvancedView = false">
+        <p class="text-sm">{{ $strings.HeaderPresets }}</p>
+      </button>
+      <button type="button" :disabled="disabled" class="w-1/2 h-8 rounded-tr-md relative border border-black-200 flex items-center justify-center -ml-px disabled:cursor-not-allowed" :class="showAdvancedView ? 'text-white bg-bg hover:bg-bg/60 border-b-bg' : 'text-gray-400 hover:text-gray-300 bg-primary/70 hover:bg-primary/60'" @click="showAdvancedView = true">
+        <p class="text-sm">{{ $strings.HeaderAdvanced }}</p>
+      </button>
+    </div>
+    <div class="p-4 md:p-8 border border-black-200 rounded-b-md mr-px bg-bg">
+      <template v-if="!showAdvancedView">
+        <div class="flex flex-wrap gap-4 sm:gap-8 justify-start sm:justify-center">
+          <div class="flex flex-col items-start gap-2">
+            <p class="text-sm w-40">{{ $strings.LabelCodec }}</p>
+            <ui-toggle-btns v-model="selectedCodec" :items="codecItems" :disabled="disabled" />
+            <p class="text-xs text-gray-300">
+              {{ $strings.LabelCurrently }} <span class="text-white">{{ currentCodec }}</span> <span v-if="isCodecsDifferent" class="text-warning">(mixed)</span>
+            </p>
+          </div>
+          <div class="flex flex-col items-start gap-2">
+            <p class="text-sm w-40">{{ $strings.LabelBitrate }}</p>
+            <ui-toggle-btns v-model="selectedBitrate" :items="bitrateItems" :disabled="disabled" />
+            <p class="text-xs text-gray-300">
+              {{ $strings.LabelCurrently }} <span class="text-white">{{ currentBitrate }} KB/s</span>
+            </p>
+          </div>
+          <div class="flex flex-col items-start gap-2">
+            <p class="text-sm w-40">{{ $strings.LabelChannels }}</p>
+            <ui-toggle-btns v-model="selectedChannels" :items="channelsItems" :disabled="disabled" />
+            <p class="text-xs text-gray-300">
+              {{ $strings.LabelCurrently }} <span class="text-white">{{ currentChannels }} ({{ currentChanelLayout }})</span>
+            </p>
+          </div>
+        </div>
+      </template>
+      <template v-else>
+        <div>
+          <div class="flex flex-wrap gap-4 sm:gap-8 justify-start sm:justify-center mb-4">
+            <div class="w-40">
+              <ui-text-input-with-label v-model="customCodec" :label="$strings.LabelAudioCodec" :disabled="disabled" @input="customCodecChanged" />
+            </div>
+            <div class="w-40">
+              <ui-text-input-with-label v-model="customBitrate" :label="$strings.LabelAudioBitrate" :disabled="disabled" @input="customBitrateChanged" />
+            </div>
+            <div class="w-40">
+              <ui-text-input-with-label v-model="customChannels" :label="$strings.LabelAudioChannels" type="number" :disabled="disabled" @input="customChannelsChanged" />
+            </div>
+          </div>
+          <p class="text-xs sm:text-sm text-warning sm:text-center">{{ $strings.LabelEncodingWarningAdvancedSettings }}</p>
+        </div>
+      </template>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    audioTracks: {
+      type: Array,
+      default: () => []
+    },
+    disabled: {
+      type: Boolean,
+      default: false
+    }
+  },
+  data() {
+    return {
+      showAdvancedView: false,
+      selectedCodec: 'aac',
+      selectedBitrate: '128k',
+      selectedChannels: 2,
+      customCodec: 'aac',
+      customBitrate: '128k',
+      customChannels: 2,
+      currentCodec: '',
+      currentBitrate: '',
+      currentChannels: '',
+      currentChanelLayout: '',
+      isCodecsDifferent: false
+    }
+  },
+  computed: {
+    codecItems() {
+      return [
+        {
+          text: 'Copy',
+          value: 'copy'
+        },
+        {
+          text: 'AAC',
+          value: 'aac'
+        },
+        {
+          text: 'OPUS',
+          value: 'opus'
+        }
+      ]
+    },
+    bitrateItems() {
+      return [
+        {
+          text: '32k',
+          value: '32k'
+        },
+        {
+          text: '64k',
+          value: '64k'
+        },
+        {
+          text: '128k',
+          value: '128k'
+        },
+        {
+          text: '192k',
+          value: '192k'
+        }
+      ]
+    },
+    channelsItems() {
+      return [
+        {
+          text: '1 (mono)',
+          value: 1
+        },
+        {
+          text: '2 (stereo)',
+          value: 2
+        }
+      ]
+    }
+  },
+  methods: {
+    customBitrateChanged(val) {
+      localStorage.setItem('embedMetadataBitrate', val)
+    },
+    customChannelsChanged(val) {
+      localStorage.setItem('embedMetadataChannels', val)
+    },
+    customCodecChanged(val) {
+      localStorage.setItem('embedMetadataCodec', val)
+    },
+    getEncodingOptions() {
+      return {
+        codec: this.selectedCodec || 'aac',
+        bitrate: this.selectedBitrate || '128k',
+        channels: this.selectedChannels || 2
+      }
+    },
+    setPreset() {
+      // If already AAC and not mixed, set copy
+      if (this.currentCodec === 'aac' && !this.isCodecsDifferent) {
+        this.selectedCodec = 'copy'
+      } else {
+        this.selectedCodec = 'aac'
+      }
+
+      if (!this.currentBitrate) {
+        this.selectedBitrate = '128k'
+      } else {
+        // Find closest bitrate rounding up
+        const bitratesToMatch = [32, 64, 128, 192]
+        const closestBitrate = bitratesToMatch.find((bitrate) => bitrate >= this.currentBitrate)
+        this.selectedBitrate = closestBitrate + 'k'
+      }
+
+      if (!this.currentChannels || isNaN(this.currentChannels)) {
+        this.selectedChannels = 2
+      } else {
+        // Either 1 or 2
+        this.selectedChannels = Math.max(Math.min(Number(this.currentChannels), 2), 1)
+      }
+    },
+    setCurrentValues() {
+      if (this.audioTracks.length === 0) return
+
+      this.currentChannels = this.audioTracks[0].channels
+      this.currentChanelLayout = this.audioTracks[0].channelLayout
+      this.currentCodec = this.audioTracks[0].codec
+
+      let totalBitrate = 0
+      for (const track of this.audioTracks) {
+        const trackBitrate = !isNaN(track.bitRate) ? track.bitRate : 0
+        totalBitrate += trackBitrate
+
+        if (track.channels > this.currentChannels) this.currentChannels = track.channels
+        if (track.codec !== this.currentCodec) {
+          console.warn('Audio track codec is different from the first track', track.codec)
+          this.isCodecsDifferent = true
+        }
+      }
+
+      this.currentBitrate = Math.round(totalBitrate / this.audioTracks.length / 1000)
+    },
+    init() {
+      this.customBitrate = localStorage.getItem('embedMetadataBitrate') || '128k'
+      this.customChannels = localStorage.getItem('embedMetadataChannels') || 2
+      this.customCodec = localStorage.getItem('embedMetadataCodec') || 'aac'
+
+      this.setCurrentValues()
+
+      this.setPreset()
+    }
+  },
+  mounted() {
+    this.init()
+  }
+}
+</script>

--- a/client/pages/audiobook/_id/manage.vue
+++ b/client/pages/audiobook/_id/manage.vue
@@ -18,8 +18,8 @@
       <div class="w-full max-w-2xl"></div>
     </div>
 
-    <div class="flex justify-center flex-wrap">
-      <div class="w-full max-w-2xl border border-white/10 bg-bg mx-2">
+    <div class="flex justify-center flex-wrap lg:flex-nowrap gap-4">
+      <div class="w-full max-w-2xl border border-white/10 bg-bg">
         <div class="flex py-2 px-4">
           <div class="w-1/3 text-xs font-semibold uppercase text-gray-200">{{ $strings.LabelMetaTag }}</div>
           <div class="w-2/3 text-xs font-semibold uppercase text-gray-200">{{ $strings.LabelValue }}</div>
@@ -35,7 +35,7 @@
           </template>
         </div>
       </div>
-      <div class="w-full max-w-2xl border border-white/10 bg-bg mx-2">
+      <div class="w-full max-w-2xl border border-white/10 bg-bg">
         <div class="flex py-2 px-4 bg-primary/25">
           <div class="grow text-xs font-semibold uppercase text-gray-200">{{ $strings.LabelChapterTitle }}</div>
           <div class="w-24 text-xs font-semibold uppercase text-gray-200">{{ $strings.LabelStart }}</div>
@@ -146,19 +146,29 @@
         <div class="flex py-2 px-4 bg-primary/25">
           <div class="w-10 text-xs font-semibold text-gray-200">#</div>
           <div class="grow text-xs font-semibold uppercase text-gray-200">{{ $strings.LabelFilename }}</div>
+          <div class="w-20 text-xs font-semibold uppercase text-gray-200 hidden lg:block">{{ $strings.LabelChannels }}</div>
+          <div class="w-16 text-xs font-semibold uppercase text-gray-200 hidden md:block">{{ $strings.LabelCodec }}</div>
+          <div class="w-16 text-xs font-semibold uppercase text-gray-200 hidden md:block">{{ $strings.LabelBitrate }}</div>
           <div class="w-16 text-xs font-semibold uppercase text-gray-200">{{ $strings.LabelSize }}</div>
           <div class="w-24"></div>
         </div>
         <template v-for="file in audioFiles">
-          <div :key="file.index" class="flex py-2 px-4 text-sm" :class="file.index % 2 === 0 ? 'bg-primary/25' : ''">
-            <div class="w-10">{{ file.index }}</div>
+          <div :key="file.index" class="flex py-2 px-4 text-xs sm:text-sm" :class="file.index % 2 === 0 ? 'bg-primary/25' : ''">
+            <div class="w-10 min-w-10">{{ file.index }}</div>
             <div class="grow">
               {{ file.metadata.filename }}
             </div>
-            <div class="w-16 font-mono text-gray-200">
+            <div class="w-20 min-w-20 text-gray-200 hidden lg:block">{{ file.channels || 'unknown' }} ({{ file.channelLayout || 'unknown' }})</div>
+            <div class="w-16 min-w-16 text-gray-200 hidden md:block">
+              {{ file.codec || 'unknown' }}
+            </div>
+            <div class="w-16 min-w-16 text-gray-200 hidden md:block">
+              {{ $bytesPretty(file.bitRate || 0, 0) }}
+            </div>
+            <div class="w-16 min-w-16 text-gray-200">
               {{ $bytesPretty(file.metadata.size) }}
             </div>
-            <div class="w-24">
+            <div class="w-24 min-w-24">
               <div class="flex justify-center">
                 <span v-if="audioFilesFinished[file.ino]" class="material-symbols text-xl text-success leading-none">check_circle</span>
                 <div v-else-if="audioFilesEncoding[file.ino]">

--- a/client/strings/en-us.json
+++ b/client/strings/en-us.json
@@ -177,6 +177,7 @@
   "HeaderPlaylist": "Playlist",
   "HeaderPlaylistItems": "Playlist Items",
   "HeaderPodcastsToAdd": "Podcasts to Add",
+  "HeaderPresets": "Presets",
   "HeaderPreviewCover": "Preview Cover",
   "HeaderRSSFeedGeneral": "RSS Details",
   "HeaderRSSFeedIsOpen": "RSS Feed is Open",

--- a/server/controllers/LibraryItemController.js
+++ b/server/controllers/LibraryItemController.js
@@ -834,8 +834,8 @@ class LibraryItemController {
     }
 
     if (req.libraryItem.isMissing || !req.libraryItem.isBook || !req.libraryItem.media.includedAudioFiles.length) {
-      Logger.error(`[LibraryItemController] Invalid library item`)
-      return res.sendStatus(500)
+      Logger.error(`[LibraryItemController] getMetadataObject: Invalid library item "${req.libraryItem.media.title}"`)
+      return res.sendStatus(400)
     }
 
     res.json(this.audioMetadataManager.getMetadataObjectForApi(req.libraryItem))

--- a/server/controllers/ToolsController.js
+++ b/server/controllers/ToolsController.js
@@ -48,6 +48,7 @@ class ToolsController {
     }
 
     const options = req.query || {}
+    Logger.info(`[ToolsController] encodeM4b: Starting audiobook merge for "${req.libraryItem.media.title}" with options: ${JSON.stringify(options)}`)
     this.abMergeManager.startAudiobookMerge(req.user.id, req.libraryItem, options)
 
     res.sendStatus(200)


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

This improves the m4b encoder tool default values and the UI/UX on the audiobook tools page.

## Which issue is fixed?

Fixes #4169 and fixes #1257

## In-depth Description

M4b tool improvements:

- Default to `copy` codec if all audio file codecs are AAC
- Select closest bit rate to one of 32k, 64k, 128k, 192k (instead of always 128k potentially increasing the size)
- Use mono channel if all audio files are mono (instead of always stereo)
- UI improvements
    - Better breakpoints for mobile and small screens
    - Use card with tabs for presets/advanced
    - Show bit rate, channels, and codec in the audio tracks table
    - Show the current bit rate, channels and codec below the presets (bit rate is averaged & channels use the max)

The preset defaults are best explained in the screenshots below.

## Screenshots

When audio tracks are mp3's the default is to encode to AAC
![image](https://github.com/user-attachments/assets/6cb63e95-1c12-44c5-b556-42383b826d12)

When not all audio track codecs are the same the default is to encode to AAC.
Note the bit rate rounds up to the nearest, this can be improved to add more presets
![image](https://github.com/user-attachments/assets/a6a4e90d-5649-4e5c-8c5a-ffe1789c7d17)

When all audio tracks are AAC then default to copy (don't re-encode).
![image](https://github.com/user-attachments/assets/7264a4d9-8063-4be6-b086-023ee35b731f)

When all audio tracks are mono channel then default to mono (if mixed the default is stereo)
![image](https://github.com/user-attachments/assets/7e6f4429-2fd5-4c2e-8410-678c636b016c)

