### PR TITLE
Potential fix/new knowledge for hangig podcasts

### DIFF
--- a/server/managers/PodcastManager.js
+++ b/server/managers/PodcastManager.js
@@ -390,7 +390,11 @@ class PodcastManager {
         // The added second is to make sure that axios can fail first and only falls back later
         setTimeout(() => reject(new Error('Timeout. getPodcastFeed seemed to timeout but not triggering the timeout.')), global.PodcastDownloadTimeout + 1000)
       )
-    ])
+    ]).catch((error) => {
+      Logger.error(`[PodcastManager] checkPodcastForNewEpisodes failed to fetch feed for ${podcastLibraryItem.media.title} (ID: ${podcastLibraryItem.id}):`, error)
+      return null
+    })
+
     if (!feed?.episodes) {
       Logger.error(`[PodcastManager] checkPodcastForNewEpisodes invalid feed payload for ${podcastLibraryItem.media.title} (ID: ${podcastLibraryItem.id})`, feed)
       return null

--- a/server/managers/PodcastManager.js
+++ b/server/managers/PodcastManager.js
@@ -384,7 +384,13 @@ class PodcastManager {
       Logger.error(`[PodcastManager] checkPodcastForNewEpisodes no feed url for ${podcastLibraryItem.media.title} (ID: ${podcastLibraryItem.id})`)
       return null
     }
-    const feed = await getPodcastFeed(podcastLibraryItem.media.feedURL)
+    const feed = await Promise.race([
+      getPodcastFeed(podcastLibraryItem.media.feedURL),
+      new Promise((_, reject) =>
+        // The added second is to make sure that axios can fail first and only falls back later
+        setTimeout(() => reject(new Error('Timeout. getPodcastFeed seemed to timeout but not triggering the timeout.')), global.PodcastDownloadTimeout + 1000)
+      )
+    ])
     if (!feed?.episodes) {
       Logger.error(`[PodcastManager] checkPodcastForNewEpisodes invalid feed payload for ${podcastLibraryItem.media.title} (ID: ${podcastLibraryItem.id})`, feed)
       return null


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

From the logs, I strongly suspect that the timeout for the feed request never triggers, which causes the code to hang. As a result, it is never removed from the executing list and is not executed again. To check this (since it is possible that the ssrf filter interferes with the timeout), I added a promise that will throw after the timeout to ensure it works. If this works, we will know that it has something to do with axios and can implement a better fix. This change does not affect any behavior and still allows axios to fail correctly (with an extra second), so it should be safe to merge.

## Which issue is fixed?

Potentially fixe s https://github.com/advplyr/audiobookshelf/issues/4098

## In-depth Description

<!--
Describe your solution in more depth.
How does it work? Why is this the best solution?
Does it solve a problem that affects multiple users or is this an edge case for your setup?
-->

## How have you tested this?

Own podcasts with 1 minute cron and custom timeout values

## Screenshots

<!-- If your PR includes any changes to the web client, please include screenshots or a short video from before and after your changes. -->
