### PR TITLE
Feat/more notifications

### DIFF
--- a/server/SocketAuthority.js
+++ b/server/SocketAuthority.js
@@ -17,7 +17,7 @@ class SocketAuthority {
   constructor() {
     this.Server = null
     this.socketIoServers = []
-    this.emittedNotifications = new Set(['item_added', 'item_updated', 'user_online', 'task_started', 'task_finished']);
+    this.emittedNotifications = new Set(['item_added', 'item_updated', 'user_online', 'task_started', 'task_finished'])
 
     /** @type {Object.<string, SocketClient>} */
     this.clients = {}
@@ -95,7 +95,7 @@ class SocketAuthority {
 
   // Emits event to all admin user clients
   adminEmitter(evt, data) {
-    void this._fireNotification(evt, data);
+    void this._fireNotification(evt, data)
     for (const socketId in this.clients) {
       if (this.clients[socketId].user?.isAdminOrUp) {
         this.clients[socketId].socket.emit(evt, data)

--- a/server/SocketAuthority.js
+++ b/server/SocketAuthority.js
@@ -17,7 +17,7 @@ class SocketAuthority {
   constructor() {
     this.Server = null
     this.socketIoServers = []
-    this.emittedNotifications = new Set(['item_added', 'item_updated', 'user_online']);
+    this.emittedNotifications = new Set(['item_added', 'item_updated', 'user_online', 'task_started', 'task_finished']);
 
     /** @type {Object.<string, SocketClient>} */
     this.clients = {}
@@ -69,7 +69,7 @@ class SocketAuthority {
    * @param {Function} [filter] optional filter function to only send event to specific users
    */
   emitter(evt, data, filter = null) {
-    void this._fireNotification(evt, data)
+    void this._fireNotification(evt, flattenAny(data))
     for (const socketId in this.clients) {
       if (this.clients[socketId].user) {
         if (filter && !filter(this.clients[socketId].user)) continue
@@ -81,7 +81,7 @@ class SocketAuthority {
 
   // Emits event to all clients for a specific user
   clientEmitter(userId, evt, data) {
-    void this._fireNotification(evt, data)
+    void this._fireNotification(evt, flattenAny(data))
     const clients = this.getClientsForUser(userId)
     if (!clients.length) {
       return Logger.debug(`[SocketAuthority] clientEmitter - no clients found for user ${userId}`)
@@ -95,7 +95,7 @@ class SocketAuthority {
 
   // Emits event to all admin user clients
   adminEmitter(evt, data) {
-    void this._fireNotification(evt, data);
+    void this._fireNotification(evt, flattenAny(data));
     for (const socketId in this.clients) {
       if (this.clients[socketId].user?.isAdminOrUp) {
         this.clients[socketId].socket.emit(evt, data)

--- a/server/SocketAuthority.js
+++ b/server/SocketAuthority.js
@@ -33,7 +33,7 @@ class SocketAuthority {
     if (!this.emittedNotifications.has(event)) return
     Logger.debug(`[SocketAuthority] fireNotification - ${event}`)
 
-    NotificationManager.fireNotificationFromSocket(event, payload)
+    NotificationManager.fireNotificationFromSocket(event, flattenAny(payload))
   }
 
   /**
@@ -69,7 +69,7 @@ class SocketAuthority {
    * @param {Function} [filter] optional filter function to only send event to specific users
    */
   emitter(evt, data, filter = null) {
-    void this._fireNotification(evt, flattenAny(data))
+    void this._fireNotification(evt, data)
     for (const socketId in this.clients) {
       if (this.clients[socketId].user) {
         if (filter && !filter(this.clients[socketId].user)) continue
@@ -81,7 +81,7 @@ class SocketAuthority {
 
   // Emits event to all clients for a specific user
   clientEmitter(userId, evt, data) {
-    void this._fireNotification(evt, flattenAny(data))
+    void this._fireNotification(evt, data)
     const clients = this.getClientsForUser(userId)
     if (!clients.length) {
       return Logger.debug(`[SocketAuthority] clientEmitter - no clients found for user ${userId}`)
@@ -95,7 +95,7 @@ class SocketAuthority {
 
   // Emits event to all admin user clients
   adminEmitter(evt, data) {
-    void this._fireNotification(evt, flattenAny(data));
+    void this._fireNotification(evt, data);
     for (const socketId in this.clients) {
       if (this.clients[socketId].user?.isAdminOrUp) {
         this.clients[socketId].socket.emit(evt, data)
@@ -111,7 +111,7 @@ class SocketAuthority {
    * @param {import('./models/LibraryItem')} libraryItem
    */
   libraryItemEmitter(evt, libraryItem) {
-    void this._fireNotification(evt, flattenAny(libraryItem.toOldJSONMinified()))
+    void this._fireNotification(evt, libraryItem.toOldJSONMinified())
     for (const socketId in this.clients) {
       if (this.clients[socketId].user?.checkCanAccessLibraryItem(libraryItem)) {
         this.clients[socketId].socket.emit(evt, libraryItem.toOldJSONExpanded())

--- a/server/managers/NotificationManager.js
+++ b/server/managers/NotificationManager.js
@@ -90,14 +90,6 @@ class NotificationManager {
     this.triggerNotification('onBackupFailed', eventData)
   }
 
-  /**
-   * @param
-   */
-  async onItemUpdated(libraryItem) {
-    console.log('onItemUpdated', libraryItem)
-    this.triggerNotification('onItemUpdated', libraryItem)
-  }
-
   onTest() {
     this.triggerNotification('onTest')
   }
@@ -132,7 +124,8 @@ class NotificationManager {
     }
 
     await Database.updateSetting(Database.notificationSettings)
-    //SocketAuthority.emitter('notifications_updated', Database.notificationSettings.toJSON())
+    // Currently results in circular dependency TODO: Fix this
+    // SocketAuthority.emitter('notifications_updated', Database.notificationSettings.toJSON())
 
     this.notificationFinished()
   }
@@ -199,6 +192,9 @@ class NotificationManager {
     const eventNameModified = eventName.replace(/_([a-z])/g, (_, c) => c.toUpperCase());
     const eventKey = `on${eventNameModified.charAt(0).toUpperCase()}${eventNameModified.slice(1)}`;
 
+    console.log(eventData)
+    console.log(Object.keys(eventData))
+
     if (!Database.notificationSettings.getHasActiveNotificationsForEvent(eventKey)) {
       // No logging to prevent console spam
       Logger.debug(`[NotificationManager] fireSocketNotification: No active notifications`)
@@ -207,11 +203,7 @@ class NotificationManager {
 
     Logger.debug(`[NotificationManager] fireNotificationFromSocket: ${eventKey} event fired`)
 
-    switch (eventKey) {
-      case 'onItemUpdated':
-        void this.onItemUpdated(eventData)
-        break
-    }
+    void this.triggerNotification(eventKey, eventData)
   }
 }
 module.exports = new NotificationManager()

--- a/server/managers/NotificationManager.js
+++ b/server/managers/NotificationManager.js
@@ -189,11 +189,8 @@ class NotificationManager {
   fireNotificationFromSocket(eventName, eventData) {
     if (!Database.notificationSettings.isUseable) return
 
-    const eventNameModified = eventName.replace(/_([a-z])/g, (_, c) => c.toUpperCase());
-    const eventKey = `on${eventNameModified.charAt(0).toUpperCase()}${eventNameModified.slice(1)}`;
-
-    console.log(eventData)
-    console.log(Object.keys(eventData))
+    const eventNameModified = eventName.replace(/_([a-z])/g, (_, c) => c.toUpperCase())
+    const eventKey = `on${eventNameModified.charAt(0).toUpperCase()}${eventNameModified.slice(1)}`
 
     if (!Database.notificationSettings.getHasActiveNotificationsForEvent(eventKey)) {
       // No logging to prevent console spam

--- a/server/objects/Notification.js
+++ b/server/objects/Notification.js
@@ -102,7 +102,7 @@ class Notification {
   }
 
   replaceVariablesInTemplate(templateText, data) {
-    const ptrn = /{{ ?([a-zA-Z]+) ?}}/mg
+    const ptrn = /{{ ?([a-zA-Z.]+) ?}}/mg
 
     var match
     var updatedTemplate = templateText

--- a/server/utils/notifications.js
+++ b/server/utils/notifications.js
@@ -4,29 +4,48 @@ const LibraryItem = require('../models/LibraryItem')
 const libraryItemVariables = [
   'id',
   'ino',
+  'oldLibraryItemId',
+  'libraryId',
+  'folderId',
   'path',
   'relPath',
-  'mediaId',
-  'mediaType',
   'isFile',
+  'mtimeMs',
+  'ctimeMs',
+  'birthtimeMs',
+  'addedAt',
+  'updatedAt',
   'isMissing',
   'isInvalid',
-  'mtime',
-  'ctime',
-  'birthtime',
-  'size',
-  'lastScan',
-  'lastScanVersion',
-  'libraryFiles',
-  'extraData',
-  'title',
-  'titleIgnorePrefix',
-  'authorNamesFirstLast',
-  'authorNamesLastFirst',
-  'createdAt',
-  'updatedAt',
-  'libraryId',
-  'libraryFolderId',
+  'mediaType',
+  'media.id',
+  'media.metadata.title',
+  'media.metadata.titleIgnorePrefix',
+  'media.metadata.subtitle',
+  'media.metadata.authorName',
+  'media.metadata.authorNameLF',
+  'media.metadata.narratorName',
+  'media.metadata.seriesName',
+  'media.metadata.genres',
+  'media.metadata.publishedYear',
+  'media.metadata.publishedDate',
+  'media.metadata.publisher',
+  'media.metadata.description',
+  'media.metadata.isbn',
+  'media.metadata.asin',
+  'media.metadata.language',
+  'media.metadata.explicit',
+  'media.metadata.abridged',
+  'media.coverPath',
+  'media.tags',
+  'media.numTracks',
+  'media.numAudioFiles',
+  'media.numChapters',
+  'media.duration',
+  'media.size',
+  'media.ebookFormat',
+  'numFiles',
+  'size'
 ]
 
 const libraryItemTestData = {
@@ -120,16 +139,39 @@ module.exports.notificationData = {
     // Sockets - Silently crying because not using typescript
 
     {
+      name: 'onItemAdded',
+      requiresLibrary: true,
+      description: 'Triggered when an item is added',
+      descriptionKey: 'NotificationOnItemAddedDescription',
+      variables: libraryItemVariables,
+      defaults: {
+        title: 'Item Added: {{media.metadata.title}}',
+        body: 'Item {{media.metadata.title}} has been added.\n\nPath: {{path}}\nSize: {{size}} bytes\nLibrary ID: {{libraryId}}'
+      },
+      testData: libraryItemTestData
+    },
+    {
       name: 'onItemUpdated',
       requiresLibrary: true,
       description: 'Triggered when an item is updated',
       descriptionKey: 'NotificationOnItemUpdatedDescription',
       variables: libraryItemVariables,
       defaults: {
-        title: 'Item Updated: {{title}}',
-        body: 'Item {{title}} has been updated.\n\nPath: {{path}}\nSize: {{size}} bytes\nLast Scan: {{lastScan}}\nLibrary ID: {{libraryId}}\nLibrary Folder ID: {{libraryFolderId}}'
+        title: 'Item Updated: {{media.metadata.title}}',
+        body: 'Item {{media.metadata.title}} has been added.\n\nPath: {{path}}\nSize: {{size}} bytes\nLibrary ID: {{libraryId}}'
       },
       testData: libraryItemTestData
+    },
+    {
+      name: 'onUserOnline',
+      requiresLibrary: false,
+      description: 'Triggered when a user comes online',
+      descriptionKey: 'NotificationOnUserOnlineDescription',
+      variables: [ 'id', 'username', 'type', 'session', 'lastSeen', 'createdAt'],
+      defaults: {
+        title: 'User Online: {{username}}',
+        body: 'User {{username}} (ID: {{id}}) is now online.'
+      },
     },
 
     // Test

--- a/server/utils/notifications.js
+++ b/server/utils/notifications.js
@@ -173,6 +173,57 @@ module.exports.notificationData = {
         body: 'User {{username}} (ID: {{id}}) is now online.'
       },
     },
+    {
+      name: 'onTaskStarted',
+      requiresLibrary: false,
+      description: 'Triggered when a task starts',
+      descriptionKey: 'NotificationOnTaskStartedDescription',
+      variables: [
+        'id',             'action',
+        'data.libraryId', 'data.libraryName',
+        'title',          'titleKey',
+        'titleSubs',      'description',
+        'descriptionKey', 'descriptionSubs',
+        'error',          'errorKey',
+        'errorSubs',      'showSuccess',
+        'isFailed',       'isFinished',
+        'startedAt',      'finishedAt'
+      ],
+      defaults: {
+        title: 'Task Started: {{title}}',
+        body: 'Task {{title}} has started.\n\nAction: {{action}}\nLibrary ID: {{data.libraryId}}\nLibrary Name: {{data.libraryName}}'
+      },
+    },
+    {
+      name: 'onTaskFinished',
+      requiresLibrary: false,
+      description: 'Triggered when a task finishes',
+      descriptionKey: 'NotificationOnTaskFinishesDescription',
+      variables: [
+        'id',
+        'action',
+        'data.libraryId',
+        'data.libraryName',
+        'title',
+        'titleKey',
+        'titleSubs',
+        'description',
+        'descriptionKey',
+        'descriptionSubs',
+        'error',
+        'errorKey',
+        'errorSubs',
+        'showSuccess',
+        'isFailed',
+        'isFinished',
+        'startedAt',
+        'finishedAt'
+      ],
+      defaults: {
+        title: 'Task Started: {{title}}',
+        body: 'Task {{title}} has started.\n\nAction: {{action}}\nLibrary ID: {{data.libraryId}}\nLibrary Name: {{data.libraryName}}'
+      },
+    },
 
     // Test
     {

--- a/server/utils/notifications.js
+++ b/server/utils/notifications.js
@@ -72,9 +72,7 @@ const libraryItemTestData = {
   updatedAt: new Date('2024-05-15T18:30:36.940Z'),
   libraryId: 'fedcba98-7654-3210-fedc-ba9876543210',
   libraryFolderId: '11223344-5566-7788-99aa-bbccddeeff00'
-};
-
-
+}
 
 module.exports.notificationData = {
   events: [
@@ -167,62 +165,33 @@ module.exports.notificationData = {
       requiresLibrary: false,
       description: 'Triggered when a user comes online',
       descriptionKey: 'NotificationOnUserOnlineDescription',
-      variables: [ 'id', 'username', 'type', 'session', 'lastSeen', 'createdAt'],
+      variables: ['id', 'username', 'type', 'session', 'lastSeen', 'createdAt'],
       defaults: {
         title: 'User Online: {{username}}',
         body: 'User {{username}} (ID: {{id}}) is now online.'
-      },
+      }
     },
     {
       name: 'onTaskStarted',
       requiresLibrary: false,
       description: 'Triggered when a task starts',
       descriptionKey: 'NotificationOnTaskStartedDescription',
-      variables: [
-        'id',             'action',
-        'data.libraryId', 'data.libraryName',
-        'title',          'titleKey',
-        'titleSubs',      'description',
-        'descriptionKey', 'descriptionSubs',
-        'error',          'errorKey',
-        'errorSubs',      'showSuccess',
-        'isFailed',       'isFinished',
-        'startedAt',      'finishedAt'
-      ],
+      variables: ['id', 'action', 'data.libraryId', 'data.libraryName', 'title', 'titleKey', 'titleSubs', 'description', 'descriptionKey', 'descriptionSubs', 'error', 'errorKey', 'errorSubs', 'showSuccess', 'isFailed', 'isFinished', 'startedAt', 'finishedAt'],
       defaults: {
         title: 'Task Started: {{title}}',
         body: 'Task {{title}} has started.\n\nAction: {{action}}\nLibrary ID: {{data.libraryId}}\nLibrary Name: {{data.libraryName}}'
-      },
+      }
     },
     {
       name: 'onTaskFinished',
       requiresLibrary: false,
       description: 'Triggered when a task finishes',
       descriptionKey: 'NotificationOnTaskFinishesDescription',
-      variables: [
-        'id',
-        'action',
-        'data.libraryId',
-        'data.libraryName',
-        'title',
-        'titleKey',
-        'titleSubs',
-        'description',
-        'descriptionKey',
-        'descriptionSubs',
-        'error',
-        'errorKey',
-        'errorSubs',
-        'showSuccess',
-        'isFailed',
-        'isFinished',
-        'startedAt',
-        'finishedAt'
-      ],
+      variables: ['id', 'action', 'data.libraryId', 'data.libraryName', 'title', 'titleKey', 'titleSubs', 'description', 'descriptionKey', 'descriptionSubs', 'error', 'errorKey', 'errorSubs', 'showSuccess', 'isFailed', 'isFinished', 'startedAt', 'finishedAt'],
       defaults: {
         title: 'Task Started: {{title}}',
         body: 'Task {{title}} has started.\n\nAction: {{action}}\nLibrary ID: {{data.libraryId}}\nLibrary Name: {{data.libraryName}}'
-      },
+      }
     },
 
     // Test

--- a/server/utils/notifications.js
+++ b/server/utils/notifications.js
@@ -1,4 +1,61 @@
 const { version } = require('../../package.json')
+const LibraryItem = require('../models/LibraryItem')
+
+const libraryItemVariables = [
+  'id',
+  'ino',
+  'path',
+  'relPath',
+  'mediaId',
+  'mediaType',
+  'isFile',
+  'isMissing',
+  'isInvalid',
+  'mtime',
+  'ctime',
+  'birthtime',
+  'size',
+  'lastScan',
+  'lastScanVersion',
+  'libraryFiles',
+  'extraData',
+  'title',
+  'titleIgnorePrefix',
+  'authorNamesFirstLast',
+  'authorNamesLastFirst',
+  'createdAt',
+  'updatedAt',
+  'libraryId',
+  'libraryFolderId',
+]
+
+const libraryItemTestData = {
+  id: '123e4567-e89b-12d3-a456-426614174000',
+  ino: '9876543',
+  path: '/audiobooks/Frank Herbert/Dune',
+  relPath: 'Frank Herbert/Dune',
+  mediaId: 'abcdef12-3456-7890-abcd-ef1234567890',
+  mediaType: 'book',
+  isFile: true,
+  isMissing: false,
+  isInvalid: false,
+  mtime: new Date('2023-11-15T10:20:30.400Z'),
+  ctime: new Date('2023-11-15T10:20:30.400Z'),
+  birthtime: new Date('2023-11-15T10:20:30.390Z'),
+  size: 987654321,
+  lastScan: new Date('2024-01-10T08:15:00.000Z'),
+  lastScanVersion: '3.2.0',
+  title: 'Dune',
+  titleIgnorePrefix: 'Dune',
+  authorNamesFirstLast: 'Frank Herbert',
+  authorNamesLastFirst: 'Herbert, Frank',
+  createdAt: new Date('2023-11-15T10:21:00.000Z'),
+  updatedAt: new Date('2024-05-15T18:30:36.940Z'),
+  libraryId: 'fedcba98-7654-3210-fedc-ba9876543210',
+  libraryFolderId: '11223344-5566-7788-99aa-bbccddeeff00'
+};
+
+
 
 module.exports.notificationData = {
   events: [
@@ -60,6 +117,22 @@ module.exports.notificationData = {
         errorMsg: 'Example error message'
       }
     },
+    // Sockets - Silently crying because not using typescript
+
+    {
+      name: 'onItemUpdated',
+      requiresLibrary: true,
+      description: 'Triggered when an item is updated',
+      descriptionKey: 'NotificationOnItemUpdatedDescription',
+      variables: libraryItemVariables,
+      defaults: {
+        title: 'Item Updated: {{title}}',
+        body: 'Item {{title}} has been updated.\n\nPath: {{path}}\nSize: {{size}} bytes\nLast Scan: {{lastScan}}\nLibrary ID: {{libraryId}}\nLibrary Folder ID: {{libraryFolderId}}'
+      },
+      testData: libraryItemTestData
+    },
+
+    // Test
     {
       name: 'onTest',
       requiresLibrary: false,

--- a/server/utils/objectUtils.js
+++ b/server/utils/objectUtils.js
@@ -1,0 +1,26 @@
+function flattenAny(obj, prefix = '', result = {}) {
+  const entries =
+    obj instanceof Map
+      ? obj.entries()
+      : Object.entries(obj);
+
+  for (const [key, value] of entries) {
+    const newKey = prefix ? `${prefix}.${key}` : `${key}`;
+    if (
+      value instanceof Map ||
+      (typeof value === 'object' &&
+        value !== null &&
+        !Array.isArray(value))
+    ) {
+      flattenAny(value, newKey, result);
+    } else {
+      result[newKey] = value;
+    }
+  }
+  return result;
+}
+
+
+module.exports = {
+  flattenAny
+}


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature.
See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for more details.

If you do not follow this template, the PR may be closed without review.

Please make sure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

This adds more notification events like `user_online` or `task_finished`.

## Which issue is fixed?

/

## In-depth Description

This uses a set number of emitter events sent by the existing websocket and sends a notification if it is enabled for this notification type. This is currently a DRAFT because examples are missing, and I have not filled all of them yet. Some things also need to be tested and added:
- `user_offline`
- `series_added`
- `series_updated`
- `author_added`
- `author_updated`
- `user_session_closed`
- `user_updated`
- `share_open`
- `share_closed`

It is easy to add, but very time-consuming.

## How have you tested this?

Local server with apprise

## Screenshots

<!-- If your PR includes any changes to the web client, please include screenshots or a short video from before and after your changes. -->