### PR TITLE
Fix freeze on some audio sources

### DIFF
--- a/server/utils/ffmpegHelpers.js
+++ b/server/utils/ffmpegHelpers.js
@@ -118,6 +118,7 @@ module.exports.downloadPodcastEpisode = (podcastEpisodeDownload) => {
           method: 'GET',
           responseType: 'stream',
           headers: {
+            'Accept': '*/*',
             'User-Agent': userAgent
           },
           timeout: global.PodcastDownloadTimeout


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

Fixed freeze when downloading some episodes.

## In-depth Description

On one of the podcasts (https://podster.fm/rss.xml?pid=48291), a situation arose where the download did not complete when downloading an episode. Even timeouts did not work. Through trial and error, I found out that the request would complete with a 200 status code, but would return an empty stream, causing ffmpeg to wait indefinitely for the input stream.

I found out that the podcast did not like the value passed in Accept. By default, `Accept: application/json, text/plain, */*` is passed. But if you pass `Accept: */*`, everything starts working and produces the necessary redirects.

## How have you tested this?

I checked all my podcasts for functionality on the master version with this change.

