### PR TITLE
Fix MediaProgress not using the lastUpdate time sent for local progress syncs

### DIFF
--- a/server/models/MediaProgress.js
+++ b/server/models/MediaProgress.js
@@ -246,9 +246,10 @@ class MediaProgress extends Model {
     // For local sync
     if (progressPayload.lastUpdate) {
       this.updatedAt = progressPayload.lastUpdate
+      this.changed('updatedAt', true)
     }
 
-    return this.save()
+    return this.save({ silent: !!progressPayload.lastUpdate })
   }
 }
 


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

When a local playback session is synced the `lastUpdate` time should be set on the media progress object to the same value. This way when comparing the timestamps for syncing they will be the same on the mobile device and server.

This was not working properly because Sequelize requires passing `silent: true` when saving.

## Which issue is fixed?

I don't believe this is the underlying issue with progress syncing on mobile but if these timestamps are lined up it will be easier to debug.

I found this while testing local progress syncing: https://github.com/advplyr/audiobookshelf-app/issues/1510#issuecomment-2902671752

Note the log:
![image](https://github.com/user-attachments/assets/f29c3750-e55c-42b0-9b51-f02489ef2133)

The progress was more recent on the server because of the bug being fixed in this PR. But you can see this was no problem because the `currentTime` on the server and the device were the same.

## In-depth Description

For local playback sessions the `lastUpdate` time of the local playback session, local media progress and server media progress should all be the same after syncing.

## How have you tested this?

I ran the same exact test outlined here https://github.com/advplyr/audiobookshelf-app/issues/1510#issuecomment-2902671752 and noted that the updated timestamps all line up now.
