### PR TITLE
Update podcast episode downloads to always attempt embedding meta tags

### DIFF
--- a/server/managers/PodcastManager.js
+++ b/server/managers/PodcastManager.js
@@ -121,28 +121,17 @@ class PodcastManager {
       await fs.mkdir(this.currentDownload.libraryItem.path)
     }
 
-    let success = false
-    if (this.currentDownload.isMp3) {
-      // Download episode and tag it
-      const ffmpegDownloadResponse = await ffmpegHelpers.downloadPodcastEpisode(this.currentDownload).catch((error) => {
-        Logger.error(`[PodcastManager] Podcast Episode download failed`, error)
-      })
-      success = !!ffmpegDownloadResponse?.success
+    // Download episode and tag it
+    const ffmpegDownloadResponse = await ffmpegHelpers.downloadPodcastEpisode(this.currentDownload).catch((error) => {
+      Logger.error(`[PodcastManager] Podcast Episode download failed`, error)
+    })
+    let success = !!ffmpegDownloadResponse?.success
 
-      // If failed due to ffmpeg error, retry without tagging
-      // e.g. RSS feed may have incorrect file extension and file type
-      // See https://github.com/advplyr/audiobookshelf/issues/3837
-      if (!success && ffmpegDownloadResponse?.isFfmpegError) {
-        Logger.info(`[PodcastManager] Retrying episode download without tagging`)
-        // Download episode only
-        success = await downloadFile(this.currentDownload.url, this.currentDownload.targetPath)
-          .then(() => true)
-          .catch((error) => {
-            Logger.error(`[PodcastManager] Podcast Episode download failed`, error)
-            return false
-          })
-      }
-    } else {
+    // If failed due to ffmpeg error, retry without tagging
+    // e.g. RSS feed may have incorrect file extension and file type
+    // See https://github.com/advplyr/audiobookshelf/issues/3837
+    if (!success && ffmpegDownloadResponse?.isFfmpegError) {
+      Logger.info(`[PodcastManager] Retrying episode download without tagging`)
       // Download episode only
       success = await downloadFile(this.currentDownload.url, this.currentDownload.targetPath)
         .then(() => true)

--- a/server/objects/PodcastEpisodeDownload.js
+++ b/server/objects/PodcastEpisodeDownload.js
@@ -63,16 +63,6 @@ class PodcastEpisodeDownload {
     const enclosureType = this.rssPodcastEpisode.enclosure.type
     return typeof enclosureType === 'string' ? enclosureType : null
   }
-  /**
-   * RSS feed may have an episode with file extension of mp3 but the specified enclosure type is not mpeg.
-   * @see https://github.com/advplyr/audiobookshelf/issues/3711
-   *
-   * @returns {boolean}
-   */
-  get isMp3() {
-    if (this.enclosureType && !this.enclosureType.includes('mpeg')) return false
-    return this.fileExtension === 'mp3'
-  }
   get episodeTitle() {
     return this.rssPodcastEpisode.title
   }


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

This removes the `isMp3` check that was used to only embed meta tags in mp3 podcast episodes. Now all episode downloads will attempt to have meta tags embedded and fallback to a regular download.

## Which issue is fixed?

None, discussed in Discord

## In-depth Description

A tangentially related issue to this is that some podcast RSS feeds provide the wrong file extension. For example, in #3837 the podcast has `.mp3` file extension but the files are actually mp4. In this case the ffmpeg meta tag embed will fail and the episode will fallback to being downloaded without meta tagging.

## How have you tested this?

Example RSS feed with 3 `.m4a` files: <https://anchor.fm/s/370d6ccc/podcast/rss>
Example RSS feed with `.ogg` files: <https://feeds.feedburner.com/TheLinuxLinkTechShowOgg-vorbisFeed>

