### PR TITLE
POC: Add LastSeenManager to batch user activity updates

### DIFF
--- a/server/Server.js
+++ b/server/Server.js
@@ -37,6 +37,7 @@ const CronManager = require('./managers/CronManager')
 const ApiCacheManager = require('./managers/ApiCacheManager')
 const BinaryManager = require('./managers/BinaryManager')
 const ShareManager = require('./managers/ShareManager')
+const LastSeenManager = require('./managers/LastSeenManager')
 const LibraryScanner = require('./scanner/LibraryScanner')
 
 //Import the main Passport and Express-Session library
@@ -107,6 +108,7 @@ class Server {
     this.cronManager = new CronManager(this.podcastManager, this.playbackSessionManager)
     this.apiCacheManager = new ApiCacheManager()
     this.binaryManager = new BinaryManager()
+    this.lastSeenManager = new LastSeenManager()
 
     // Routers
     this.apiRouter = new ApiRouter(this)
@@ -128,6 +130,20 @@ class Server {
   authMiddleware(req, res, next) {
     // ask passportjs if the current request is authenticated
     this.auth.isAuthenticated(req, res, next)
+  }
+
+  /**
+   * Middleware to track user activity for lastSeen updates
+   *
+   * @param {import('express').Request} req
+   * @param {import('express').Response} res
+   * @param {import('express').NextFunction} next
+   */
+  lastSeenMiddleware(req, res, next) {
+    if (req.user && req.user.id) {
+      this.lastSeenManager.addActiveUser(req.user.id)
+    }
+    next()
   }
 
   cancelLibraryScan(libraryId) {
@@ -174,6 +190,7 @@ class Server {
     const libraries = await Database.libraryModel.getAllWithFolders()
     await this.cronManager.init(libraries)
     this.apiCacheManager.init()
+    this.lastSeenManager.init()
 
     if (Database.serverSettings.scannerDisableWatcher) {
       Logger.info(`[Server] Watcher is disabled`)
@@ -311,7 +328,7 @@ class Server {
     router.use(express.urlencoded({ extended: true, limit: '5mb' }))
     router.use(express.json({ limit: '10mb' }))
 
-    router.use('/api', this.auth.ifAuthNeeded(this.authMiddleware.bind(this)), this.apiRouter.router)
+    router.use('/api', this.auth.ifAuthNeeded(this.authMiddleware.bind(this)), this.lastSeenMiddleware.bind(this), this.apiRouter.router)
     router.use('/hls', this.hlsRouter.router)
     router.use('/public', this.publicRouter.router)
 
@@ -499,6 +516,13 @@ class Server {
    */
   async stop() {
     Logger.info('=== Stopping Server ===')
+
+    // Cleanup LastSeenManager first to flush any pending updates
+    if (this.lastSeenManager) {
+      await this.lastSeenManager.cleanup()
+      Logger.info('[Server] LastSeenManager Cleaned Up')
+    }
+
     Watcher.close()
     Logger.info('[Server] Watcher Closed')
     await SocketAuthority.close()

--- a/server/SocketAuthority.js
+++ b/server/SocketAuthority.js
@@ -269,9 +269,11 @@ class SocketAuthority {
 
     this.adminEmitter('user_online', client.user.toJSONForPublic(this.Server.playbackSessionManager.sessions))
 
-    // Update user lastSeen without firing sequelize bulk update hooks
-    user.lastSeen = Date.now()
-    await user.save({ hooks: false })
+    if (this.Server.lastSeenManager) {
+      this.Server.lastSeenManager.addActiveUser(user.id)
+      // To ensure actual lastSeen behaviour does not change, we just flush when connecting. This should not add much overhead as this is only for the authenticated socket.
+      this.Server.lastSeenManager.flushActiveUsers()
+    }
 
     const initialPayload = {
       userId: client.user.id,

--- a/server/managers/LastSeenManager.js
+++ b/server/managers/LastSeenManager.js
@@ -1,0 +1,114 @@
+const Logger = require('../Logger')
+const Database = require('../Database')
+
+/**
+ * Manager for handling lastSeen updates
+ */
+class LastSeenManager {
+  constructor() {
+    /** @type {Set<string>} Set of user IDs that have made requests */
+    this.activeUsers = new Set()
+
+    /** @type {NodeJS.Timeout} Flush interval timer */
+    this.flushInterval = null
+
+    /** @type {number} Flush interval */
+    this.flushIntervalMs = 1000 * 60 * 5
+  }
+
+  /**
+   * Initialize the LastSeenManager
+   * Start the periodic flush process
+   */
+  init() {
+    Logger.info('[LastSeenManager] Initializing')
+    this.startFlushInterval()
+  }
+
+  /**
+   * Start the periodic flush interval
+   */
+  startFlushInterval() {
+    if (this.flushInterval) {
+      clearInterval(this.flushInterval)
+    }
+
+    this.flushInterval = setInterval(() => {
+      this.flushActiveUsers()
+    }, this.flushIntervalMs)
+
+    Logger.info(`[LastSeenManager] Started flush interval every ${this.flushIntervalMs / 1000} seconds`)
+  }
+
+  /**
+   * Stop the flush interval
+   */
+  stopFlushInterval() {
+    if (this.flushInterval) {
+      clearInterval(this.flushInterval)
+      this.flushInterval = null
+      Logger.info('[LastSeenManager] Stopped flush interval')
+    }
+  }
+
+  /**
+   * Add a user to the active users set
+   * @param {string} userId - User ID
+   */
+  addActiveUser(userId) {
+    if (userId) {
+      this.activeUsers.add(userId)
+    }
+  }
+
+  /**
+   * Flush all active users to the database and clear the set
+   * Updates lastSeen timestamp for all users in the set
+   */
+  async flushActiveUsers() {
+    if (this.activeUsers.size === 0) {
+      Logger.debug('[LastSeenManager] No active users to flush')
+      return
+    }
+
+    const userIds = Array.from(this.activeUsers)
+    const currentTime = Date.now()
+
+    Logger.debug(`[LastSeenManager] Flushing ${userIds.length} active users to database`)
+
+    try {
+      const affectedRows = await Database.userModel.update(
+        { lastSeen: new Date(currentTime) },
+        {
+          where: {
+            id: userIds
+          },
+          hooks: false
+        }
+      )
+
+      Logger.debug(`[LastSeenManager] Successfully updated lastSeen for ${affectedRows[0]} users`)
+
+      // Clear the active users set
+      this.activeUsers.clear()
+    } catch (error) {
+      Logger.error(`[LastSeenManager] Failed to flush active users:`, error)
+    }
+  }
+
+  async forceFlush() {
+    Logger.info('[LastSeenManager] Force flushing active users')
+    await this.flushActiveUsers()
+  }
+
+  /**
+   * Cleanup and stop all processes
+   */
+  async cleanup() {
+    Logger.info('[LastSeenManager] Cleaning up')
+    this.stopFlushInterval()
+    await this.forceFlush()
+  }
+}
+
+module.exports = LastSeenManager


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

This pull request introduces a new `LastSeenManager` to handle user activity tracking and periodic updates to the `lastSeen` timestamp in the database without just relying on the socket. The changes integrate this manager into the server's lifecycle.

## Which issue is fixed?

N/A

## In-depth Description

Collects users into a Set, flushes every 5 minutes, and sets the timestamp. This is not very accurate (it can be up to 5 minutes off), but it should be the most efficient solution. It might be okay to add the real timestamp, but I think it is not necessary. When authentication happens, the time is updated accurately. So we just add a estimate and do not change the current behaviour

## How have you tested this?

My own server

## Screenshots

N/A