### PR TITLE
Sanitize media item & episode description on update

### DIFF
--- a/server/controllers/PodcastController.js
+++ b/server/controllers/PodcastController.js
@@ -9,6 +9,7 @@ const fs = require('../libs/fsExtra')
 const { getPodcastFeed, findMatchingEpisodes } = require('../utils/podcastUtils')
 const { getFileTimestampsWithIno, filePathToPOSIX } = require('../utils/fileUtils')
 const { validateUrl } = require('../utils/index')
+const htmlSanitizer = require('../utils/htmlSanitizer')
 
 const Scanner = require('../scanner/Scanner')
 const CoverManager = require('../managers/CoverManager')
@@ -404,6 +405,15 @@ class PodcastController {
     const supportedStringKeys = ['title', 'subtitle', 'description', 'pubDate', 'episode', 'season', 'episodeType']
     for (const key in req.body) {
       if (supportedStringKeys.includes(key) && typeof req.body[key] === 'string') {
+        // Sanitize description HTML
+        if (key === 'description' && req.body[key]) {
+          const sanitizedDescription = htmlSanitizer.sanitize(req.body[key])
+          if (sanitizedDescription !== req.body[key]) {
+            Logger.debug(`[PodcastController] Sanitized description from "${req.body[key]}" to "${sanitizedDescription}"`)
+            req.body[key] = sanitizedDescription
+          }
+        }
+
         updatePayload[key] = req.body[key]
       } else if (key === 'chapters' && Array.isArray(req.body[key]) && req.body[key].every((ch) => typeof ch === 'object' && ch.title && ch.start)) {
         updatePayload[key] = req.body[key]

--- a/server/models/Book.js
+++ b/server/models/Book.js
@@ -377,8 +377,17 @@ class Book extends Model {
         if (typeof payload.metadata[key] == 'number') {
           payload.metadata[key] = String(payload.metadata[key])
         }
-          
+
         if ((typeof payload.metadata[key] === 'string' || payload.metadata[key] === null) && this[key] !== payload.metadata[key]) {
+          // Sanitize description HTML
+          if (key === 'description' && payload.metadata[key]) {
+            const sanitizedDescription = htmlSanitizer.sanitize(payload.metadata[key])
+            if (sanitizedDescription !== payload.metadata[key]) {
+              Logger.debug(`[Book] "${this.title}" Sanitized description from "${payload.metadata[key]}" to "${sanitizedDescription}"`)
+              payload.metadata[key] = sanitizedDescription
+            }
+          }
+
           this[key] = payload.metadata[key] || null
 
           if (key === 'title') {

--- a/server/models/Podcast.js
+++ b/server/models/Podcast.js
@@ -2,6 +2,7 @@ const { DataTypes, Model } = require('sequelize')
 const { getTitlePrefixAtEnd, getTitleIgnorePrefix } = require('../utils')
 const Logger = require('../Logger')
 const libraryItemsPodcastFilters = require('../utils/queries/libraryItemsPodcastFilters')
+const htmlSanitizer = require('../utils/htmlSanitizer')
 
 /**
  * @typedef PodcastExpandedProperties
@@ -215,6 +216,15 @@ class Podcast extends Model {
           newKey = 'itunesPageURL'
         }
         if ((typeof payload.metadata[key] === 'string' || payload.metadata[key] === null) && payload.metadata[key] !== this[newKey]) {
+          // Sanitize description HTML
+          if (key === 'description' && payload.metadata[key]) {
+            const sanitizedDescription = htmlSanitizer.sanitize(payload.metadata[key])
+            if (sanitizedDescription !== payload.metadata[key]) {
+              Logger.debug(`[Podcast] "${this.title}" Sanitized description from "${payload.metadata[key]}" to "${sanitizedDescription}"`)
+              payload.metadata[key] = sanitizedDescription
+            }
+          }
+
           this[newKey] = payload.metadata[key] || null
 
           if (key === 'title') {


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

This is an API update to sanitize HTML descriptions

## Which issue is fixed?

No issue, related to #4349

## In-depth Description

API endpoints `/items/:id/media` and `/api/podcasts/:id/episode/:episodeId` support updating the description for book/podcast & podcast episodes.

Since those descriptions support HTML they need to be sanitized.

Sanitization options
```js
{
    allowedTags: ['p', 'ol', 'ul', 'li', 'a', 'strong', 'em', 'del', 'br', 'b', 'i'],
    disallowedTagsMode: 'discard',
    allowedAttributes: {
      a: ['href', 'name', 'target']
    },
    allowedSchemes: ['http', 'https', 'mailto'],
    allowProtocolRelative: false
  }
```

## How have you tested this?

API
