### PR TITLE
Update podcast episode downloads to have a fallback user agent string

### DIFF
--- a/server/utils/ffmpegHelpers.js
+++ b/server/utils/ffmpegHelpers.js
@@ -103,18 +103,39 @@ module.exports.resizeImage = resizeImage
  */
 module.exports.downloadPodcastEpisode = (podcastEpisodeDownload) => {
   return new Promise(async (resolve) => {
-    const response = await axios({
-      url: podcastEpisodeDownload.url,
-      method: 'GET',
-      responseType: 'stream',
-      headers: {
-        'User-Agent': 'audiobookshelf (+https://audiobookshelf.org; like iTMS)'
-      },
-      timeout: global.PodcastDownloadTimeout
-    }).catch((error) => {
-      Logger.error(`[ffmpegHelpers] Failed to download podcast episode with url "${podcastEpisodeDownload.url}"`, error)
-      return null
-    })
+    // Some podcasts fail due to user agent strings
+    // See: https://github.com/advplyr/audiobookshelf/issues/3246 (requires iTMS user agent)
+    // See: https://github.com/advplyr/audiobookshelf/issues/4401 (requires no iTMS user agent)
+    const userAgents = ['audiobookshelf (+https://audiobookshelf.org; like iTMS)', 'audiobookshelf (+https://audiobookshelf.org)']
+
+    let response = null
+    let lastError = null
+
+    for (const userAgent of userAgents) {
+      try {
+        response = await axios({
+          url: podcastEpisodeDownload.url,
+          method: 'GET',
+          responseType: 'stream',
+          headers: {
+            'User-Agent': userAgent
+          },
+          timeout: global.PodcastDownloadTimeout
+        })
+
+        Logger.debug(`[ffmpegHelpers] Successfully connected with User-Agent: ${userAgent}`)
+        break
+      } catch (error) {
+        lastError = error
+        Logger.warn(`[ffmpegHelpers] Failed to download podcast episode with User-Agent "${userAgent}" for url "${podcastEpisodeDownload.url}"`, error.message)
+
+        // If this is the last attempt, log the full error
+        if (userAgent === userAgents[userAgents.length - 1]) {
+          Logger.error(`[ffmpegHelpers] All User-Agent attempts failed for url "${podcastEpisodeDownload.url}"`, lastError)
+        }
+      }
+    }
+
     if (!response) {
       return resolve({
         success: false


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

Some podcasts fail with different user agents

## Which issue is fixed?

Fixes #4401
Related #3246
Related #3322

## In-depth Description

This will have podcast episode downloads fallback to another user agent string on any failure.
Primary user-agent: `audiobookshelf (+https://audiobookshelf.org; like iTMS)`
Fallback user-agent: `audiobookshelf (+https://audiobookshelf.org)`

RSS feed: https://www1.nobexpartners.com/getfeed.ashx?id=46434&list=LIRAZ
Can download with the primary user-agent but not the fallback user-agent (reported in #4401)

RSS feed: https://feeds.captivate.fm/james-obrien-the-who/
Fails to download using the primary user-agent but works with the fallback (reported in #3246)

A related user-agent issue was with requesting the RSS feed (not downloading) for CBC podcasts (reported in #3322)

The user-agent was first added here #3099 and was previously the default axios one

