### PR TITLE
Fix set token on page load #4509

### DIFF
--- a/client/pages/login.vue
+++ b/client/pages/login.vue
@@ -191,7 +191,10 @@ export default {
 
       this.$store.commit('libraries/setCurrentLibrary', userDefaultLibraryId)
       this.$store.commit('user/setUser', user)
-      this.$store.commit('user/setAccessToken', user.accessToken)
+      // Access token only returned from login, not authorize
+      if (user.accessToken) {
+        this.$store.commit('user/setAccessToken', user.accessToken)
+      }
 
       this.$store.dispatch('user/loadUserSettings')
     },
@@ -225,6 +228,8 @@ export default {
 
       this.processing = true
 
+      this.$store.commit('user/setAccessToken', token)
+
       return this.$axios
         .$post('/api/authorize', null, {
           headers: {
@@ -240,6 +245,7 @@ export default {
             this.showNewAuthSystemAdminMessage = res.user.type === 'admin' || res.user.type === 'root'
             return false
           }
+
           this.setUser(res)
           return true
         })


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

This sets `accessToken` in user store before calling authorize

## Which issue is fixed?

Fixes #4509

## Screenshots

Page load when access token is expired:
<img width="424" height="184" alt="image" src="https://github.com/user-attachments/assets/a90d1095-cdf9-49ab-ad07-fd939053b0ff" />

Regular page load:
<img width="424" height="115" alt="image" src="https://github.com/user-attachments/assets/e2df8680-9a38-43df-ae3b-5fdbb9d3fcab" />
