### PR TITLE
Fix Invalid callback URL - must be same-origin for NPM users

### DIFF
--- a/server/auth/OidcAuthStrategy.js
+++ b/server/auth/OidcAuthStrategy.js
@@ -527,7 +527,16 @@ class OidcAuthStrategy {
 
       // For absolute URLs, ensure they point to the same origin
       const callbackUrlObj = new URL(callbackUrl)
-      const currentProtocol = req.secure || req.get('x-forwarded-proto') === 'https' ? 'https' : 'http'
+      // NPM appends both http and https in x-forwarded-proto sometimes, so we need to check for both
+      const xfp = (req.get('x-forwarded-proto') || '').toLowerCase()
+      const currentProtocol =
+        req.secure ||
+        xfp
+          .split(',')
+          .map((s) => s.trim())
+          .includes('https')
+          ? 'https'
+          : 'http'
       const currentHost = req.get('host')
 
       // Check if protocol and host match exactly


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

NPM, even if it's not the spec, returns `'x-forwarded-proto': 'http, https',` as header. 

## Which issue is fixed?

Fixes #4609 

## In-depth Description

See Discord conversation. This is basically because NPM adds both protocols as forwarded.

## How have you tested this?

Local NPM setup

## Screenshots

<!-- If your PR includes any changes to the web client, please include screenshots or a short video from before and after your changes. -->
