### PR TITLE
Fix issue with episode downloads without streams

### DIFF
--- a/server/managers/PodcastManager.js
+++ b/server/managers/PodcastManager.js
@@ -127,10 +127,20 @@ class PodcastManager {
     })
     let success = !!ffmpegDownloadResponse?.success
 
-    // If failed due to ffmpeg error, retry without tagging
+    if (success) {
+      // Attempt to ffprobe and add podcast episode audio file
+      success = await this.scanAddPodcastEpisodeAudioFile()
+      if (!success) {
+        Logger.error(`[PodcastManager] Failed to scan and add podcast episode audio file - removing file`)
+        await fs.remove(this.currentDownload.targetPath)
+      }
+    }
+
+    // If failed due to ffmpeg or ffprobe error, retry without tagging
     // e.g. RSS feed may have incorrect file extension and file type
     // See https://github.com/advplyr/audiobookshelf/issues/3837
-    if (!success && ffmpegDownloadResponse?.isFfmpegError) {
+    // e.g. Ffmpeg may be download the file without streams causing the ffprobe to fail
+    if (!success && !ffmpegDownloadResponse?.isRequestError) {
       Logger.info(`[PodcastManager] Retrying episode download without tagging`)
       // Download episode only
       success = await downloadFile(this.currentDownload.url, this.currentDownload.targetPath)
@@ -139,23 +149,20 @@ class PodcastManager {
           Logger.error(`[PodcastManager] Podcast Episode download failed`, error)
           return false
         })
+
+      if (success) {
+        success = await this.scanAddPodcastEpisodeAudioFile()
+        if (!success) {
+          Logger.error(`[PodcastManager] Failed to scan and add podcast episode audio file - removing file`)
+          await fs.remove(this.currentDownload.targetPath)
+        }
+      }
     }
 
     if (success) {
-      success = await this.scanAddPodcastEpisodeAudioFile()
-      if (!success) {
-        await fs.remove(this.currentDownload.targetPath)
-        this.currentDownload.setFinished(false)
-        const taskFailedString = {
-          text: 'Failed',
-          key: 'MessageTaskFailed'
-        }
-        task.setFailed(taskFailedString)
-      } else {
-        Logger.info(`[PodcastManager] Successfully downloaded podcast episode "${this.currentDownload.episodeTitle}"`)
-        this.currentDownload.setFinished(true)
-        task.setFinished()
-      }
+      Logger.info(`[PodcastManager] Successfully downloaded podcast episode "${this.currentDownload.episodeTitle}"`)
+      this.currentDownload.setFinished(true)
+      task.setFinished()
     } else {
       const taskFailedString = {
         text: 'Failed',

--- a/server/utils/ffmpegHelpers.js
+++ b/server/utils/ffmpegHelpers.js
@@ -99,7 +99,7 @@ module.exports.resizeImage = resizeImage
 /**
  *
  * @param {import('../objects/PodcastEpisodeDownload')} podcastEpisodeDownload
- * @returns {Promise<{success: boolean, isFfmpegError?: boolean}>}
+ * @returns {Promise<{success: boolean, isRequestError?: boolean}>}
  */
 module.exports.downloadPodcastEpisode = (podcastEpisodeDownload) => {
   return new Promise(async (resolve) => {
@@ -118,7 +118,7 @@ module.exports.downloadPodcastEpisode = (podcastEpisodeDownload) => {
           method: 'GET',
           responseType: 'stream',
           headers: {
-            'Accept': '*/*',
+            Accept: '*/*',
             'User-Agent': userAgent
           },
           timeout: global.PodcastDownloadTimeout
@@ -139,7 +139,8 @@ module.exports.downloadPodcastEpisode = (podcastEpisodeDownload) => {
 
     if (!response) {
       return resolve({
-        success: false
+        success: false,
+        isRequestError: true
       })
     }
 
@@ -204,8 +205,7 @@ module.exports.downloadPodcastEpisode = (podcastEpisodeDownload) => {
         Logger.error(`Full stderr dump for episode url "${podcastEpisodeDownload.url}": ${stderrLines.join('\n')}`)
       }
       resolve({
-        success: false,
-        isFfmpegError: true
+        success: false
       })
     })
     ffmpeg.on('progress', (progress) => {


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

Update podcast episode downloads to fallback to regular download if the ffprobe fails.

## Which issue is fixed?

None, mentioned on Discord

## In-depth Description

A private patreon podcast RSS feed that has m4a audio files is unable to be streamed into ffmpeg for download. The audio file gets downloaded with no media streams so the ffprobe fails.

This update moves the non-ffmpeg fallback download to after the ffprobe.

## How have you tested this?

This resolves that patreon RSS feed

