### PR TITLE
Normalize tags and genres in BookFinder results

### DIFF
--- a/server/finders/BookFinder.js
+++ b/server/finders/BookFinder.js
@@ -595,6 +595,15 @@ class BookFinder {
         book.description = htmlSanitizer.sanitize(book.description)
         book.descriptionPlain = htmlSanitizer.stripAllTags(book.description)
       }
+      if (book.tags) {
+        // Some return comma-separated strings, some return arrays
+        const tagsArray = Array.isArray(book.tags) ? book.tags : String(book.tags).split(',')
+        book.tags = [...new Set(tagsArray.map((t) => t.trim()).filter(Boolean))]
+      }
+      if (book.genres) {
+        const genresArray = Array.isArray(book.genres) ? book.genres : String(book.genres).split(',')
+        book.genres = [...new Set(genresArray.map((g) => g.trim()).filter(Boolean))]
+      }
     })
     return books
   }


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

Mentioned in https://github.com/advplyr/audiobookshelf/issues/4634#issuecomment-3239425190 Audible returns the same tag twice. This caused #4636. To avoid more issues, this PR adds validation to convert the strings/array into a Set first to make them unique. 

On a side note, I am not sure why we return genres as an array and tags as a string (at least for the Audible Provider), and why both also work the other way around. This code normalizes it to always return an array. In my tests, this did not break anything, especially since ", " could interfere with actual tag comma separations.

## Which issue is fixed?

Related to #4634 

## In-depth Description

See short description

## How have you tested this?

Matching the mentioned book and a few other ones.

## Screenshots

<!-- If your PR includes any changes to the web client, please include screenshots or a short video from before and after your changes. -->
