### PR TITLE
Fix podcast episode track index null in playback session

### DIFF
--- a/server/controllers/SessionController.js
+++ b/server/controllers/SessionController.js
@@ -288,7 +288,12 @@ class SessionController {
       return res.sendStatus(404)
     }
 
-    const audioTrack = playbackSession.audioTracks.find((t) => t.index === audioTrackIndex)
+    let audioTrack = playbackSession.audioTracks.find((t) => toNumber(t.index, 1) === audioTrackIndex)
+
+    // Support clients passing 0 or 1 for podcast episode audio track index (handles old episodes pre-v2.21.0 having null index)
+    if (!audioTrack && playbackSession.mediaType === 'podcast' && audioTrackIndex === 0) {
+      audioTrack = playbackSession.audioTracks[0]
+    }
     if (!audioTrack) {
       Logger.error(`[SessionController] Unable to find audio track with index=${audioTrackIndex}`)
       return res.sendStatus(404)

--- a/server/models/PodcastEpisode.js
+++ b/server/models/PodcastEpisode.js
@@ -185,6 +185,7 @@ class PodcastEpisode extends Model {
     const track = structuredClone(this.audioFile)
     track.startOffset = 0
     track.title = this.audioFile.metadata.filename
+    track.index = 1 // Podcast episodes only have one track
     track.contentUrl = `/api/items/${libraryItemId}/file/${track.ino}`
     return track
   }


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

Make sure podcast episode audio track index is always 1 in playback sessions & support 1 or 0 track index in the direct play endpoint.

## Which issue is fixed?

Fixes https://github.com/advplyr/audiobookshelf-app/issues/1635

## In-depth Description

In [v2.21.0](https://github.com/advplyr/audiobookshelf/releases/tag/v2.21.0) a bug was fixed where podcast episodes scanned in from the file system had an audio track with an index of `null`. https://github.com/advplyr/audiobookshelf/commit/7c114a051a08d401b5b6dded1620a6f1f92f05c0

In [v2.22.0](https://github.com/advplyr/audiobookshelf/pull/4263) new API endpoints for direct playing was added that use the audio track index in the url.

When playing an episode with an index value of `null` in the web client it falls back to transcoding because the track isn't found.

In mobile app v0.10.0-beta the new direct play endpoints are used. 
When playing the `null` index episode on iOS it falls back to transcoding. When playing on Android it crashes the server due to a bug where Android is still using the direct play endpoint when transcoding. That separate bug is how this bug was found.

The fix is to two-fold:
1. Updated the `/public/session/:id/track/:index` endpoint to support index `0` or `1` being passed in for podcast episodes.
2. Update the podcast episode audio track in the playback session to always use index 1

## How have you tested this?

Tested on web, iOS and Android with null audio track index

