### PR TITLE
Fix filesystem pathexists path join

### DIFF
--- a/server/controllers/FileSystemController.js
+++ b/server/controllers/FileSystemController.js
@@ -89,7 +89,6 @@ class FileSystemController {
     }
 
     const { directory, folderPath } = req.body
-
     if (!directory?.length || typeof directory !== 'string' || !folderPath?.length || typeof folderPath !== 'string') {
       Logger.error(`[FileSystemController] Invalid request body: ${JSON.stringify(req.body)}`)
       return res.status(400).json({
@@ -109,7 +108,8 @@ class FileSystemController {
       return res.sendStatus(404)
     }
 
-    const filepath = Path.posix.join(libraryFolder.path, directory)
+    const filepath = Path.join(libraryFolder.path, directory)
+
     // Ensure filepath is inside library folder (prevents directory traversal)
     if (!filepath.startsWith(libraryFolder.path)) {
       Logger.error(`[FileSystemController] Filepath is not inside library folder: ${filepath}`)


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

This is a follow up to #4342 to fix an edge case

## Which issue is fixed?

No issue

## In-depth Description

When using `Path.posix.join` with a posix file path and a Windows file path the resulting join isn't normalized.

For example:
```js
Path.posix.join("C:/Users/Test/audiobooks", "..\\test")
```

returns `C:/Users/Test/audiobooks/..\test`

`Path.join` returns `C:/Users/Test/test` as expected

This is an issue because `fs.pathExists` is normalizing the posix and non-posix path

## How have you tested this?

Making API calls. The web ui doesn't use relative paths.

