### PR TITLE
Fix listening url log with ipv6 host

### DIFF
--- a/server/Server.js
+++ b/server/Server.js
@@ -11,6 +11,7 @@ const axios = require('axios')
 const { version } = require('../package.json')
 
 // Utils
+const is = require('./libs/requestIp/isJs')
 const fileUtils = require('./utils/fileUtils')
 const { toNumber } = require('./utils/index')
 const Logger = require('./Logger')
@@ -419,8 +420,13 @@ class Server {
       })
     } else {
       this.server.listen(this.Port, this.Host, () => {
-        if (this.Host) Logger.info(`Listening on http://${this.Host}:${this.Port}`)
-        else Logger.info(`Listening on port :${this.Port}`)
+        if (this.Host) {
+          let host = this.Host
+          if (is.ipv6(host)) {
+            host = '[' + host + ']'
+          }
+          Logger.info(`Listening on http://${host}:${this.Port}`)
+        } else Logger.info(`Listening on port :${this.Port}`)
       })
     }
 

--- a/server/Server.js
+++ b/server/Server.js
@@ -420,13 +420,8 @@ class Server {
       })
     } else {
       this.server.listen(this.Port, this.Host, () => {
-        if (this.Host) {
-          let host = this.Host
-          if (is.ipv6(host)) {
-            host = '[' + host + ']'
-          }
-          Logger.info(`Listening on http://${host}:${this.Port}`)
-        } else Logger.info(`Listening on port :${this.Port}`)
+        if (this.Host) Logger.info(`Listening on http://${is.ipv6(this.Host) ? `[${this.Host}]` : this.Host}:${this.Port}`)
+        else Logger.info(`Listening on port :${this.Port}`)
       })
     }
 


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

Fix incorrect listening url in log when use ipv6 host

## In-depth Description

Run with ipv6 host return incorrect url in log:
```
> node index.js --host ::
...
[2025-08-16 17:55:56.554] INFO: Listening on http://:::12378
...
```

After change:
```
> node index.js --host ::
...
[2025-08-16 17:55:56.554] INFO: Listening on http://[::]:12378
...
```
