### PR TITLE
Update cleanDatabase to remove duplicate mediaProgresses

### DIFF
--- a/server/Database.js
+++ b/server/Database.js
@@ -765,6 +765,15 @@ class Database {
     if (badSessionsRemoved > 0) {
       Logger.warn(`Removed ${badSessionsRemoved} sessions that were 3 seconds or less`)
     }
+
+    // Remove mediaProgresses with duplicate mediaItemId (remove the oldest updatedAt)
+    const [duplicateMediaProgresses] = await this.sequelize.query(`SELECT id, mediaItemId FROM mediaProgresses WHERE (mediaItemId, updatedAt) IN (SELECT mediaItemId, MIN(updatedAt) FROM mediaProgresses GROUP BY mediaItemId HAVING COUNT(*) > 1)`)
+    for (const duplicateMediaProgress of duplicateMediaProgresses) {
+      Logger.warn(`Found duplicate mediaProgress for mediaItem "${duplicateMediaProgress.mediaItemId}" - removing it`)
+      await this.mediaProgressModel.destroy({
+        where: { id: duplicateMediaProgress.id }
+      })
+    }
   }
 
   async createTextSearchQuery(query) {


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

Adds a step in the clean database function to remove duplicate `mediaProgresses` entries

## Which issue is fixed?

No issue, but related to #4366 and probably others. This is often brought up in Discord.

## In-depth Description

A race condition in the API when syncing sessions and/or creating media progress can result in multiple media progress records with the same `mediaItemId`. So far this is only seen with the third party app Plappa.

This PR doesn't fix that issue but it will clean up the duplicates on server startup.

## How have you tested this?

Created duplicates in the db manually

