### PR TITLE
Update change password to support null or empty string passwords #4522

### DIFF
--- a/server/controllers/MeController.js
+++ b/server/controllers/MeController.js
@@ -280,7 +280,7 @@ class MeController {
     }
 
     const { password, newPassword } = req.body
-    if (!password || !newPassword || typeof password !== 'string' || typeof newPassword !== 'string') {
+    if ((typeof password !== 'string' && password !== null) || (typeof newPassword !== 'string' && newPassword !== null)) {
       return res.status(400).send('Missing or invalid password or new password')
     }
 


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

Unable to change root password on account page when it is empty. And unable to set root password to empty.

## Which issue is fixed?

Fixes #4522

## In-depth Description

Allow empty string or null passwords to get passed in to `/api/me/password`


