### PR TITLE
Add new api endpoint for direct playing audio files using session id

### DIFF
--- a/client/players/AudioTrack.js
+++ b/client/players/AudioTrack.js
@@ -1,5 +1,5 @@
 export default class AudioTrack {
-  constructor(track, sessionId, routerBasePath) {
+  constructor(track, sessionId, userToken, routerBasePath) {
     this.index = track.index || 0
     this.startOffset = track.startOffset || 0 // Total time of all previous tracks
     this.duration = track.duration || 0
@@ -10,7 +10,11 @@ export default class AudioTrack {
 
     this.sessionId = sessionId
     this.routerBasePath = routerBasePath || ''
-    this.sessionTrackUrl = `/public/session/${sessionId}/track/${this.index}`
+    if (this.contentUrl?.startsWith('/hls')) {
+      this.sessionTrackUrl = `${this.contentUrl}?token=${userToken}`
+    } else {
+      this.sessionTrackUrl = `/public/session/${sessionId}/track/${this.index}`
+    }
   }
 
   /**

--- a/client/players/AudioTrack.js
+++ b/client/players/AudioTrack.js
@@ -1,5 +1,5 @@
 export default class AudioTrack {
-  constructor(track, userToken, routerBasePath) {
+  constructor(track, sessionId, routerBasePath) {
     this.index = track.index || 0
     this.startOffset = track.startOffset || 0 // Total time of all previous tracks
     this.duration = track.duration || 0
@@ -8,28 +8,25 @@ export default class AudioTrack {
     this.mimeType = track.mimeType
     this.metadata = track.metadata || {}
 
-    this.userToken = userToken
+    this.sessionId = sessionId
     this.routerBasePath = routerBasePath || ''
+    this.sessionTrackUrl = `/public/session/${sessionId}/track/${this.index}`
   }
 
   /**
    * Used for CastPlayer
    */
   get fullContentUrl() {
-    if (!this.contentUrl || this.contentUrl.startsWith('http')) return this.contentUrl
-
     if (process.env.NODE_ENV === 'development') {
-      return `${process.env.serverUrl}${this.contentUrl}?token=${this.userToken}`
+      return `${process.env.serverUrl}${this.sessionTrackUrl}`
     }
-    return `${window.location.origin}${this.routerBasePath}${this.contentUrl}?token=${this.userToken}`
+    return `${window.location.origin}${this.routerBasePath}${this.sessionTrackUrl}`
   }
 
   /**
    * Used for LocalPlayer
    */
   get relativeContentUrl() {
-    if (!this.contentUrl || this.contentUrl.startsWith('http')) return this.contentUrl
-
-    return `${this.routerBasePath}${this.contentUrl}?token=${this.userToken}`
+    return `${this.routerBasePath}${this.sessionTrackUrl}`
   }
 }

--- a/client/players/PlayerHandler.js
+++ b/client/players/PlayerHandler.js
@@ -37,9 +37,6 @@ export default class PlayerHandler {
   get isPlayingLocalItem() {
     return this.libraryItem && this.player instanceof LocalAudioPlayer
   }
-  get userToken() {
-    return this.ctx.$store.getters['user/getToken']
-  }
   get playerPlaying() {
     return this.playerState === 'PLAYING'
   }
@@ -226,7 +223,7 @@ export default class PlayerHandler {
 
     console.log('[PlayerHandler] Preparing Session', session)
 
-    var audioTracks = session.audioTracks.map((at) => new AudioTrack(at, this.userToken, this.ctx.$config.routerBasePath))
+    var audioTracks = session.audioTracks.map((at) => new AudioTrack(at, session.id, this.ctx.$config.routerBasePath))
 
     this.ctx.playerLoading = true
     this.isHlsTranscode = true

--- a/client/players/PlayerHandler.js
+++ b/client/players/PlayerHandler.js
@@ -37,6 +37,9 @@ export default class PlayerHandler {
   get isPlayingLocalItem() {
     return this.libraryItem && this.player instanceof LocalAudioPlayer
   }
+  get userToken() {
+    return this.ctx.$store.getters['user/getToken']
+  }
   get playerPlaying() {
     return this.playerState === 'PLAYING'
   }
@@ -223,7 +226,7 @@ export default class PlayerHandler {
 
     console.log('[PlayerHandler] Preparing Session', session)
 
-    var audioTracks = session.audioTracks.map((at) => new AudioTrack(at, session.id, this.ctx.$config.routerBasePath))
+    var audioTracks = session.audioTracks.map((at) => new AudioTrack(at, session.id, this.userToken, this.ctx.$config.routerBasePath))
 
     this.ctx.playerLoading = true
     this.isHlsTranscode = true

--- a/server/managers/PlaybackSessionManager.js
+++ b/server/managers/PlaybackSessionManager.js
@@ -26,6 +26,12 @@ class PlaybackSessionManager {
     this.sessions = []
   }
 
+  /**
+   * Get open session by id
+   *
+   * @param {string} sessionId
+   * @returns {PlaybackSession}
+   */
   getSession(sessionId) {
     return this.sessions.find((s) => s.id === sessionId)
   }

--- a/server/routers/PublicRouter.js
+++ b/server/routers/PublicRouter.js
@@ -1,5 +1,6 @@
 const express = require('express')
 const ShareController = require('../controllers/ShareController')
+const SessionController = require('../controllers/SessionController')
 
 class PublicRouter {
   constructor(playbackSessionManager) {
@@ -17,6 +18,7 @@ class PublicRouter {
     this.router.get('/share/:slug/cover', ShareController.getMediaItemShareCoverImage.bind(this))
     this.router.get('/share/:slug/download', ShareController.downloadMediaItemShare.bind(this))
     this.router.patch('/share/:slug/progress', ShareController.updateMediaItemShareProgress.bind(this))
+    this.router.get('/session/:id/track/:index', SessionController.getTrack.bind(this))
   }
 }
 module.exports = PublicRouter


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

When direct playing, Audio track URLs include the user token. As outlined in #4259 this is a security concern when casting because you aren't making the request to your server.

This PR creates a separate API endpoint at `/public/session/:sessionId/track/:index` that is only accessible while the session is open. This endpoint debug logs the session id, username and track index.

## Which issue is fixed?

Fixes #4259

## In-depth Description

Open playback sessions are automatically closed after 36 hours and a new session id (UUIDv4) is created each time a session is opened.

There is a remaining update to be made for HLS streams because they still include the user token in the URL.
This PR fully addresses #4259 because HLS isn't supported for casting, only direct play.
