### PR TITLE
Corrects removing of attachments for Trix

### DIFF
--- a/client/components/ui/VueTrix.vue
+++ b/client/components/ui/VueTrix.vue
@@ -318,10 +318,8 @@ export default {
       }
     },
     handleAttachmentAdd(event) {
-      // Prevent pasting in images from the browser
-      if (!event.attachment.file) {
-        event.attachment.remove()
-      }
+      // Prevent pasting in images/any files from the browser
+      event.attachment.remove()
     }
   },
   mounted() {


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

Currently, files can be added to the editor, which I think is nice and could be brought back in the future. However, because the description is sanitized,(btw. ignore name of branch. Not possible because of sanitization). I noticed that files can be pasted, including images, so maybe we should consider allowing files in the future, but right now, sanitization removes them when the description is saved. To get parity now all attachments are disallowed, also including files

Maybe there's a reason we allowed files that I missed (in that case, please close this), but at the moment, you can add files (such as images or Excel files) that are just lost after saving.

## Which issue is fixed?

None

## In-depth Description

See description

## How have you tested this?

Copy pasting images and files

## Screenshots

<!-- If your PR includes any changes to the web client, please include screenshots or a short video from before and after your changes. -->
