### PR TITLE
Fix scanner after deleting single file books #4459

### DIFF
--- a/server/scanner/LibraryItemScanner.js
+++ b/server/scanner/LibraryItemScanner.js
@@ -206,6 +206,11 @@ class LibraryItemScanner {
   async scanPotentialNewLibraryItem(libraryItemPath, library, folder, isSingleMediaItem) {
     const libraryItemScanData = await this.getLibraryItemScanData(libraryItemPath, library, folder, isSingleMediaItem)
 
+    if (!libraryItemScanData.libraryFiles.length) {
+      Logger.info(`[LibraryItemScanner] Library item at path "${libraryItemPath}" has no files - ignoring`)
+      return null
+    }
+
     const scanLogger = new ScanLogger()
     scanLogger.verbose = true
     scanLogger.setData('libraryItem', libraryItemScanData.relPath)

--- a/server/scanner/LibraryScanner.js
+++ b/server/scanner/LibraryScanner.js
@@ -606,6 +606,11 @@ class LibraryScanner {
       } else if (library.settings.audiobooksOnly && !hasAudioFiles(fileUpdateGroup, itemDir)) {
         Logger.debug(`[LibraryScanner] Folder update for relative path "${itemDir}" has no audio files`)
         continue
+      } else if (!(await fs.pathExists(fullPath))) {
+        Logger.info(`[LibraryScanner] File update group "${itemDir}" does not exist - ignoring`)
+
+        itemGroupingResults[itemDir] = ScanResult.NOTHING
+        continue
       }
 
       // Check if a library item is a subdirectory of this dir

--- a/server/utils/fileUtils.js
+++ b/server/utils/fileUtils.js
@@ -109,7 +109,7 @@ function getIno(path) {
     .stat(path, { bigint: true })
     .then((data) => String(data.ino))
     .catch((err) => {
-      Logger.error('[Utils] Failed to get ino for path', path, err)
+      Logger.warn(`[Utils] Failed to get ino for path "${path}"`, err)
       return null
     })
 }


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

When deleting a single file book via the web ui the scanner re-adds the item

## Which issue is fixed?

Fixes #4459

## In-depth Description

Reproducible steps in #4459 

The issue is single file books in the root folder don't run `recurseFiles` that is normally run on a folder getting scanned in. The single file book is not checked if it exists like a folder is.

This PR updates the scanner to add that check. It will also bail earlier when a scan runs after deleting a library item folder.

I also updated the file utils `getIno` to log a warning instead of an error since it is not an error when a file doesn't exist.

