### PR TITLE
Make cache and metadata directories during Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,5 +69,8 @@ ENV SOURCE="docker"
 ENV NUSQLITE3_DIR=${NUSQLITE3_DIR}
 ENV NUSQLITE3_PATH=${NUSQLITE3_PATH}
 
+# Construct cache and metadata directories
+RUN mkdir -p ${CONFIG_PATH} ${METADATA_PATH} && chmod 777 ${CONFIG_PATH} ${METADATA_PATH}
+
 ENTRYPOINT ["tini", "--"]
 CMD ["node", "index.js"]


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

Make the cache and metadata directories with global permissions during image creation. This allows the container to run as a non-root user.

## Which issue is fixed?

Closes #4471

## In-depth Description

By creating the directories during image creation with global permissions non-root users are able to read/write files into them. However, this only works with the default cache and metadata paths. If a user wishes to modify these paths (why?!) they will not be able to run as non-root.

Users using bind mounts will also have to ensure the paths on the host have permissions for the user to access them.

By creating the directories during image creation we also avoid chmoding the directories at runtime so we won't run afoul of #2057

## How have you tested this?

Using the docker compose in #4471, I brought the container up from scratch with fresh volumes. If the user attempts to switch from root to a non-root user with existing metadata and cache they might still run into permission issues.

## Screenshots

<!-- If your PR includes any changes to the web client, please include screenshots or a short video from before and after your changes. -->
