### PR TITLE
Add clickable seek-to-time links for timestamps in descriptions

### DIFF
--- a/client/components/modals/podcast/ViewEpisode.vue
+++ b/client/components/modals/podcast/ViewEpisode.vue
@@ -120,7 +120,7 @@ export default {
       const timeRegex = /\b((\d{1,2}:)?\d{1,2}:\d{2})\b/g
 
       return htmlString.replace(timeRegex, (match) => {
-        const totalSeconds = timeStringToSeconds(match)
+        const totalSeconds = this.timeStringToSeconds(match)
         if (totalSeconds !== null) {
           return `<a href="#" class="timestamp-link" data-time-seconds="${totalSeconds}">${match}</a>`
         }

--- a/client/components/modals/podcast/ViewEpisode.vue
+++ b/client/components/modals/podcast/ViewEpisode.vue
@@ -100,20 +100,31 @@ export default {
   methods: {
     timeStringToSeconds(timeStr) {
       const parts = timeStr.split(':').map(Number)
-      let seconds = 0
+      let hours = 0,
+        minutes = 0,
+        seconds = 0
       if (parts.length === 3) {
-        seconds = parts[0] * 3600 + parts[1] * 60 + parts[2]
+        ;[hours, minutes, seconds] = parts
       } else if (parts.length === 2) {
-        seconds = parts[0] * 60 + parts[1]
+        ;[minutes, seconds] = parts
+      } else {
+        return null
       }
-      return seconds
+      if (minutes >= 60 || seconds >= 60 || hours < 0 || minutes < 0 || seconds < 0) {
+        return null
+      }
+
+      return hours * 3600 + minutes * 60 + seconds
     },
     linkifyTimestamps(htmlString) {
       const timeRegex = /\b((\d{1,2}:)?\d{1,2}:\d{2})\b/g
 
       return htmlString.replace(timeRegex, (match) => {
-        const totalSeconds = this.timeStringToSeconds(match)
-        return `<a href="#" class="timestamp-link" data-time-seconds="${totalSeconds}">${match}</a>`
+        const totalSeconds = timeStringToSeconds(match)
+        if (totalSeconds !== null) {
+          return `<a href="#" class="timestamp-link" data-time-seconds="${totalSeconds}">${match}</a>`
+        }
+        return match
       })
     },
     handleDescriptionClick(e) {


### PR DESCRIPTION
## Brief summary

This PR introduces a new feature that automatically detects timestamps (e.g., `59:23` or `01:03:55`) in an item's description and converts them into clickable links. When a user clicks on one of these links, the player will seek to that specific time in the audio.

This enhances the user experience by allowing creators to easily reference parts of the audio in the description, and listeners to jump directly to those points of interest.

## Which issue is fixed?

<!-- Which issue number does this PR fix? Ex: "Fixes #1234" -->

## In-depth Description

1.  A new computed property, `processedDescription`, uses a regular expression to find all timestamp patterns in the item's HTML description.
2.  Each found timestamp is wrapped in an `<a>` tag with a `data-time-seconds` attribute containing the time converted to total seconds.
3.  An event delegation pattern is used on the description container (`@click="handleDescriptionClick"`). This avoids attaching numerous event listeners and efficiently captures clicks on the dynamically generated links.
4.  When a timestamp link is clicked, the handler extracts the time in seconds from the `data` attribute and calls the existing `timestampClick` method to seek the player.

## How have you tested this?

<!-- Please describe in detail with reproducible steps how you tested your changes. -->

## Screenshots

### Before

`39:14-53:42 My favorite part`

![image](https://github.com/user-attachments/assets/af9eab41-c42e-466d-8ade-46262e039694)

### After

`<a href="#">39:14</a>-<a href="#">53:42</a> My favorite part` (Clicking "39:14" seeks the audio to 39 minutes and 14 seconds).

![image](https://github.com/user-attachments/assets/ff7ec9da-e0fc-41d4-b93b-fe3c1b0f4203)

https://github.com/user-attachments/assets/d2b034f7-327d-410f-ac09-d65fe13caf98