### PR TITLE
[fix] prevent duplicates in multi-selects

### DIFF
--- a/client/components/ui/MultiSelect.vue
+++ b/client/components/ui/MultiSelect.vue
@@ -278,7 +278,7 @@ export default {
       })
     },
     insertNewItem(item) {
-      this.selected.push(item)
+      if (!this.selected.includes(item)) this.selected.push(item)
       this.$emit('input', this.selected)
       this.$emit('newItem', item)
       this.textInput = null

--- a/client/components/ui/MultiSelectQueryInput.vue
+++ b/client/components/ui/MultiSelectQueryInput.vue
@@ -287,7 +287,7 @@ export default {
       })
     },
     insertNewItem(item) {
-      this.selected.push(item)
+      if (!this.selected.find((i) => i.name === item.name)) this.selected.push(item)
       this.$emit('input', this.selected)
       this.$emit('newItem', item)
       this.textInput = null


### PR DESCRIPTION
## Brief summary

Ensure that items are not duplicated in multi-select components.


## In-depth Description

Previously, selecting items multiple times could add duplicates to the `selected` list.  
This PR updates the logic for multi-select in multiple components:

- `if (!this.selected.find((i) => i.name === item.name)) this.selected.push(item)`
- `if (!this.selected.includes(item)) this.selected.push(item)`

Now, both components only add items that are not already selected, ensuring uniqueness in the `selected` list.

## How have you tested this?

1. Open book details.  
2. Input the same item multiple times.  
3. Verify that the item appears only once in the `selected` list.  
4. Test with different items to ensure all are selectable without duplication.

##Before


https://github.com/user-attachments/assets/2e175f76-22ec-4bae-9959-e8858b6e3a75


##After


https://github.com/user-attachments/assets/e189b794-2f2b-47aa-8070-4e088fb845a4

