### PR TITLE
Fixes hls crash on Android

### DIFF
--- a/server/controllers/SessionController.js
+++ b/server/controllers/SessionController.js
@@ -302,6 +302,16 @@ class SessionController {
     const user = await Database.userModel.getUserById(playbackSession.userId)
     Logger.debug(`[SessionController] Serving audio track ${audioTrack.index} for session "${req.params.id}" belonging to user "${user.username}"`)
 
+    // Handle HLS streams - they have contentUrl and mimeType set but no metadata
+    if (!audioTrack.metadata && audioTrack.contentUrl) {
+      Logger.debug(`[SessionController] Redirecting to HLS stream: ${audioTrack.contentUrl}`)
+      if (audioTrack.mimeType) {
+        res.setHeader('Content-Type', audioTrack.mimeType)
+      }
+      return res.redirect(audioTrack.contentUrl)
+    }
+
+    // Handle regular audio files
     if (global.XAccel) {
       const encodedURI = encodeUriPath(global.XAccel + audioTrack.metadata.path)
       Logger.debug(`Use X-Accel to serve static file ${encodedURI}`)


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

The new getTrack is made for real files instead of hls streams. Since we use the metadata object, which does not exist on the hls audioTrack object, the server crashes. This PR adds a redirect to the hls source. I have NOT checked if it works with the android app and if it can follow redirects, but this at least stops the server from crashing. The hls stream should be reached using the correct URL anyway (shouldn't it?).

I am not up to date on the mobile repo, but it would need to be changed (in case it does not follow redirects) so it requests hls streams directly

## Which issue is fixed?

fixes https://github.com/advplyr/audiobookshelf/issues/4555

## In-depth Description

<!--
Describe your solution in more depth.
How does it work? Why is this the best solution?
Does it solve a problem that affects multiple users or is this an edge case for your setup?
-->

Look at the code xD. Short description should give enough hints.
SessionController.js
PlaybackSessionManager.js
AudioTrack.js

## How have you tested this?

local dev server

## Screenshots

<!-- If your PR includes any changes to the web client, please include screenshots or a short video from before and after your changes. -->
