### PR TITLE
Update max allowed json request size #4250

### DIFF
--- a/client/components/modals/podcast/EpisodeFeed.vue
+++ b/client/components/modals/podcast/EpisodeFeed.vue
@@ -244,8 +244,8 @@ export default {
       const sizeInMb = payloadSize / 1024 / 1024
       const sizeInMbPretty = sizeInMb.toFixed(2) + 'MB'
       console.log('Request size', sizeInMb)
-      if (sizeInMb > 4.99) {
-        return this.$toast.error(`Request is too large (${sizeInMbPretty}) should be < 5Mb`)
+      if (sizeInMb > 9.99) {
+        return this.$toast.error(`Request is too large (${sizeInMbPretty}) should be < 10Mb`)
       }
 
       this.processing = true

--- a/server/Server.js
+++ b/server/Server.js
@@ -310,7 +310,7 @@ class Server {
       })
     )
     router.use(express.urlencoded({ extended: true, limit: '5mb' }))
-    router.use(express.json({ limit: '5mb' }))
+    router.use(express.json({ limit: '10mb' }))
 
     router.use('/api', this.auth.ifAuthNeeded(this.authMiddleware.bind(this)), this.apiRouter.router)
     router.use('/hls', this.hlsRouter.router)


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

This increases the limit of [express.json](https://expressjs.com/en/api.html#express.json) from 5mb to 10mb.
And updates the check when downloading episodes that prevents too large of requests.

## Which issue is fixed?

Fixes #4250

## In-depth Description

Increasing the limit allows for downloading more episodes in a single request. This is the only place in the app where JSON requests of that size are sent. We could break up the request into multiple and keep them under 5mb, but having a 10mb limit seemed reasonable.

## How have you tested this?

Example RSS feed: https://feeds.simplecast.com/54nAGcIl

When adding this podcast and selecting all episodes to download at once, the request size is around 9.7mb. This is now supported.