### PR TITLE
Adds ENV for MaxFailedEpisodeChecks

### DIFF
--- a/server/managers/PodcastManager.js
+++ b/server/managers/PodcastManager.js
@@ -30,7 +30,7 @@ class PodcastManager {
     this.currentDownload = null
 
     this.failedCheckMap = {}
-    this.MaxFailedEpisodeChecks = process.env.MAX_FAILED_EPISODE_CHECKS || 24
+    this.MaxFailedEpisodeChecks = parseInt(process.env.MAX_FAILED_EPISODE_CHECKS, 10) || 24
   }
 
   getEpisodeDownloadsInQueue(libraryItemId) {
@@ -345,7 +345,7 @@ class PodcastManager {
       // Allow up to MaxFailedEpisodeChecks failed attempts before disabling auto download
       if (!this.failedCheckMap[libraryItem.id]) this.failedCheckMap[libraryItem.id] = 0
       this.failedCheckMap[libraryItem.id]++
-      if (this.MaxFailedEpisodeChecks != 0 && this.failedCheckMap[libraryItem.id] >= this.MaxFailedEpisodeChecks) {
+      if (this.MaxFailedEpisodeChecks !== 0 && this.failedCheckMap[libraryItem.id] >= this.MaxFailedEpisodeChecks) {
         Logger.error(`[PodcastManager] runEpisodeCheck ${this.failedCheckMap[libraryItem.id]} failed attempts at checking episodes for "${libraryItem.media.title}" - disabling auto download`)
         libraryItem.media.autoDownloadEpisodes = false
         delete this.failedCheckMap[libraryItem.id]

--- a/server/managers/PodcastManager.js
+++ b/server/managers/PodcastManager.js
@@ -30,7 +30,7 @@ class PodcastManager {
     this.currentDownload = null
 
     this.failedCheckMap = {}
-    this.MaxFailedEpisodeChecks = 24
+    this.MaxFailedEpisodeChecks = process.env.MAX_FAILED_EPISODE_CHECKS || 24
   }
 
   getEpisodeDownloadsInQueue(libraryItemId) {
@@ -345,7 +345,7 @@ class PodcastManager {
       // Allow up to MaxFailedEpisodeChecks failed attempts before disabling auto download
       if (!this.failedCheckMap[libraryItem.id]) this.failedCheckMap[libraryItem.id] = 0
       this.failedCheckMap[libraryItem.id]++
-      if (this.failedCheckMap[libraryItem.id] >= this.MaxFailedEpisodeChecks) {
+      if (this.MaxFailedEpisodeChecks != 0 && this.failedCheckMap[libraryItem.id] >= this.MaxFailedEpisodeChecks) {
         Logger.error(`[PodcastManager] runEpisodeCheck ${this.failedCheckMap[libraryItem.id]} failed attempts at checking episodes for "${libraryItem.media.title}" - disabling auto download`)
         libraryItem.media.autoDownloadEpisodes = false
         delete this.failedCheckMap[libraryItem.id]


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

Adds ENV (`MAX_FAILED_EPISODE_CHECKS`) for MaxFailedEpisodeChecks. 0 skips the check.

## Which issue is fixed?

No particular, but this would give the ability to higher the amount if someone does hourly checks e.g. (or lower it) or just disable it if the person does not want any checks.

> [!NOTE]
> Currently not tested! Should work, because minor fixes, but will test in the upcoming days (and update with a comment if so)

## In-depth Description

<!--
Describe your solution in more depth.
How does it work? Why is this the best solution?
Does it solve a problem that affects multiple users or is this an edge case for your setup?
-->

## How have you tested this?

<!-- Please describe in detail with reproducible steps how you tested your changes. -->

## Screenshots

<!-- If your PR includes any changes to the web client, please include screenshots or a short video from before and after your changes. -->
