### PR TITLE
Update OpenID auth URI construction in login page

### DIFF
--- a/client/pages/login.vue
+++ b/client/pages/login.vue
@@ -132,9 +132,7 @@ export default {
       return this.$store.state.user.user
     },
     openidAuthUri() {
-      const baseUrl = `${window.location.origin}/auth/openid`
-      const callback = encodeURIComponent(window.location.href.split('?').shift())
-      return `${baseUrl}?callback=${callback}`
+      return `${this.$config.routerBasePath}/auth/openid?callback=${window.location.href.split('?').shift()}`
     },
     openIDButtonText() {
       return this.authFormData?.authOpenIDButtonText || 'Login with OpenId'


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

Outlined in https://github.com/advplyr/audiobookshelf/issues/4609#issuecomment-3239221989 the OIDC button does not respect the currently opened URL, but instead uses the environment. This normally should not be an issue, but with the new enforced callback URLs it should at least match the same host/origin as the callback URL. That is why `location` is used. This does not fix the outlined issue though. But e.g. for dev builds that always gets redirected to the localhost address even if not using localhost

And for dev environments serverUrl is always set to localhost:3333. If you connect to <local ip not localhost>:3333 the oidc still redirects to localhost. For deployments this is a non issue.

## Which issue is fixed?

<!-- Which issue number does this PR fix? Ex: "Fixes #1234" -->

## In-depth Description

<!--
Describe your solution in more depth.
How does it work? Why is this the best solution?
Does it solve a problem that affects multiple users or is this an edge case for your setup?
-->

## How have you tested this?

Tested with autoLaunch and without autoLaunch

## Screenshots

<!-- If your PR includes any changes to the web client, please include screenshots or a short video from before and after your changes. -->
