### PR TITLE
Fix OIDC auto register user #4485

### DIFF
--- a/server/auth/OidcAuthStrategy.js
+++ b/server/auth/OidcAuthStrategy.js
@@ -121,7 +121,7 @@ class OidcAuthStrategy {
         throw new Error(`Group claim ${Database.serverSettings.authOpenIDGroupClaim} not found or empty in userinfo`)
       }
 
-      let user = await Database.userModel.findOrCreateUserFromOpenIdUserInfo(userinfo, this)
+      let user = await Database.userModel.findOrCreateUserFromOpenIdUserInfo(userinfo)
 
       if (!user?.isActive) {
         throw new Error('User not active or not found')

--- a/server/auth/TokenManager.js
+++ b/server/auth/TokenManager.js
@@ -82,6 +82,18 @@ class TokenManager {
   }
 
   /**
+   * Generate a JWT token for a given user
+   * TODO: Old method with no expiration
+   * @deprecated
+   *
+   * @param {{ id:string, username:string }} user
+   * @returns {string}
+   */
+  static generateAccessToken(user) {
+    return jwt.sign({ userId: user.id, username: user.username }, TokenManager.TokenSecret)
+  }
+
+  /**
    * Function to generate a jwt token for a given user
    * TODO: Old method with no expiration
    * @deprecated
@@ -90,7 +102,7 @@ class TokenManager {
    * @returns {string}
    */
   generateAccessToken(user) {
-    return jwt.sign({ userId: user.id, username: user.username }, TokenManager.TokenSecret)
+    return TokenManager.generateAccessToken(user)
   }
 
   /**


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

The OIDC auth refactor caused the generate access token function to be unavailable when auto registering a user.

This adds a static generate token function.

When the old auth method gets removed this won't be necessary and those functions will be removed.

## Which issue is fixed?

Fixes #4485

