### PR TITLE
Update HLS stream endpoints to not include user token

### DIFF
--- a/client/players/AudioTrack.js
+++ b/client/players/AudioTrack.js
@@ -1,5 +1,5 @@
 export default class AudioTrack {
-  constructor(track, sessionId, userToken, routerBasePath) {
+  constructor(track, sessionId, routerBasePath) {
     this.index = track.index || 0
     this.startOffset = track.startOffset || 0 // Total time of all previous tracks
     this.duration = track.duration || 0
@@ -11,7 +11,7 @@ export default class AudioTrack {
     this.sessionId = sessionId
     this.routerBasePath = routerBasePath || ''
     if (this.contentUrl?.startsWith('/hls')) {
-      this.sessionTrackUrl = `${this.contentUrl}?token=${userToken}`
+      this.sessionTrackUrl = this.contentUrl
     } else {
       this.sessionTrackUrl = `/public/session/${sessionId}/track/${this.index}`
     }

--- a/client/players/PlayerHandler.js
+++ b/client/players/PlayerHandler.js
@@ -37,9 +37,6 @@ export default class PlayerHandler {
   get isPlayingLocalItem() {
     return this.libraryItem && this.player instanceof LocalAudioPlayer
   }
-  get userToken() {
-    return this.ctx.$store.getters['user/getToken']
-  }
   get playerPlaying() {
     return this.playerState === 'PLAYING'
   }
@@ -226,7 +223,7 @@ export default class PlayerHandler {
 
     console.log('[PlayerHandler] Preparing Session', session)
 
-    var audioTracks = session.audioTracks.map((at) => new AudioTrack(at, session.id, this.userToken, this.ctx.$config.routerBasePath))
+    var audioTracks = session.audioTracks.map((at) => new AudioTrack(at, session.id, this.ctx.$config.routerBasePath))
 
     this.ctx.playerLoading = true
     this.isHlsTranscode = true

--- a/server/Server.js
+++ b/server/Server.js
@@ -313,7 +313,7 @@ class Server {
     router.use(express.json({ limit: '5mb' }))
 
     router.use('/api', this.auth.ifAuthNeeded(this.authMiddleware.bind(this)), this.apiRouter.router)
-    router.use('/hls', this.authMiddleware.bind(this), this.hlsRouter.router)
+    router.use('/hls', this.hlsRouter.router)
     router.use('/public', this.publicRouter.router)
 
     // Static path to generated nuxt


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

This is a follow up on #4263 to update HLS streams to not use the user token in the URL.

## Which issue is fixed?

No issue but related to #4259

## In-depth Description

The HLS stream URLs are structured `/hls/:sessionId/:file` and is only accessible while the session is open. Sessions are automatically closed after 36 hours.
Both direct streaming and HLS transcoding streams will use the session id in the URL.
