### PR TITLE
Ukrainian translation fix

### DIFF
--- a/client/strings/uk.json
+++ b/client/strings/uk.json
@@ -262,7 +262,7 @@
   "LabelBackupsNumberToKeepHelp": "Видаляється лише 1 резервна копія за раз, тому якщо у вас більше копій, видаліть їх вручну.",
   "LabelBitrate": "Бітрейт",
   "LabelBonus": "Бонус",
-  "LabelBooks": "Книги",
+  "LabelBooks": "Книг",
   "LabelButtonText": "Текст кнопки",
   "LabelByAuthor": "від {0}",
   "LabelChangePassword": "Змінити пароль",


### PR DESCRIPTION
## Brief summary

Ukrainian translation fixes
1. Differentiation between "download" and "upload" both words were translated the same
2. Lexical, grammatical and logical fixes

## Which issue is fixed?

No issue

## In-depth Description

No description needed

## How have you tested this?

No tests needed


