### PR TITLE
Including total durations into the de-branding from #4226 as warning message is always present currently

### DIFF
--- a/client/pages/audiobook/_id/chapters.vue
+++ b/client/pages/audiobook/_id/chapters.vue
@@ -609,6 +609,11 @@ export default {
           data.chapters.pop()
         }
 
+        // Remove Branding durations from Runtime totals
+        data.runtimeLengthMs -= introDuration + outroDuration
+        data.runtimeLengthSec = Math.floor(data.runtimeLengthMs / 1000)
+        console.log('Brandless Chapter data', data)
+
         return data
       } catch {
         return data

--- a/client/pages/audiobook/_id/chapters.vue
+++ b/client/pages/audiobook/_id/chapters.vue
@@ -572,7 +572,7 @@ export default {
           if (data.error) {
             this.asinError = this.$getString(data.stringKey)
           } else {
-            console.log('Chapter data', data)
+            console.log('Chapter data', { ...data })
             this.chapterData = this.removeBranding ? this.removeBrandingFromData(data) : data
           }
         })


### PR DESCRIPTION
## Brief summary

Issue #4226 introduced the ability to remove the audible branding when editing chapters. While it does this well for the chapters themselves, all other validations do not account for it. This update is to remove the branding times from the runtime totals as well.

## Which issue is fixed?

Related to #4226

## In-depth Description

Although the branding times are removed and the chapters are shifted, you will always receive the warning that the total time doesn't match you local audio files. This is because the #4226 feature didn't also remove the branding from the total runtime. This update also removes the intro/outro branding times from the total duration, which is used in the validation logic.

## How have you tested this?

I did not test this. Not sure how.

## Screenshots

The branding time in the example below is 6,873 millis, which results in the difference of 7 secs.
<img width="536" height="283" alt="image" src="https://github.com/user-attachments/assets/a1e2d507-7ab6-4fd4-9a60-3197b88e4438" />

