### PR TITLE
Make `NUSQLITE3_PATH` build arg configurable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,7 @@ WORKDIR /app
 # Copy compiled frontend and server from build stages
 COPY --from=build-client /client/dist /app/client/dist
 COPY --from=build-server /server /app
-COPY --from=build-server /usr/local/lib/nusqlite3 /usr/local/lib/nusqlite3
+COPY --from=build-server ${NUSQLITE3_PATH} ${NUSQLITE3_PATH}
 
 EXPOSE 80
 


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

Make `NUSQLITE3_PATH` build arg configurable

## Which issue is fixed?

None

## In-depth Description

The dockerfile currently exposes two build args (`NUSQLITE3_DIR` and `NUSQLITE3_PATH`) to configure the location of the  nunicode-sqlite library, but one COPY instruction from that dockerfile hardcodes the default value of that arg, leading any build with a custom value of that arg to fail.
<!--
Describe your solution in more depth.
How does it work? Why is this the best solution?
Does it solve a problem that affects multiple users or is this an edge case for your setup?
-->

## How have you tested this?

Before:
`docker build --build-arg NUSQLITE3_DIR=/something .` fails with:
```
 => ERROR [stage-2 6/6] COPY --from=build-server /usr/local/lib/nusqlite3 /usr/local/lib/nusqlite3                                                                                 0.0s 
------                                                                                                                                                                                  
 > [stage-2 6/6] COPY --from=build-server /usr/local/lib/nusqlite3 /usr/local/lib/nusqlite3:                                                                                            
------                                                                                                                                                                                  
Dockerfile:60                                                                                                                                                                           
--------------------
  58 |     COPY --from=build-client /client/dist /app/client/dist
  59 |     COPY --from=build-server /server /app
  60 | >>> COPY --from=build-server /usr/local/lib/nusqlite3 /usr/local/lib/nusqlite3
  61 |     
  62 |     EXPOSE 80
--------------------
ERROR: failed to solve: failed to compute cache key: failed to calculate checksum of ref C7EG:K5UQ:XJBR:E73C:GPFP:XRKP:5MHC:MR66:I3CH:5QUB:3T6N:3T5Z::bwnen464mqy9zqt5ucrcetcsq: "/usr/local/lib/nusqlite3": not found
```

After:
The same command successfully builds a working image.

## Screenshots

Does not apply