### PR TITLE
Update SideRail.vue

### DIFF
--- a/client/components/app/SideRail.vue
+++ b/client/components/app/SideRail.vue
@@ -116,7 +116,7 @@
     </div>
 
     <div class="w-full h-12 px-1 py-2 border-t border-black/20 bg-bg absolute left-0" :style="{ bottom: streamLibraryItem ? '224px' : '65px' }">
-      <p class="underline font-mono text-xs text-center text-gray-300 leading-3 mb-1" @click="clickChangelog">v{{ $config.version }}</p>
+      <p class="underline font-mono text-xs text-center text-gray-300 leading-3 mb-1 cursor-pointer" @click="clickChangelog">v{{ $config.version }}</p>
       <a v-if="hasUpdate" :href="githubTagUrl" target="_blank" class="text-warning text-xxs text-center block leading-3">Update</a>
       <p v-else class="text-xxs text-gray-400 leading-3 text-center italic">{{ Source }}</p>
     </div>


### PR DESCRIPTION
Changed cursor at version to pointer

## Brief summary

It´s just a little CSS fix to change the cursor.

## Which issue is fixed?

On the webclient the version, which acts as a button to open the changelog menu had the wrong cursor.

## In-depth Description

Its just a quick little CSS update. It´s not a big issue but it still affects everyone who uses the webclient. It helps keeping the app more consistent.

## How have you tested this?

I set the service up locally and also reran all cypress tests to check if I somehow broke anything else.
