### PR TITLE
Fix various typos

### DIFF
--- a/client/cypress/tests/components/cards/LazyBookCard.cy.js
+++ b/client/cypress/tests/components/cards/LazyBookCard.cy.js
@@ -238,7 +238,7 @@ describe('LazyBookCard', () => {
       }
     })
 
-    it('shows the collpased series', () => {
+    it('shows the collapsed series', () => {
       cy.mount(LazyBookCard, mountOptions)
 
       cy.get('&titleImageNotReady').should('be.hidden')

--- a/client/mixins/uploadHelpers.js
+++ b/client/mixins/uploadHelpers.js
@@ -70,7 +70,7 @@ export default {
       }
     },
     fileTreeToItems(filetree, mediaType) {
-      // Has directores - Is Multi Book Drop
+      // Has directories - Is Multi Book Drop
       if (filetree.some((f) => f.isDirectory)) {
         var ignoredFilesInRoot = filetree.filter((f) => !f.isDirectory)
         if (ignoredFilesInRoot.length) filetree = filetree.filter((f) => f.isDirectory)

--- a/docs/objects/mediaTypes/Podcast.yaml
+++ b/docs/objects/mediaTypes/Podcast.yaml
@@ -53,7 +53,7 @@ components:
           description: The maximum number of episodes to keep.
         maxNewEpisodesToDownload:
           type: integer
-          description: The maximum number of new episodes to download when automatically downloading epsiodes.
+          description: The maximum number of new episodes to download when automatically downloading episodes.
         lastCoverSearch:
           type: integer
           description: The timestamp of the last cover search.

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3973,7 +3973,7 @@
           },
           "maxNewEpisodesToDownload": {
             "type": "integer",
-            "description": "The maximum number of new episodes to download when automatically downloading epsiodes."
+            "description": "The maximum number of new episodes to download when automatically downloading episodes."
           },
           "lastCoverSearch": {
             "type": "integer",

--- a/readme.md
+++ b/readme.md
@@ -342,7 +342,7 @@ The `Name` needs to match the `Parameters` above `audiobookshelf`.
 
 ##### Health checking:
 
-Health checking is enabled by default. `Http check method` of `OPTIONS` is not supported on Audiobookshelf. If Health check fails, data will not be forwared. Need to do one of following:
+Health checking is enabled by default. `Http check method` of `OPTIONS` is not supported on Audiobookshelf. If Health check fails, data will not be forwarded. Need to do one of following:
 
 - To disable: Change `Health check method` to `none`.
 - To make Health checking function: Change `Http check method` to `HEAD` or `GET`.

--- a/server/auth/OidcAuthStrategy.js
+++ b/server/auth/OidcAuthStrategy.js
@@ -405,7 +405,7 @@ class OidcAuthStrategy {
       //  the post_logout_redirect_uri parameter at all and for other providers
       //  we would also need again to implement (and even before get to know somehow for 3rd party apps)
       //  the correct app link like audiobookshelf://login (and maybe also provide a redirect like mobile-redirect).
-      //   Instead because its null (and this way the parameter will be omitted completly), the client/app can simply append something like
+      //   Instead because its null (and this way the parameter will be omitted completely), the client/app can simply append something like
       //  &post_logout_redirect_uri=audiobookshelf://login to the received logout url by itself which is the simplest solution
       //   (The URL needs to be whitelisted in the config of the SSO/ID provider)
 

--- a/server/finders/BookFinder.js
+++ b/server/finders/BookFinder.js
@@ -345,7 +345,7 @@ class BookFinder {
       }
       const results = [...new Set(await Promise.all(promises))]
       filteredCandidates = results.filter((author) => author)
-      // If no valid candidates were found, add back an aggresively cleaned author version
+      // If no valid candidates were found, add back an aggressively cleaned author version
       if (!filteredCandidates.length && this.cleanAuthor) filteredCandidates.push(this.agressivelyCleanAuthor)
       // Always add an empty author candidate
       filteredCandidates.push('')
@@ -403,7 +403,7 @@ class BookFinder {
 
       // Remove underscores and parentheses with their contents, and replace with a separator
       const cleanTitle = title.replace(/\[.*?\]|\(.*?\)|{.*?}|_/g, ' - ')
-      // Split title into hypen-separated parts
+      // Split title into hyphen-separated parts
       const titleParts = cleanTitle.split(/ - | -|- /)
       for (const titlePart of titleParts) authorCandidates.add(titlePart)
       authorCandidates = await authorCandidates.getCandidates()
@@ -659,7 +659,7 @@ function cleanTitleForCompares(title, keepSubtitle = false) {
   // Remove subtitle if there (i.e. "Cool Book: Coolest Ever" becomes "Cool Book")
   let stripped = keepSubtitle ? title : stripSubtitle(title)
 
-  // Remove text in paranthesis (i.e. "Ender's Game (Ender's Saga)" becomes "Ender's Game")
+  // Remove text in parenthesis (i.e. "Ender's Game (Ender's Saga)" becomes "Ender's Game")
   let cleaned = stripped.replace(/ *\([^)]*\) */g, '')
 
   // Remove single quotes (i.e. "Ender's Game" becomes "Enders Game")

--- a/server/libs/archiver/archiverUtils/fsRealpath/old.js
+++ b/server/libs/archiver/archiverUtils/fsRealpath/old.js
@@ -67,7 +67,7 @@ function maybeCallback(cb) {
   return typeof cb === 'function' ? cb : rethrow();
 }
 
-// Regexp that finds the next partion of a (partial) path
+// Regexp that finds the next portion of a (partial) path
 // result is [base_with_slash, base], e.g. ['somedir/', 'somedir']
 if (isWindows) {
   var nextPartRe = /(.*?)(?:[\/\\]+|$)/g;

--- a/server/libs/commandLineArgs/index.js
+++ b/server/libs/commandLineArgs/index.js
@@ -280,7 +280,7 @@ class ArgvArray extends Array {
  * @static
  */
 function expandCombinedShortArg(arg) {
-  /* remove initial hypen */
+  /* remove initial hyphen */
   arg = arg.slice(1);
   return arg.split('').map(letter => '-' + letter)
 }
@@ -875,7 +875,7 @@ class Definitions extends Array {
     if (someDontHaveFunctionType) {
       halt(
         'INVALID_DEFINITIONS',
-        'Invalid option definitions: the `type` property must be a setter fuction (default: `Boolean`)'
+        'Invalid option definitions: the `type` property must be a setter function (default: `Boolean`)'
       );
     }
 
@@ -1194,7 +1194,7 @@ class Option {
         this.state = state;
       }
     } else {
-      /* throw if already set on a singlar defaultOption */
+      /* throw if already set on a singular defaultOption */
       if (!def.isMultiple() && this.state === 'set') {
         const err = new Error(`Singular option already set [${this.definition.name}=${this.get()}]`);
         err.name = 'ALREADY_SET';

--- a/server/libs/fsExtra/ensure/symlink-paths.js
+++ b/server/libs/fsExtra/ensure/symlink-paths.js
@@ -23,7 +23,7 @@ const pathExists = require('../path-exists').pathExists
  * does it will use it. If it does not, it checks if there's a file that
  * exists that is relative to the current working directory, if does its used.
  * This preserves the expectations of the original fs.symlink spec and adds
- * the ability to pass in `relative to current working direcotry` paths.
+ * the ability to pass in `relative to current working directory` paths.
  */
 
 function symlinkPaths (srcpath, dstpath, callback) {

--- a/server/libs/libarchive/wasm-module.js
+++ b/server/libs/libarchive/wasm-module.js
@@ -159,7 +159,7 @@ class WasmModule {
       // const char * get_version()
       getVersion: this.cwrap('get_version', 'string', []),
       // void * archive_open( const void * buffer, size_t buffer_size)
-      // retuns archive pointer
+      // returns archive pointer
       openArchive: this.cwrap('archive_open', 'number', ['number', 'number', 'string']),
       // void * get_entry(void * archive)
       // return archive entry pointer
@@ -178,7 +178,7 @@ class WasmModule {
       /*
       #define AE_IFMT		((__LA_MODE_T)0170000)
       #define AE_IFREG	((__LA_MODE_T)0100000) // Regular file
-      #define AE_IFLNK	((__LA_MODE_T)0120000) // Sybolic link
+      #define AE_IFLNK	((__LA_MODE_T)0120000) // Symbolic link
       #define AE_IFSOCK	((__LA_MODE_T)0140000) // Socket
       #define AE_IFCHR	((__LA_MODE_T)0020000) // Character device
       #define AE_IFBLK	((__LA_MODE_T)0060000) // Block device

--- a/server/libs/passportLocal/strategy.js
+++ b/server/libs/passportLocal/strategy.js
@@ -26,7 +26,7 @@ function lookup(obj, field) {
  * Applications must supply a `verify` callback which accepts `username` and
  * `password` credentials, and then calls the `done` callback supplying a
  * `user`, which should be set to `false` if the credentials are not valid.
- * If an exception occured, `err` should be set.
+ * If an exception occurred, `err` should be set.
  *
  * Optionally, `options` can be used to change the fields in which the
  * credentials are found.

--- a/server/libs/requestIp/index.js
+++ b/server/libs/requestIp/index.js
@@ -74,7 +74,7 @@ function getClientIp(req) {
 
     if (is.ip(req.headers['cf-connecting-ip'])) {
       return req.headers['cf-connecting-ip'];
-    } // Fastly and Firebase hosting header (When forwared to cloud function)
+    } // Fastly and Firebase hosting header (When forwarded to cloud function)
 
 
     if (is.ip(req.headers['fastly-client-ip'])) {

--- a/server/utils/migrations/dbMigration.js
+++ b/server/utils/migrations/dbMigration.js
@@ -427,7 +427,7 @@ function migrateAuthors(oldAuthors, oldLibraryItems) {
  */
 function migrateSeries(oldSerieses, oldLibraryItems) {
   const _newRecords = []
-  // Originaly series were shared between libraries if they had the same name
+  // Originally series were shared between libraries if they had the same name
   // Series will be separate between libraries
   for (const oldSeries of oldSerieses) {
     // Get an array of NEW library ids that have this series

--- a/server/utils/parsers/parseFullName.js
+++ b/server/utils/parsers/parseFullName.js
@@ -105,7 +105,7 @@ module.exports = (nameToParse, partToReturn, fixCase, stopOnError, useLongLists)
     );
   }
 
-  // Initilize lists of prefixs, suffixs, and titles to detect
+  // Initialize lists of prefixs, suffixs, and titles to detect
   // Note: These list entries must be all lowercase
   if (useLongLists) {
     suffixList = ['esq', 'esquire', 'jr', 'jnr', 'sr', 'snr', '2', 'ii', 'iii', 'iv',

--- a/server/utils/scandir.js
+++ b/server/utils/scandir.js
@@ -43,7 +43,7 @@ module.exports.checkFilepathIsAudioFile = checkFilepathIsAudioFile
  * @param {import('./fileUtils').FilePathItem[]} fileItems
  * @param {boolean} audiobooksOnly
  * @param {boolean} [includeNonMediaFiles=false] - Used by the watcher to re-scan when covers/metadata files are added/removed
- * @returns {Record<string,string[]>} map of files grouped into potential libarary item dirs
+ * @returns {Record<string,string[]>} map of files grouped into potential library item dirs
  */
 function groupFileItemsIntoLibraryItemDirs(mediaType, fileItems, audiobooksOnly, includeNonMediaFiles = false) {
   // Step 1: Filter out non-book-media files in root dir (with depth of 0)

--- a/test/server/finders/BookFinder.test.js
+++ b/test/server/finders/BookFinder.test.js
@@ -200,7 +200,7 @@ describe('AuthorCandidates', () => {
     describe('no adds', () => {
       ;[
         ['adds aggressively cleaned cleanAuthor', 'fyodor dostoevsky, translated by jackie chan', ['fyodor dostoevsky']],
-        ['adds cleanAuthor if aggresively cleaned cleanAuthor is empty', ', jackie chan', [', jackie chan']]
+        ['adds cleanAuthor if aggressively cleaned cleanAuthor is empty', ', jackie chan', [', jackie chan']]
       ].forEach(([name, cleanAuthor, expected]) =>
         it(name, async () => {
           authorCandidates = new bookFinder.constructor.AuthorCandidates(cleanAuthor, audnexus)


### PR DESCRIPTION
## Brief summary

Fixing some user-facing and non-user facing typos.  
Found via `codespell -L als,autor,mape,mis,te,ue`

## Which issue is fixed?

n/a

## In-depth Description

n/a

## How have you tested this?

Has not been tested

## Screenshots

n/a