### PR TITLE
Show duration in episode view modal & episode feed modal

### DIFF
--- a/client/components/modals/podcast/EpisodeFeed.vue
+++ b/client/components/modals/podcast/EpisodeFeed.vue
@@ -35,7 +35,14 @@
               <widgets-podcast-type-indicator :type="episode.episodeType" />
             </div>
             <p v-if="episode.subtitle" class="mb-1 text-sm text-gray-300 line-clamp-2">{{ episode.subtitle }}</p>
-            <p class="text-xs text-gray-300">Published {{ episode.publishedAt ? $dateDistanceFromNow(episode.publishedAt) : 'Unknown' }}</p>
+            <div class="flex items-center space-x-2">
+              <!-- published -->
+              <p class="text-xs text-gray-300 w-40">Published {{ episode.publishedAt ? $dateDistanceFromNow(episode.publishedAt) : 'Unknown' }}</p>
+              <!-- duration -->
+              <p v-if="episode.duration && !isNaN(episode.duration) && Number(episode.duration) > 0" class="text-xs text-gray-300 min-w-28">{{ $strings.LabelDuration }}: {{ $elapsedPretty(Number(episode.duration)) }}</p>
+              <!-- size -->
+              <p v-if="episode.enclosure?.length && !isNaN(episode.enclosure.length) && Number(episode.enclosure.length) > 0" class="text-xs text-gray-300">{{ $strings.LabelSize }}: {{ $bytesPretty(Number(episode.enclosure.length)) }}</p>
+            </div>
           </div>
         </div>
       </div>

--- a/client/components/modals/podcast/EpisodeFeed.vue
+++ b/client/components/modals/podcast/EpisodeFeed.vue
@@ -39,7 +39,7 @@
               <!-- published -->
               <p class="text-xs text-gray-300 w-40">Published {{ episode.publishedAt ? $dateDistanceFromNow(episode.publishedAt) : 'Unknown' }}</p>
               <!-- duration -->
-              <p v-if="episode.duration && !isNaN(episode.duration) && Number(episode.duration) > 0" class="text-xs text-gray-300 min-w-28">{{ $strings.LabelDuration }}: {{ $elapsedPretty(Number(episode.duration)) }}</p>
+              <p v-if="episode.durationSeconds && !isNaN(episode.durationSeconds)" class="text-xs text-gray-300 min-w-28">{{ $strings.LabelDuration }}: {{ $elapsedPretty(episode.durationSeconds) }}</p>
               <!-- size -->
               <p v-if="episode.enclosure?.length && !isNaN(episode.enclosure.length) && Number(episode.enclosure.length) > 0" class="text-xs text-gray-300">{{ $strings.LabelSize }}: {{ $bytesPretty(Number(episode.enclosure.length)) }}</p>
             </div>

--- a/client/components/modals/podcast/ViewEpisode.vue
+++ b/client/components/modals/podcast/ViewEpisode.vue
@@ -34,6 +34,12 @@
             {{ audioFileSize }}
           </p>
         </div>
+        <div class="grow">
+          <p class="font-semibold text-xs mb-1">{{ $strings.LabelDuration }}</p>
+          <p class="mb-2 text-xs">
+            {{ audioFileDuration }}
+          </p>
+        </div>
       </div>
     </div>
   </modals-modal>
@@ -89,6 +95,10 @@ export default {
       const size = this.episode.audioFile?.metadata?.size || 0
 
       return this.$bytesPretty(size)
+    },
+    audioFileDuration() {
+      const duration = this.episode.duration || 0
+      return this.$elapsedPretty(duration)
     },
     bookCoverAspectRatio() {
       return this.$store.getters['libraries/getBookCoverAspectRatio']

--- a/server/utils/podcastUtils.js
+++ b/server/utils/podcastUtils.js
@@ -25,6 +25,7 @@ const Fuse = require('../libs/fusejs')
  * @property {string} episode
  * @property {string} author
  * @property {string} duration
+ * @property {number|null} durationSeconds - Parsed from duration string if duration is valid
  * @property {string} explicit
  * @property {number} publishedAt - Unix timestamp
  * @property {{ url: string, type?: string, length?: string }} enclosure
@@ -217,8 +218,9 @@ function extractEpisodeData(item) {
   })
 
   // Extract psc:chapters if duration is set
-  let episodeDuration = !isNaN(episode.duration) ? timestampToSeconds(episode.duration) : null
-  if (item['psc:chapters']?.[0]?.['psc:chapter']?.length && episodeDuration) {
+  episode.durationSeconds = episode.duration ? timestampToSeconds(episode.duration) : null
+
+  if (item['psc:chapters']?.[0]?.['psc:chapter']?.length && episode.durationSeconds) {
     // Example chapter:
     // {"id":0,"start":0,"end":43.004286,"title":"chapter 1"}
 
@@ -244,7 +246,7 @@ function extractEpisodeData(item) {
     } else {
       episode.chapters = cleanedChapters.map((chapter, index) => {
         const nextChapter = cleanedChapters[index + 1]
-        const end = nextChapter ? nextChapter.start : episodeDuration
+        const end = nextChapter ? nextChapter.start : episode.durationSeconds
         return {
           id: chapter.id,
           title: chapter.title,
@@ -273,6 +275,7 @@ function cleanEpisodeData(data) {
     episode: data.episode || '',
     author: data.author || '',
     duration: data.duration || '',
+    durationSeconds: data.durationSeconds || null,
     explicit: data.explicit || '',
     publishedAt,
     enclosure: data.enclosure,


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

While testing a podcast issue I noticed that when an episode is in progress or marked as finished there is no place to view the episode duration. This PR adds the duration to the view episode modal.

This also adds the duration and file size to the episode feed modal. The episode feed modal is using data from the podcast RSS feed and in some cases the file size or duration isn't specified. In those cases the size and/or duration isn't shown.

The podcast episode RSS feed object includes `episodeDuration` that is parsed from the `duration` set in the RSS feed. The duration can be the number of seconds or a timestamp like "1:12:27".

## Which issue is fixed?

No issue

## Screenshots

Syntax doesn't include file size in enclosure
![image](https://github.com/user-attachments/assets/80410581-6b2d-4dfd-b7d8-2af24c59c172)

Self-Hosted uses timestamps like "1:12:27" for duration
![image](https://github.com/user-attachments/assets/8ccee348-b301-401d-9b86-792bdb167be5)

View episode modal now includes duration
![image](https://github.com/user-attachments/assets/a97c6667-b9fc-4dc2-9b76-d1bda19ddd01)

