### PR TITLE
Remove token from hls url

### DIFF
--- a/server/objects/Stream.js
+++ b/server/objects/Stream.js
@@ -146,7 +146,7 @@ class Stream extends EventEmitter {
 
   async generatePlaylist() {
     await fs.ensureDir(this.streamPath)
-    await hlsPlaylistGenerator(this.playlistPath, 'output', this.totalDuration, this.segmentLength, this.hlsSegmentType, this.userToken)
+    await hlsPlaylistGenerator(this.playlistPath, 'output', this.totalDuration, this.segmentLength, this.hlsSegmentType)
     return this.clientPlaylistUri
   }
 

--- a/server/utils/generators/hlsPlaylistGenerator.js
+++ b/server/utils/generators/hlsPlaylistGenerator.js
@@ -1,6 +1,6 @@
 const fs = require('../../libs/fsExtra')
 
-function getPlaylistStr(segmentName, duration, segmentLength, hlsSegmentType, token) {
+function getPlaylistStr(segmentName, duration, segmentLength, hlsSegmentType) {
   var ext = hlsSegmentType === 'fmp4' ? 'm4s' : 'ts'
 
   var lines = [
@@ -18,18 +18,18 @@ function getPlaylistStr(segmentName, duration, segmentLength, hlsSegmentType, to
   var lastSegment = duration - (numSegments * segmentLength)
   for (let i = 0; i < numSegments; i++) {
     lines.push(`#EXTINF:6,`)
-    lines.push(`${segmentName}-${i}.${ext}?token=${token}`)
+    lines.push(`${segmentName}-${i}.${ext}`)
   }
   if (lastSegment > 0) {
     lines.push(`#EXTINF:${lastSegment},`)
-    lines.push(`${segmentName}-${numSegments}.${ext}?token=${token}`)
+    lines.push(`${segmentName}-${numSegments}.${ext}`)
   }
   lines.push('#EXT-X-ENDLIST')
   return lines.join('\n')
 }
 
-function generatePlaylist(outputPath, segmentName, duration, segmentLength, hlsSegmentType, token) {
-  var playlistStr = getPlaylistStr(segmentName, duration, segmentLength, hlsSegmentType, token)
+function generatePlaylist(outputPath, segmentName, duration, segmentLength, hlsSegmentType) {
+  var playlistStr = getPlaylistStr(segmentName, duration, segmentLength, hlsSegmentType)
   return fs.writeFile(outputPath, playlistStr)
 }
 module.exports = generatePlaylist


### PR DESCRIPTION


<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

PR #4266 removed authorization for hls streams so there is no need to add the token to the url of the audio chucks

## Which issue is fixed?

Following PR #4263

## In-depth Description

Showing the token in the URL could be unsafe in some situations

## How have you tested this?

Browser with custom client

## Screenshots

<img width="293" height="84" alt="Screenshot 2025-08-19 at 15 44 06" src="https://github.com/user-attachments/assets/a7dc7790-aabb-4605-851e-e44ee30387f2" />

<img width="327" height="153" alt="Screenshot 2025-08-19 at 15 46 02" src="https://github.com/user-attachments/assets/e729e4e1-3778-4db4-96af-79869da8e7e6" />


