### PR TITLE
Add missing series sequence to “Get a Library's Series” response

### DIFF
--- a/server/utils/queries/seriesFilters.js
+++ b/server/utils/queries/seriesFilters.js
@@ -205,6 +205,7 @@ module.exports = {
         delete bs.book.libraryItem
         libraryItem.media = bs.book
         const oldLibraryItem = libraryItem.toOldJSONMinified()
+        oldLibraryItem.sequence = bs.sequence
         return oldLibraryItem
       })
       allOldSeries.push(oldSeries)


### PR DESCRIPTION
## Brief summary

Adds a `sequence` value to each library item returned from the /libraries/:id/series endpoint.

## Which issue is fixed?

N/A

## In-depth Description

Not sure if this is intended or if the docs are just out of date, but the docs do indicate that books within a Book Series object should have a sequence tacked on. This PR adds that.

## How have you tested this?

Fairly minimal, but the change is low impact.

## Screenshots

N/A