### PR TITLE
Update rich text editor to prevent pasting in images from the browser

### DIFF
--- a/client/components/ui/VueTrix.vue
+++ b/client/components/ui/VueTrix.vue
@@ -31,7 +31,7 @@
         </div>
       </div>
     </trix-toolbar>
-    <trix-editor :toolbar="toolbarId" :contenteditable="!disabledEditor" :class="['trix-content']" ref="trix" :input="computedId" :placeholder="placeholder" @trix-change="handleContentChange" @trix-initialize="handleInitialize" @trix-focus="processTrixFocus" @trix-blur="processTrixBlur" />
+    <trix-editor :toolbar="toolbarId" :contenteditable="!disabledEditor" :class="['trix-content']" ref="trix" :input="computedId" :placeholder="placeholder" @trix-change="handleContentChange" @trix-initialize="handleInitialize" @trix-focus="processTrixFocus" @trix-blur="processTrixBlur" @trix-attachment-add="handleAttachmentAdd" />
     <input type="hidden" :name="inputName" :id="computedId" :value="editorContent" />
   </div>
 </template>
@@ -315,6 +315,12 @@ export default {
     blur() {
       if (this.$refs.trix && this.$refs.trix.blur) {
         this.$refs.trix.blur()
+      }
+    },
+    handleAttachmentAdd(event) {
+      // Prevent pasting in images from the browser
+      if (!event.attachment.file) {
+        event.attachment.remove()
       }
     }
   },


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

Disable the ability to paste images into the rich text editor

## Which issue is fixed?

No issue, discussed in Discord

## In-depth Description

Trix editor by default allows for pasting in image files that are copied from a browser. This is a potential security issue since the URL of the image is included.
