### PR TITLE
Add ipaddress to playbacksession

### DIFF
--- a/client/components/modals/ListeningSessionModal.vue
+++ b/client/components/modals/ListeningSessionModal.vue
@@ -89,7 +89,7 @@
 
           <p v-if="hasDeviceInfo" class="font-semibold uppercase text-xs text-gray-400 tracking-wide mt-6 mb-2">{{ $strings.LabelDevice }}</p>
           <p v-if="clientDisplayName" class="mb-1">{{ clientDisplayName }}</p>
-          <p v-if="deviceInfo.ipAddress" class="mb-1">{{ deviceInfo.ipAddress }}</p>
+          <p v-if="_session.ipAddress" class="mb-1">{{ _session.ipAddress }}</p>
           <p v-if="osDisplayName" class="mb-1">{{ osDisplayName }}</p>
           <p v-if="deviceInfo.browserName" class="mb-1">{{ deviceInfo.browserName }}</p>
           <p v-if="deviceDisplayName" class="mb-1">{{ deviceDisplayName }}</p>
@@ -136,7 +136,7 @@ export default {
       return this._session.deviceInfo || {}
     },
     hasDeviceInfo() {
-      return Object.keys(this.deviceInfo).length
+      return Object.keys(this.deviceInfo).length || this._session.ipAddress
     },
     osDisplayName() {
       if (!this.deviceInfo.osName) return null

--- a/client/components/modals/ListeningSessionModal.vue
+++ b/client/components/modals/ListeningSessionModal.vue
@@ -136,7 +136,7 @@ export default {
       return this._session.deviceInfo || {}
     },
     hasDeviceInfo() {
-      return Object.keys(this.deviceInfo).length || this._session.ipAddress
+      return Object.keys(this.deviceInfo).length
     },
     osDisplayName() {
       if (!this.deviceInfo.osName) return null

--- a/server/managers/PlaybackSessionManager.js
+++ b/server/managers/PlaybackSessionManager.js
@@ -62,7 +62,6 @@ class PlaybackSessionManager {
         if (existingDevice.update(deviceInfo)) {
           await Database.deviceModel.updateFromOld(existingDevice)
         }
-        existingDevice.ipAddress = ip
         return existingDevice
       }
     }

--- a/server/managers/PlaybackSessionManager.js
+++ b/server/managers/PlaybackSessionManager.js
@@ -62,6 +62,7 @@ class PlaybackSessionManager {
         if (existingDevice.update(deviceInfo)) {
           await Database.deviceModel.updateFromOld(existingDevice)
         }
+        existingDevice.ipAddress = ip
         return existingDevice
       }
     }
@@ -181,6 +182,7 @@ class PlaybackSessionManager {
       // New session from local
       session = new PlaybackSession(sessionJson)
       session.deviceInfo = deviceInfo
+      session.ipAddress = deviceInfo.ipAddress
 
       if (session.mediaMetadata == null) {
         session.mediaMetadata = {}

--- a/server/migrations/v2.20.1-add-ipaddress-to-playbacksession.js
+++ b/server/migrations/v2.20.1-add-ipaddress-to-playbacksession.js
@@ -1,0 +1,67 @@
+/**
+ * @typedef MigrationContext
+ * @property {import('sequelize').QueryInterface} queryInterface - a Sequelize QueryInterface object.
+ * @property {import('../Logger')} logger - a Logger object.
+ *
+ * @typedef MigrationOptions
+ * @property {MigrationContext} context - an object containing the migration context.
+ */
+
+const migrationVersion = '2.20.1'
+const migrationName = `${migrationVersion}-add-ipaddress-to-playbacksession`
+const loggerPrefix = `[${migrationVersion} migration]`
+
+/**
+ * This migration script adds the ipAddress column to the playbackSessions table.
+ *
+ * @param {MigrationOptions} options - an object containing the migration context.
+ * @returns {Promise<void>} - A promise that resolves when the migration is complete.
+ */
+async function up({ context: { queryInterface, logger } }) {
+  logger.info(`${loggerPrefix} UPGRADE BEGIN: ${migrationName}`)
+
+  if (await queryInterface.tableExists('playbackSessions')) {
+    const tableDescription = await queryInterface.describeTable('playbackSessions')
+    if (!tableDescription.ipAddress) {
+      logger.info(`${loggerPrefix} Adding ipAddress column to playbackSessions table`)
+      await queryInterface.addColumn('playbackSessions', 'ipAddress', {
+        type: queryInterface.sequelize.Sequelize.DataTypes.STRING,
+        allowNull: true
+      })
+      logger.info(`${loggerPrefix} Added ipAddress column to playbackSessions table`)
+    } else {
+      logger.info(`${loggerPrefix} ipAddress column already exists in playbackSessions table`)
+    }
+  } else {
+    logger.info(`${loggerPrefix} playbackSessions table does not exist`)
+  }
+
+  logger.info(`${loggerPrefix} UPGRADE END: ${migrationName}`)
+}
+
+/**
+ * This migration script removes the ipAddress column from the playbackSessions table.
+ *
+ * @param {MigrationOptions} options - an object containing the migration context.
+ * @returns {Promise<void>} - A promise that resolves when the migration is complete.
+ */
+async function down({ context: { queryInterface, logger } }) {
+  logger.info(`${loggerPrefix} DOWNGRADE BEGIN: ${migrationName}`)
+
+  if (await queryInterface.tableExists('playbackSessions')) {
+    const tableDescription = await queryInterface.describeTable('playbackSessions')
+    if (tableDescription.ipAddress) {
+      logger.info(`${loggerPrefix} Removing ipAddress column from playbackSessions table`)
+      await queryInterface.removeColumn('playbackSessions', 'ipAddress')
+      logger.info(`${loggerPrefix} Removed ipAddress column from playbackSessions table`)
+    } else {
+      logger.info(`${loggerPrefix} ipAddress column does not exist in playbackSessions table`)
+    }
+  } else {
+    logger.info(`${loggerPrefix} playbackSessions table does not exist`)
+  }
+
+  logger.info(`${loggerPrefix} DOWNGRADE END: ${migrationName}`)
+}
+
+module.exports = { up, down } 

--- a/server/models/PlaybackSession.js
+++ b/server/models/PlaybackSession.js
@@ -16,6 +16,8 @@ class PlaybackSession extends Model {
     this.displayTitle
     /** @type {string} */
     this.displayAuthor
+    /** @type {string} */
+    this.ipAddress
     /** @type {number} */
     this.duration
     /** @type {number} */
@@ -93,6 +95,7 @@ class PlaybackSession extends Model {
       displayAuthor: playbackSessionExpanded.displayAuthor,
       coverPath: playbackSessionExpanded.coverPath,
       duration: playbackSessionExpanded.duration,
+      ipAddress: playbackSessionExpanded.ipAddress,
       playMethod: playbackSessionExpanded.playMethod,
       mediaPlayer: playbackSessionExpanded.mediaPlayer,
       deviceInfo: playbackSessionExpanded.device?.getOldDevice() || null,
@@ -141,6 +144,7 @@ class PlaybackSession extends Model {
       displayTitle: oldPlaybackSession.displayTitle,
       displayAuthor: oldPlaybackSession.displayAuthor,
       duration: oldPlaybackSession.duration,
+      ipAddress: oldPlaybackSession.ipAddress,
       playMethod: oldPlaybackSession.playMethod,
       mediaPlayer: oldPlaybackSession.mediaPlayer,
       startTime: oldPlaybackSession.startTime,
@@ -184,6 +188,7 @@ class PlaybackSession extends Model {
         displayTitle: DataTypes.STRING,
         displayAuthor: DataTypes.STRING,
         duration: DataTypes.FLOAT,
+        ipAddress: DataTypes.STRING,
         playMethod: DataTypes.INTEGER,
         mediaPlayer: DataTypes.STRING,
         startTime: DataTypes.FLOAT,

--- a/server/objects/PlaybackSession.js
+++ b/server/objects/PlaybackSession.js
@@ -226,7 +226,7 @@ class PlaybackSession {
 
     this.mediaPlayer = mediaPlayer
     this.deviceInfo = deviceInfo || new DeviceInfo()
-    this.ipAddress = this.deviceInfo.ipAddress
+    this.ipAddress = deviceInfo?.ipAddress || null
     this.serverVersion = serverVersion
 
     this.timeListening = 0

--- a/server/objects/PlaybackSession.js
+++ b/server/objects/PlaybackSession.js
@@ -23,6 +23,7 @@ class PlaybackSession {
     this.playMethod = null
     this.mediaPlayer = null
     this.deviceInfo = null
+    this.ipAddress = null
     this.serverVersion = null
 
     this.date = null
@@ -67,6 +68,7 @@ class PlaybackSession {
       playMethod: this.playMethod,
       mediaPlayer: this.mediaPlayer,
       deviceInfo: this.deviceInfo?.toJSON() || null,
+      ipAddress: this.ipAddress,
       serverVersion: this.serverVersion,
       date: this.date,
       dayOfWeek: this.dayOfWeek,
@@ -101,6 +103,7 @@ class PlaybackSession {
       playMethod: this.playMethod,
       mediaPlayer: this.mediaPlayer,
       deviceInfo: this.deviceInfo?.toJSON() || null,
+      ipAddress: this.ipAddress,
       serverVersion: this.serverVersion,
       date: this.date,
       dayOfWeek: this.dayOfWeek,
@@ -125,6 +128,7 @@ class PlaybackSession {
     this.duration = session.duration
     this.playMethod = session.playMethod
     this.mediaPlayer = session.mediaPlayer || null
+    this.ipAddress = session.ipAddress || null
 
     // Temp do not store old IDs
     if (this.libraryId?.startsWith('lib_')) {
@@ -222,6 +226,7 @@ class PlaybackSession {
 
     this.mediaPlayer = mediaPlayer
     this.deviceInfo = deviceInfo || new DeviceInfo()
+    this.ipAddress = this.deviceInfo.ipAddress
     this.serverVersion = serverVersion
 
     this.timeListening = 0


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

Store IP address per listening session instead of per device.

## Which issue is fixed?

No issue.

## In-depth Description

Previously, the application only stored the last known IP address for a device. This meant that if a user connected from different networks, the IP address history for their listening sessions was lost, and the UI would only show the most recent IP for the device, not the IP used for that specific session.

This change modifies the PlaybackSession object and its corresponding database model to include an ipAddress field. A database migration has been added to support this new column. The PlaybackSessionManager has been updated to capture the IP address from the current request when a session is created, ensuring the session-specific IP is saved. The frontend modal for viewing session details has also been updated to display the IP address from the session data, providing an accurate history of the IP used for each listening session.

## How have you tested this?

I ran the full server-side test suite using the npm test command. All 295 tests passed, confirming that the modifications did not introduce any regressions.

To test the feature, I started a new listening session and verified that the IP address was displayed correctly. Next, I initiated another listening session (on a different IP address) and confirmed that the IP addresses shown for each listening session were indeed different.
