### PR TITLE
Add support for searching podcast episode titles #3301

### DIFF
--- a/client/components/app/BookShelfCategorized.vue
+++ b/client/components/app/BookShelfCategorized.vue
@@ -217,6 +217,16 @@ export default {
         })
       }
 
+      if (this.results.episodes?.length) {
+        shelves.push({
+          id: 'episodes',
+          label: 'Episodes',
+          labelStringKey: 'LabelEpisodes',
+          type: 'episode',
+          entities: this.results.episodes.map((res) => res.libraryItem)
+        })
+      }
+
       if (this.results.series?.length) {
         shelves.push({
           id: 'series',

--- a/client/components/cards/EpisodeSearchCard.vue
+++ b/client/components/cards/EpisodeSearchCard.vue
@@ -1,0 +1,60 @@
+<template>
+  <div class="flex items-center h-full px-1 overflow-hidden">
+    <covers-book-cover :library-item="libraryItem" :width="coverWidth" :book-cover-aspect-ratio="bookCoverAspectRatio" />
+    <div class="grow px-2 episodeSearchCardContent">
+      <p class="truncate text-sm">{{ episodeTitle }}</p>
+      <p class="text-xs text-gray-200 truncate">{{ podcastTitle }}</p>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    libraryItem: {
+      type: Object,
+      default: () => {}
+    },
+    episode: {
+      type: Object,
+      default: () => {}
+    }
+  },
+  data() {
+    return {}
+  },
+  computed: {
+    bookCoverAspectRatio() {
+      return this.$store.getters['libraries/getBookCoverAspectRatio']
+    },
+    coverWidth() {
+      if (this.bookCoverAspectRatio === 1) return 50 * 1.2
+      return 50
+    },
+    media() {
+      return this.libraryItem?.media || {}
+    },
+    mediaMetadata() {
+      return this.media.metadata || {}
+    },
+    episodeTitle() {
+      return this.episode.title || 'No Title'
+    },
+    podcastTitle() {
+      return this.mediaMetadata.title || 'No Title'
+    }
+  },
+  methods: {},
+  mounted() {}
+}
+</script>
+
+<style>
+.episodeSearchCardContent {
+  width: calc(100% - 80px);
+  height: 75px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+</style>

--- a/client/components/controls/GlobalSearch.vue
+++ b/client/components/controls/GlobalSearch.vue
@@ -39,6 +39,15 @@
             </li>
           </template>
 
+          <p v-if="episodeResults.length" class="uppercase text-xs text-gray-400 my-1 px-1 font-semibold">{{ $strings.LabelEpisodes }}</p>
+          <template v-for="item in episodeResults">
+            <li :key="item.libraryItem.recentEpisode.id" class="text-gray-50 select-none relative cursor-pointer hover:bg-black-400 py-1" role="option" @click="clickOption">
+              <nuxt-link :to="`/item/${item.libraryItem.id}`">
+                <cards-episode-search-card :episode="item.libraryItem.recentEpisode" :library-item="item.libraryItem" />
+              </nuxt-link>
+            </li>
+          </template>
+
           <p v-if="authorResults.length" class="uppercase text-xs text-gray-400 mb-1 mt-3 px-1 font-semibold">{{ $strings.LabelAuthors }}</p>
           <template v-for="item in authorResults">
             <li :key="item.id" class="text-gray-50 select-none relative cursor-pointer hover:bg-black-400 py-1" role="option" @click="clickOption">
@@ -100,6 +109,7 @@ export default {
       isFetching: false,
       search: null,
       podcastResults: [],
+      episodeResults: [],
       bookResults: [],
       authorResults: [],
       seriesResults: [],
@@ -132,6 +142,7 @@ export default {
       this.search = null
       this.lastSearch = null
       this.podcastResults = []
+      this.episodeResults = []
       this.bookResults = []
       this.authorResults = []
       this.seriesResults = []
@@ -175,6 +186,7 @@ export default {
       if (!this.isFetching) return
 
       this.podcastResults = searchResults.podcast || []
+      this.episodeResults = searchResults.episodes || []
       this.bookResults = searchResults.book || []
       this.authorResults = searchResults.authors || []
       this.seriesResults = searchResults.series || []

--- a/client/components/controls/GlobalSearch.vue
+++ b/client/components/controls/GlobalSearch.vue
@@ -125,7 +125,7 @@ export default {
       return this.$store.state.libraries.currentLibraryId
     },
     totalResults() {
-      return this.bookResults.length + this.seriesResults.length + this.authorResults.length + this.tagResults.length + this.genreResults.length + this.podcastResults.length + this.narratorResults.length
+      return this.bookResults.length + this.seriesResults.length + this.authorResults.length + this.tagResults.length + this.genreResults.length + this.podcastResults.length + this.narratorResults.length + this.episodeResults.length
     }
   },
   methods: {

--- a/client/pages/library/_library/search.vue
+++ b/client/pages/library/_library/search.vue
@@ -22,6 +22,7 @@ export default {
     })
     results = {
       podcasts: results?.podcast || [],
+      episodes: results?.episodes || [],
       books: results?.book || [],
       authors: results?.authors || [],
       series: results?.series || [],
@@ -61,6 +62,7 @@ export default {
       })
       this.results = {
         podcasts: results?.podcast || [],
+        episodes: results?.episodes || [],
         books: results?.book || [],
         authors: results?.authors || [],
         series: results?.series || [],

--- a/server/utils/queries/libraryItemsPodcastFilters.js
+++ b/server/utils/queries/libraryItemsPodcastFilters.js
@@ -411,6 +411,43 @@ module.exports = {
       })
     }
 
+    // Search podcast episode title
+    const podcastEpisodes = await Database.podcastEpisodeModel.findAll({
+      where: [
+        Sequelize.literal(textSearchQuery.matchExpression('podcastEpisode.title')),
+        {
+          '$podcast.libraryItem.libraryId$': library.id
+        }
+      ],
+      replacements: userPermissionPodcastWhere.replacements,
+      include: [
+        {
+          model: Database.podcastModel,
+          where: [...userPermissionPodcastWhere.podcastWhere],
+          include: [
+            {
+              model: Database.libraryItemModel
+            }
+          ]
+        }
+      ],
+      distinct: true,
+      offset,
+      limit
+    })
+    const episodeMatches = []
+    for (const episode of podcastEpisodes) {
+      const libraryItem = episode.podcast.libraryItem
+      libraryItem.media = episode.podcast
+      libraryItem.media.podcastEpisodes = []
+      const oldPodcastEpisodeJson = episode.toOldJSONExpanded(libraryItem.id)
+      const libraryItemJson = libraryItem.toOldJSONExpanded()
+      libraryItemJson.recentEpisode = oldPodcastEpisodeJson
+      episodeMatches.push({
+        libraryItem: libraryItemJson
+      })
+    }
+
     const matchJsonValue = textSearchQuery.matchExpression('json_each.value')
 
     // Search tags
@@ -450,7 +487,8 @@ module.exports = {
     return {
       podcast: itemMatches,
       tags: tagMatches,
-      genres: genreMatches
+      genres: genreMatches,
+      episodes: episodeMatches
     }
   },
 


### PR DESCRIPTION
## Brief summary

Add support for global search in podcast libraries to search episode titles.

## Which issue is fixed?

Fixes #3301

## In-depth Description

In order to re-use the cards used for episodes on the home page, the returned `episodes` from the search endpoint is an array of library items with a `recentEpisode` attached.

Episode cards shown on the search page are the same as those shown on the home page. Episodes shown in the global search dropdown show the podcast cover, episode title and podcast title.

To stay consistent with the podcast/book search, I didn't add the description to the query. It may not be worthwhile to add the description until the search is improved to better sort best match.

## How have you tested this?

This is also tested with users that don't have access to the podcast.

## Screenshots

![image](https://github.com/user-attachments/assets/fe36348c-19c8-44ee-a5d5-01dbce6042e2)

![image](https://github.com/user-attachments/assets/a4edda8b-57c9-4911-8797-1594ec273113)

