### PR TITLE
Add ENV REACT_CLIENT_PATH to target a Nextjs frontend instead of Nuxt

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,6 +28,7 @@ if (isDev) {
   if (devEnv.SkipBinariesCheck) process.env.SKIP_BINARIES_CHECK = '1'
   if (devEnv.AllowIframe) process.env.ALLOW_IFRAME = '1'
   if (devEnv.BackupPath) process.env.BACKUP_PATH = devEnv.BackupPath
+  if (devEnv.ReactClientPath) process.env.REACT_CLIENT_PATH = devEnv.ReactClientPath
   process.env.SOURCE = 'local'
   process.env.ROUTER_BASE_PATH = devEnv.RouterBasePath ?? '/audiobookshelf'
 }

--- a/server/Auth.js
+++ b/server/Auth.js
@@ -442,7 +442,17 @@ class Auth {
     // Local strategy login route (takes username and password)
     router.post('/login', passport.authenticate('local'), async (req, res) => {
       // return the user login response json if the login was successfull
-      res.json(await this.getUserLoginResponsePayload(req.user))
+      const userResponse = await this.getUserLoginResponsePayload(req.user)
+
+      // Experimental Next.js client uses bearer token in cookies
+      res.cookie('auth_token', userResponse.user.token, {
+        httpOnly: true,
+        secure: req.secure || req.get('x-forwarded-proto') === 'https',
+        sameSite: 'strict',
+        maxAge: 1000 * 60 * 60 * 24 * 7 // 7 days
+      })
+
+      res.json(userResponse)
     })
 
     // openid strategy login route (this redirects to the configured openid login provider)
@@ -718,6 +728,7 @@ class Auth {
           const authMethod = req.cookies.auth_method
 
           res.clearCookie('auth_method')
+          res.clearCookie('auth_token')
 
           let logoutUrl = null
 


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

When ENV variable `REACT_CLIENT_PATH` is set the server will start a next.js app at the location instead of serving the nuxt app.

This is for testing a separate React frontend.

## In-depth Description

As of now the goal is to replace Nuxt with React (probably Next but not certain) and to keep the frontend in a separate repo from the server.

In the following days I'll set up a repo for the client. I have one on my local that is working well but needs to be cleaned up.

Some of the main reasons for choosing Next:
- Works with CJS (including SSR)
- `pkg` can create binaries for Windows/Debian
- HMR in development works out-of-the-box without running another process

