### PR TITLE
fix(Dockerfile): Wire ROUTER_BASE_PATH to build arg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,13 @@
 ARG NUSQLITE3_DIR="/usr/local/lib/nusqlite3"
 ARG NUSQLITE3_PATH="${NUSQLITE3_DIR}/libnusqlite3.so"
+ARG ROUTER_BASE_PATH="/audiobookshelf"
 
 ### STAGE 0: Build client ###
 FROM node:20-alpine AS build-client
+
+ARG ROUTER_BASE_PATH
+
+ENV ROUTER_BASE_PATH=${ROUTER_BASE_PATH}
 
 WORKDIR /client
 COPY /client /client
@@ -14,8 +19,10 @@ FROM node:20-alpine AS build-server
 
 ARG NUSQLITE3_DIR
 ARG TARGETPLATFORM
+ARG ROUTER_BASE_PATH
 
 ENV NODE_ENV=production
+ENV ROUTER_BASE_PATH=${ROUTER_BASE_PATH}
 
 RUN apk add --no-cache --update \
   curl \
@@ -45,6 +52,7 @@ FROM node:20-alpine
 
 ARG NUSQLITE3_DIR
 ARG NUSQLITE3_PATH
+ARG ROUTER_BASE_PATH
 
 # Install only runtime dependencies
 RUN apk add --no-cache --update \
@@ -68,6 +76,7 @@ ENV METADATA_PATH="/metadata"
 ENV SOURCE="docker"
 ENV NUSQLITE3_DIR=${NUSQLITE3_DIR}
 ENV NUSQLITE3_PATH=${NUSQLITE3_PATH}
+ENV ROUTER_BASE_PATH=${ROUTER_BASE_PATH}
 
 ENTRYPOINT ["tini", "--"]
 CMD ["node", "index.js"]


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

Create a clear interface for building an image with an empty or alternate `ROUTER_BASE_PATH` without needing to modify source, shell into containers, or rebuild at all.

## Which issue is fixed?

Not sure if I'd consider this a fix per-se, but it may ease tension on sentiments along the lines of #3874 

## In-depth Description
The best I could make of the [saga of this change](https://github.com/advplyr/audiobookshelf/issues/3874#issuecomment-2614154863) given my available time is that if one desires a containerized instance of audiobookshelf with an empty `ROUTER_BASE_PATH`, they're responsible for building it themselves.

I haven't tested extensively yet as I'm still getting familiar with some of the features, but if I've understood the process recommended for doing so at present, it should work to set `ROUTER_BASE_PATH` empty before building the apps. I was surprised then to see then this variable wasn't wired up to a Docker build arg where it can be easily set from outside the build or containers without modifying the source:

```sh
docker build --build-arg ROUTER_BASE_PATH= . -t audiobookshelf:no_router_base_path
```

This PR was created both to ask the experts whether this is a complete and valid approach, and if so, offered as a small-diff pressure-release valve for people like myself who were initially flustered about the opinionated nature of this change.

<!--
Describe your solution in more depth.
How does it work? Why is this the best solution?
Does it solve a problem that affects multiple users or is this an edge case for your setup?
-->

## How have you tested this?
I tested local and remote access via browser, the official Android app, and RSS feeds via PodcastAddict.

## Screenshots
<img width="955" alt="abs" src="https://github.com/user-attachments/assets/51254142-6457-4113-aa21-bd06088b0e0f" />
