### PR TITLE
Add autoplay for next book in series after queue ends

### DIFF
--- a/server/controllers/SeriesController.js
+++ b/server/controllers/SeriesController.js
@@ -87,6 +87,30 @@ class SeriesController {
   }
 
   /**
+   * GET: /api/series/:id/next-book/:libraryItemId
+   * Get the next book in a series after the given library item
+   *
+   * @param {SeriesControllerRequest} req
+   * @param {Response} res
+   */
+  async getNextBook(req, res) {
+    const currentLibraryItemId = req.params.libraryItemId
+    const libraryItems = req.libraryItemsInSeries
+
+    const currentBookIndex = libraryItems.findIndex((li) => li.id === currentLibraryItemId)
+    if (currentBookIndex === -1) {
+      return res.status(404).send('Current book not found in series')
+    }
+
+    if (currentBookIndex >= libraryItems.length - 1) {
+      return res.status(404).send('No next book in series')
+    }
+
+    const nextBook = libraryItems[currentBookIndex + 1]
+    res.json(nextBook.toOldJSONExpanded())
+  }
+
+  /**
    *
    * @param {RequestWithUser} req
    * @param {Response} res

--- a/server/routers/ApiRouter.js
+++ b/server/routers/ApiRouter.js
@@ -222,6 +222,7 @@ class ApiRouter {
     //
     this.router.get('/series/:id', SeriesController.middleware.bind(this), SeriesController.findOne.bind(this))
     this.router.patch('/series/:id', SeriesController.middleware.bind(this), SeriesController.update.bind(this))
+    this.router.get('/series/:id/next-book/:libraryItemId', SeriesController.middleware.bind(this), SeriesController.getNextBook.bind(this))
 
     //
     // Playback Session Routes


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

This PR adds automatic playing a series if the queue ends. It intentionally does NOT add all the items to the queue, a. to save bandwith and b. to give users the possibility to add items to the queue.

## Which issue is fixed?

Fixes https://github.com/advplyr/audiobookshelf/issues/4007

## In-depth Description

This adds a new route to get the next book in a series. This could be done in the frontend, but I decided not to because a series can have hundreds of books and fetching the full series at once would not be good. This endpoint can also be used by other apps to display the following books and is a small addition. I hope this makes sense.  

The next book in a series only plays if the queue is empty and there is a next book available. If auto play in the queue is disabled, it will not play. I am not sure if that is the best way (since people might want to use the queue and not automatically listen to series books, but I think adding a new control just for this is unnecessary).

## How have you tested this?

Own server

## Screenshots

None