### PR TITLE
Fix authorize race condition by not updating the user on token refresh

### DIFF
--- a/client/layouts/default.vue
+++ b/client/layouts/default.vue
@@ -199,7 +199,7 @@ export default {
           }
         } else {
           console.error('User has no more accessible libraries')
-          this.$store.commit('libraries/setCurrentLibrary', null)
+          this.$store.commit('libraries/setCurrentLibrary', { id: null })
         }
       }
     },

--- a/client/pages/login.vue
+++ b/client/pages/login.vue
@@ -189,7 +189,7 @@ export default {
         require('@/plugins/chromecast.js').default(this)
       }
 
-      this.$store.commit('libraries/setCurrentLibrary', userDefaultLibraryId)
+      this.$store.commit('libraries/setCurrentLibrary', { id: userDefaultLibraryId })
       this.$store.commit('user/setUser', user)
       // Access token only returned from login, not authorize
       if (user.accessToken) {

--- a/client/store/libraries.js
+++ b/client/store/libraries.js
@@ -133,7 +133,7 @@ export const actions = {
         commit('setNumUserPlaylists', numUserPlaylists)
         commit('scanners/setCustomMetadataProviders', customMetadataProviders, { root: true })
 
-        commit('setCurrentLibrary', libraryId)
+        commit('setCurrentLibrary', { id: libraryId })
         return data
       })
       .catch((error) => {
@@ -182,8 +182,8 @@ export const mutations = {
   setLibraryIssues(state, val) {
     state.issues = val
   },
-  setCurrentLibrary(state, val) {
-    state.currentLibraryId = val
+  setCurrentLibrary(state, { id }) {
+    state.currentLibraryId = id
   },
   set(state, libraries) {
     state.libraries = libraries

--- a/client/store/user.js
+++ b/client/store/user.js
@@ -152,7 +152,6 @@ export const actions = {
       .$post('/auth/refresh')
       .then(async (response) => {
         const newAccessToken = response.user.accessToken
-        commit('setUser', response.user)
         commit('setAccessToken', newAccessToken)
         // Emit event used to re-authenticate socket in default.vue since $root is not available here
         if (this.$eventBus) {


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

Fixes a race condition happening when refreshing the access token on initial page load.

## Which issue is fixed?

Fixes #4567

## In-depth Description

When refreshing the access token on `/api/authorize` the response from the `/auth/refresh` is updating the user. This user update is triggering the user watcher in `login.vue` before the default library id is set.

There is no reason to update the user from the token refresh response so that is removed
