### PR TITLE
Use PowerShell to get windows drive paths.

### DIFF
--- a/server/utils/fileUtils.js
+++ b/server/utils/fileUtils.js
@@ -476,7 +476,7 @@ module.exports.getWindowsDrives = async () => {
     return []
   }
   return new Promise((resolve, reject) => {
-    exec('wmic logicaldisk get name', async (error, stdout, stderr) => {
+    exec('powershell -Command "(Get-PSDrive -PSProvider FileSystem).Name"', async (error, stdout, stderr) => {
       if (error) {
         reject(error)
         return
@@ -485,10 +485,9 @@ module.exports.getWindowsDrives = async () => {
         ?.split(/\r?\n/)
         .map((line) => line.trim())
         .filter((line) => line)
-        .slice(1)
       const validDrives = []
       for (const drive of drives) {
-        let drivepath = drive + '/'
+        let drivepath = drive + ':/'
         if (await fs.pathExists(drivepath)) {
           validDrives.push(drivepath)
         } else {


### PR DESCRIPTION
wmic has been deprecated on newer versions of Windows 11 and is not installed.

## Brief summary

Allows windows 11 users to select paths for their library w/o having to manually enable wmic.

## Which issue is fixed?

fixes #4531

## In-depth Description

It uses PowerShell to get drive letters instead of wmic, 
It works since PowerShell is also installed on all Windows boxes.
2 users have reported it (mikiher/audiobookshelf-windows/issues/40 and #4531), but it'll impact anyone on the latest version of Windows 11 that do not enable wmic as a workaround.

## How have you tested this?

I just tested the changes manually in a node repl to ensure the output was the same on a windows box:
```javascript
const { exec } = require('child_process');

// old command
exec('wmic logicaldisk get name', (error, stdout, stderr) => {
  if (error) {
    console.error('Error:', error);
    return;
  }

  const drives = stdout
    ?.split(/\r?\n/)
    .map((line) => line.trim())
    .filter((line) => line)
    .slice(1);

  const validDrives = drives.map((drive) => `${drive}/`);
  console.log('Valid Drives:', validDrives);
});

// new command
exec('powershell -Command "(Get-PSDrive -PSProvider FileSystem).Name"', (error, stdout, stderr) => {
  if (error) {
    console.error('Error:', error);
    return;
  }

  const drives = stdout
    ?.split(/\r?\n/)
    .map((line) => line.trim())
    .filter((line) => line);

  const validDrives = drives.map((drive) => `${drive}:/`);
  console.log('Valid Drives:', validDrives);
});
```
