### PR TITLE
Fix ereader update socket event sending all devices #4529

### DIFF
--- a/server/controllers/MeController.js
+++ b/server/controllers/MeController.js
@@ -450,7 +450,7 @@ class MeController {
     if (updated) {
       await Database.updateSetting(Database.emailSettings)
       SocketAuthority.clientEmitter(req.user.id, 'ereader-devices-updated', {
-        ereaderDevices: Database.emailSettings.ereaderDevices
+        ereaderDevices: Database.emailSettings.getEReaderDevices(req.user)
       })
     }
     res.json({


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

When updating an e-reader on the account page a socket event, `ereader-devices-updated`, is sent with all the e-reader devices instead of filtered by user access.

## Which issue is fixed?

Fixes #4529

## In-depth Description

Reproduce with:
1. Log in to a user with ereader access
2. On account page make any update to an e-reader
3. Navigate to a new page and back
4. Observe all ereader devices are visible

