### PR TITLE
Fix: MultiSelect causes web client to become unresponsive if duplicate keys exist

### DIFF
--- a/client/components/ui/MultiSelect.vue
+++ b/client/components/ui/MultiSelect.vue
@@ -4,10 +4,11 @@
     <div ref="wrapper" class="relative">
       <form @submit.prevent="submitForm">
         <div ref="inputWrapper" role="list" style="min-height: 36px" class="flex-wrap relative w-full shadow-xs flex items-center border border-gray-600 rounded-sm px-2 py-1" :class="wrapperClass" @click.stop.prevent="clickWrapper" @mouseup.stop.prevent @mousedown.prevent>
-          <div v-for="item in selected" :key="item" role="listitem" class="rounded-full px-2 py-1 mx-0.5 my-0.5 text-xs bg-bg flex flex-nowrap break-all items-center relative">
+          <!-- Use index in v-for and key in case the same key exists multiple times -->
+          <div v-for="(item, idx) in selected" :key="item + '-' + idx" role="listitem" class="rounded-full px-2 py-1 mx-0.5 my-0.5 text-xs bg-bg flex flex-nowrap break-all items-center relative">
             <div v-if="!disabled" class="w-full h-full rounded-full absolute top-0 left-0 px-1 bg-bg/75 flex items-center justify-end opacity-0 hover:opacity-100" :class="{ 'opacity-100': inputFocused }">
               <button v-if="showEdit" type="button" :aria-label="$strings.ButtonEdit" class="material-symbols text-white hover:text-warning cursor-pointer" style="font-size: 1.1rem" @click.stop="editItem(item)">edit</button>
-              <button type="button" :aria-label="$strings.ButtonRemove" class="material-symbols text-white hover:text-error focus:text-error cursor-pointer" style="font-size: 1.1rem" @click.stop="removeItem(item)" @keydown.enter.stop.prevent="removeItem(item)" @focus="setInputFocused(true)" @blur="setInputFocused(false)" tabindex="0">close</button>
+              <button type="button" :aria-label="$strings.ButtonRemove" class="material-symbols text-white hover:text-error focus:text-error cursor-pointer" style="font-size: 1.1rem" @click.stop="removeItem(item, idx)" @keydown.enter.stop.prevent="removeItem(item)" @focus="setInputFocused(true)" @blur="setInputFocused(false)" tabindex="0">close</button>
             </div>
             {{ item }}
           </div>
@@ -259,8 +260,9 @@ export default {
       }
       this.focus()
     },
-    removeItem(item) {
-      var remaining = this.selected.filter((i) => i !== item)
+    removeItem(item, idx) {
+      var remaining = this.selected.slice()
+      remaining.splice(idx, 1)
       this.$emit('input', remaining)
       this.$emit('removedItem', item)
       this.$nextTick(() => {

--- a/client/components/ui/MultiSelect.vue
+++ b/client/components/ui/MultiSelect.vue
@@ -8,7 +8,7 @@
           <div v-for="(item, idx) in selected" :key="item + '-' + idx" role="listitem" class="rounded-full px-2 py-1 mx-0.5 my-0.5 text-xs bg-bg flex flex-nowrap break-all items-center relative">
             <div v-if="!disabled" class="w-full h-full rounded-full absolute top-0 left-0 px-1 bg-bg/75 flex items-center justify-end opacity-0 hover:opacity-100" :class="{ 'opacity-100': inputFocused }">
               <button v-if="showEdit" type="button" :aria-label="$strings.ButtonEdit" class="material-symbols text-white hover:text-warning cursor-pointer" style="font-size: 1.1rem" @click.stop="editItem(item)">edit</button>
-              <button type="button" :aria-label="$strings.ButtonRemove" class="material-symbols text-white hover:text-error focus:text-error cursor-pointer" style="font-size: 1.1rem" @click.stop="removeItem(item, idx)" @keydown.enter.stop.prevent="removeItem(item)" @focus="setInputFocused(true)" @blur="setInputFocused(false)" tabindex="0">close</button>
+              <button type="button" :aria-label="$strings.ButtonRemove" class="material-symbols text-white hover:text-error focus:text-error cursor-pointer" style="font-size: 1.1rem" @click.stop="removeItem(item, idx)" @keydown.enter.stop.prevent="removeItem(item, idx)" @focus="setInputFocused(true)" @blur="setInputFocused(false)" tabindex="0">close</button>
             </div>
             {{ item }}
           </div>


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

This PR adds a unique identifier to the Vue for loop to ensure all keys have a unique identifier.

## Which issue is fixed?

Related to https://github.com/advplyr/audiobookshelf/issues/4634

## In-depth Description

If the same key exists multiple times in a MultiSelect component, the unique key requirement for `v-for` is violated. By adding an index to the key, we ensure that every key is unique, but do not change the values displayed in the front-end.

This can only happen if the database incorrectly includes the same value in an array, such as the same tag applied to the same book multiple times. Instead of filtering out the duplicate tags, these should be displayed to ensure consistent behavior when comparing against the API or another client and allow the user to fix the duplicate tag.

This does not fix the root of the problem where the same tag can be added to the same book, but fixes the symptom.

## How have you tested this?

Used database with the same tag on a book multiple times and ensured:
- Correctly removes selected tag when no duplicates exists (unchanged)
- Correctly adds new tags (unchanged)
- Correctly removes selected tag when duplicate tags exist
<img width="775" height="83" alt="Screenshot from 2025-08-30 10-07-57" src="https://github.com/user-attachments/assets/1467a9ec-f9cd-465a-b3f4-a8b696642819" />
<img width="775" height="83" alt="Screenshot from 2025-08-30 10-08-01" src="https://github.com/user-attachments/assets/3f040d39-85b0-46b4-8a82-6ca01a9b766b" />

- Correctly removes all duplicate tags when unselected using the dropdown

<img width="775" height="150" alt="Screenshot from 2025-08-30 10-07-27" src="https://github.com/user-attachments/assets/cecf11ea-7eea-432e-acd4-3cd504ad13ac" />
<img width="775" height="150" alt="Screenshot from 2025-08-30 10-07-33" src="https://github.com/user-attachments/assets/ac093321-6e08-481d-8ef8-1f9e5d6337ad" />

## Screenshots

See above to match with test case.
