### PR TITLE
Audible confidence score

### DIFF
--- a/client/components/cards/BookMatchCard.vue
+++ b/client/components/cards/BookMatchCard.vue
@@ -16,6 +16,7 @@
         <p v-if="book.author" class="text-gray-300 text-xs md:text-sm">{{ $getString('LabelByAuthor', [book.author]) }}</p>
         <p v-if="book.narrator" class="text-gray-400 text-xs">{{ $strings.LabelNarrators }}: {{ book.narrator }}</p>
         <p v-if="book.duration" class="text-gray-400 text-xs">{{ $strings.LabelDuration }}: {{ $elapsedPrettyExtended(bookDuration, false) }} {{ bookDurationComparison }}</p>
+        <p v-if="book.matchConfidence" class="text-gray-400 text-xs">{{ $strings.LabelMatchConfidence }}: {{ book.matchConfidence.toFixed(3) }}</p>
         <div v-if="book.series?.length" class="flex py-1 -mx-1">
           <div v-for="(series, index) in book.series" :key="index" class="bg-white/10 rounded-full px-1 py-0.5 mx-1">
             <p class="leading-3 text-xs text-gray-400">

--- a/client/strings/en-us.json
+++ b/client/strings/en-us.json
@@ -425,6 +425,7 @@
   "LabelLogLevelWarn": "Warn",
   "LabelLookForNewEpisodesAfterDate": "Look for new episodes after this date",
   "LabelLowestPriority": "Lowest Priority",
+  "LabelMatchConfidence": "Match Confidence",
   "LabelMatchExistingUsersBy": "Match existing users by",
   "LabelMatchExistingUsersByDescription": "Used for connecting existing users. Once connected, users will be matched by a unique id from your SSO provider",
   "LabelMaxEpisodesToDownload": "Max # of episodes to download. Use 0 for unlimited.",

--- a/server/utils/index.js
+++ b/server/utils/index.js
@@ -34,6 +34,14 @@ const levenshteinDistance = (str1, str2, caseSensitive = false) => {
 }
 module.exports.levenshteinDistance = levenshteinDistance
 
+const levenshteinSimilarity = (str1, str2, caseSensitive = false) => {
+  const distance = levenshteinDistance(str1, str2, caseSensitive)
+  const maxLength = Math.max(str1.length, str2.length)
+  if (maxLength === 0) return 1
+  return 1 - distance / maxLength
+}
+module.exports.levenshteinSimilarity = levenshteinSimilarity
+
 module.exports.isObject = (val) => {
   return val !== null && typeof val === 'object'
 }


### PR DESCRIPTION
## Brief summary

This adds a match confidence score when matching audiobooks using Audible.

## Which issue is fixed?

Fixes #4277 (eventually).

## In-depth Description

When returning match results from Audible, a new match confidence score is calculated based on book duration, title and subtitle, and author.

Details: 
- The duration, title, and author scores are linearly combined
  - duration is weighted 0.7, title 0.2 and author 0.1
- Duration is given 1.0 score if diff is less than 1 minute, then the score drops linearly to 0.6 if diff is 5 mintues, and then more sharply to 0.0 when diff is 10 minutes.
- The title score is calculated by comparing the book title to the actual title query. 
  - If the title query seens to have a subtitle,  we compare it to the book title + subtitle
- The author score is calculated by comparing the book author to the actual author query
  - If the book author has multiple authors (separated by commas), we try to compare against each of the authors and take the maximum score
- if the title is an ASIN, a 1.0 match confidence score is returned (the duration, title, and author scores are not calculated).

The combined score is written to the result record.

I added some code to display it in BookMatchCard.vue (only so you can easily check it - this is not necessarily how we want to display it)

At this point, I haven't yet added the quick match dialog support. This is just for you to comment on the confidence score.

## How have you tested this?

Added extensice unit testing, and ran through many books to see what kinds of score we get. It looks like a threshold of 0.85-0.9 could be used for bypass the intended quick match dialog.