### PR TITLE
Update episode secondary sort to pubDate and episode #4262

### DIFF
--- a/client/components/tables/podcast/LazyEpisodesTable.vue
+++ b/client/components/tables/podcast/LazyEpisodesTable.vue
@@ -1,4 +1,3 @@
-
 <template>
   <div id="lazy-episodes-table" class="w-full py-6">
     <div class="flex flex-wrap flex-col md:flex-row md:items-center mb-4">
@@ -176,6 +175,13 @@ export default {
           return episodeProgress && !episodeProgress.isFinished
         })
         .sort((a, b) => {
+          // Swap values if sort descending
+          if (this.sortDesc) {
+            const temp = a
+            a = b
+            b = temp
+          }
+
           let aValue
           let bValue
 
@@ -194,10 +200,23 @@ export default {
             if (!bValue) bValue = Number.MAX_VALUE
           }
 
-          if (this.sortDesc) {
-            return String(bValue).localeCompare(String(aValue), undefined, { numeric: true, sensitivity: 'base' })
+          const primaryCompare = String(aValue).localeCompare(String(bValue), undefined, { numeric: true, sensitivity: 'base' })
+          if (primaryCompare !== 0 || this.sortKey === 'publishedAt') return primaryCompare
+
+          // When sorting by season, secondary sort is by episode number
+          if (this.sortKey === 'season') {
+            const aEpisode = a.episode || ''
+            const bEpisode = b.episode || ''
+
+            const secondaryCompare = String(aEpisode).localeCompare(String(bEpisode), undefined, { numeric: true, sensitivity: 'base' })
+            if (secondaryCompare !== 0) return secondaryCompare
           }
-          return String(aValue).localeCompare(String(bValue), undefined, { numeric: true, sensitivity: 'base' })
+
+          // Final sort by publishedAt
+          let aPubDate = a.publishedAt || Number.MAX_VALUE
+          let bPubDate = b.publishedAt || Number.MAX_VALUE
+
+          return String(aPubDate).localeCompare(String(bPubDate), undefined, { numeric: true, sensitivity: 'base' })
         })
     },
     episodesList() {


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

This implements a secondary sort on the podcast episodes table.

## Which issue is fixed?

Fixes #4262

## In-depth Description

When sorting by `Title`, `Episode` or `Filename` the secondary sort is `Pub Date`.

When sorting by `Season` the secondary sort is `Episode` with a tertiary sort of `Pub Date`.

## How have you tested this?

Downloaded episodes from https://www.spreaker.com/show/4488937/episodes/feed and manually added seasons and episodes

## Screenshots

Example sorting by season descending

Season -> Episode -> Pub Date descending

![image](https://github.com/user-attachments/assets/9b718338-f687-4bdb-a985-cf5faf03ca9b)
