### PR TITLE
feat(docker): Add PUID/PGID support for volume permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,8 @@ ARG NUSQLITE3_PATH
 RUN apk add --no-cache --update \
   tzdata \
   ffmpeg \
-  tini
+  tini \
+  gosu
 
 WORKDIR /app
 
@@ -58,6 +59,10 @@ WORKDIR /app
 COPY --from=build-client /client/dist /app/client/dist
 COPY --from=build-server /server /app
 COPY --from=build-server ${NUSQLITE3_PATH} ${NUSQLITE3_PATH}
+
+# Copy Entry script and add execute permissions.
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 
 EXPOSE 80
 
@@ -69,5 +74,7 @@ ENV SOURCE="docker"
 ENV NUSQLITE3_DIR=${NUSQLITE3_DIR}
 ENV NUSQLITE3_PATH=${NUSQLITE3_PATH}
 
-ENTRYPOINT ["tini", "--"]
+# Call entrypoint script instead of just tini.
+ENTRYPOINT ["tini", "--", "/usr/local/bin/docker-entrypoint.sh"]
+# This becomes the argument ($@) for the entrypoint script
 CMD ["node", "index.js"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,51 @@
+#!/bin/sh
+set -e
+
+# --- PUID/PGID Check and Defaults ---
+# Set default PUID/PGID to 1000 if not provided
+PUID=${PUID:-1000}
+PGID=${PGID:-1000}
+
+echo "Starting with PUID: $PUID, PGID: $PGID"
+
+# --- User/Group Setup ---
+# Create or modify the 'appuser' group to match the PGID
+if [ -z "$(getent group "${PGID}")" ]; then
+    addgroup -g "${PGID}" appgroup
+else
+    # Group exists, ensure the name is correct for the PUID/PGID
+    group_name=$(getent group "${PGID}" | cut -d: -f1)
+    if [ "$group_name" != "appgroup" ]; then
+        echo "WARNING: PGID ${PGID} already exists with name ${group_name}. Using existing group."
+        app_group_name="${group_name}"
+    else
+        app_group_name="appgroup"
+    fi
+fi
+
+# Create or modify the 'appuser' user to match the PUID and assign to the PGID
+if [ -z "$(getent passwd "${PUID}")" ]; then
+    adduser -u "${PUID}" -G "${app_group_name:-appgroup}" -D -s /bin/sh appuser
+else
+    # User exists, ensure the name is correct for the PUID/PGID
+    user_name=$(getent passwd "${PUID}" | cut -d: -f1)
+    if [ "$user_name" != "appuser" ]; then
+        echo "WARNING: PUID ${PUID} already exists with name ${user_name}. Using existing user."
+        app_user_name="${user_name}"
+    else
+        app_user_name="appuser"
+    fi
+fi
+
+# --- Permission Fix (Crucial Step) ---
+# This fixes permissions on directories meant for bind mounts (volumes)
+# CONFIG_PATH and METADATA_PATH are the likely mount points
+echo "Fixing permissions on volume paths (${CONFIG_PATH} and ${METADATA_PATH})..."
+chown -R "${PUID}":"${PGID}" "${CONFIG_PATH}" || true
+chown -R "${PUID}":"${PGID}" "${METADATA_PATH}" || true
+
+# --- Execute Main Command ---
+# Use 'gosu' to securely drop privileges and run the main command
+# Pass all arguments ($@) to the final application command
+echo "Executing CMD as user ${PUID}..."
+exec gosu "${PUID}":"${PGID}" "$@"


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

Introduces an entrypoint script and 'gosu' to allow users to specify Process User ID (PUID) and Process Group ID (PGID) via environment variables.

## Which issue is fixed?

Fixes #4471

## In-depth Description

Introduces an entrypoint script and 'gosu' to allow users to specify Process User ID (PUID) and Process Group ID (PGID) via environment variables.

This resolves permission errors encountered when binding host volumes into the container, as the entrypoint script now runs 'chown' on /config and /metadata as root before dropping privileges and running the application.

- Adds 'gosu' dependency to the runtime stage.
- Implements 'docker-entrypoint.sh' to handle user switching and permission fixing.
- Updates ENTRYPOINT to use the wrapper script, passing CMD as arguments.

## How have you tested this?

I built the container and I'm running it now with a non root user it had no issues working with the files when previously it did when I used the user: directive in my docker compose.

Build Results
```shell
docker build -t audiobookshelf/server:puid-fix .
[+] Building 0.4s (23/23) FINISHED
 => [internal] load build definition from Dockerfile
 => => transferring dockerfile: 2.10kB
 => [internal] load metadata for docker.io/library/node:20-alpine
 => [internal] load .dockerignore
 => => transferring context: 198B
 => [internal] load build context
 => => transferring context: 58.91kB
 => [build-server 1/7] FROM docker.io/library/node:20-alpine@sha256:eabac870db94f7342d6c33560d6613f188bbcf4bbe1f4eb47d5e2a08e1a37722
 => CACHED [stage-2 2/8] RUN apk add --no-cache --update   tzdata   ffmpeg   tini   gosu
 => CACHED [stage-2 3/8] WORKDIR /app
 => CACHED [build-client 2/5] WORKDIR /client
 => CACHED [build-client 3/5] COPY /client /client
 => CACHED [build-client 4/5] RUN npm ci && npm cache clean --force
 => CACHED [build-client 5/5] RUN npm run generate
 => CACHED [stage-2 4/8] COPY --from=build-client /client/dist /app/client/dist
 => CACHED [build-server 2/7] RUN apk add --no-cache --update   curl   make   python3   g++   unzip
 => CACHED [build-server 3/7] WORKDIR /server
 => CACHED [build-server 4/7] COPY index.js package* /server
 => CACHED [build-server 5/7] COPY /server /server/server
 => CACHED [build-server 6/7] RUN case "linux/amd64" in   "linux/amd64")   curl -L -o /tmp/library.zip "https://github.com/mikiher/nunic
 => CACHED [build-server 7/7] RUN npm ci --only=production
 => CACHED [stage-2 5/8] COPY --from=build-server /server /app
 => CACHED [stage-2 6/8] COPY --from=build-server /usr/local/lib/nusqlite3/libnusqlite3.so /usr/local/lib/nusqlite3/libnusqlite3.so
 => CACHED [stage-2 7/8] COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 => CACHED [stage-2 8/8] RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 => exporting to image
 => => exporting layers
 => => writing image sha256:57b26ab064340edc5aee2ce7c1b341e3a5bd67ffe197786c71c4ec4dc6b9385d
 => => naming to docker.io/audiobookshelf/server:puid-fix 
 ```

Docker Compose Example
```yaml
name: audiobookshelf
services:
  app:
    container_name: audiobookshelf
    image: audiobookshelf/server:puid-fix
    environment:
      - PUID=568
      - PGID=568
    ports:
      - 13378:80
    volumes:
      - /data:/Data
      - ./metadata:/metadata
      - ./config:/config
    restart: unless-stopped
```

## Screenshots

Not applicable.
