### PR TITLE
feat: Added progress indicator to upload

### DIFF
--- a/client/components/ui/LoadingIndicator.vue
+++ b/client/components/ui/LoadingIndicator.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="w-40">
+  <div :class="hasSlotContent ? 'w-auto' : 'w-40'">
     <div class="bg-bg border border-gray-500 py-2 px-5 rounded-lg flex items-center flex-col box-shadow-md">
       <div class="loader-dots block relative w-20 h-5 mt-2">
         <div class="absolute top-0 mt-1 w-3 h-3 rounded-full bg-green-500"></div>
@@ -7,7 +7,9 @@
         <div class="absolute top-0 mt-1 w-3 h-3 rounded-full bg-green-500"></div>
         <div class="absolute top-0 mt-1 w-3 h-3 rounded-full bg-green-500"></div>
       </div>
-      <div class="text-gray-200 text-xs font-light mt-2 text-center">{{ message }}</div>
+      <slot>
+        <div class="text-gray-200 text-xs font-light mt-2 text-center">{{ message }}</div>
+      </slot>
     </div>
   </div>
 </template>
@@ -23,6 +25,9 @@ export default {
   computed: {
     message() {
       return this.text || this.$strings.MessagePleaseWait
+    },
+    hasSlotContent() {
+      return this.$slots.default && this.$slots.default.length > 0
     }
   }
 }

--- a/client/pages/upload/index.vue
+++ b/client/pages/upload/index.vue
@@ -297,6 +297,15 @@ export default {
         ref.setUploadStatus(status)
       }
     },
+    updateItemCardProgress(index, progress) {
+      var ref = this.$refs[`itemCard-${index}`]
+      if (ref && ref.length) ref = ref[0]
+      if (!ref) {
+        console.error('Book card ref not found', index, this.$refs)
+      } else {
+        ref.setUploadProgress(progress)
+      }
+    },
     async uploadItem(item) {
       var form = new FormData()
       form.set('title', item.title)
@@ -312,8 +321,20 @@ export default {
         form.set(`${index++}`, file)
       })
 
+      const config = {
+        onUploadProgress: (progressEvent) => {
+          if (progressEvent.lengthComputable) {
+            const progress = {
+              loaded: progressEvent.loaded,
+              total: progressEvent.total
+            }
+            this.updateItemCardProgress(item.index, progress)
+          }
+        }
+      }
+
       return this.$axios
-        .$post('/api/upload', form)
+        .$post('/api/upload', form, config)
         .then(() => true)
         .catch((error) => {
           console.error('Failed to upload item', error)


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

This PR adds a progress (in percentage and as bytes) when uploading items. It should work with single, multiple and multi-file items

## Which issue is fixed?

Fixes #895 

## In-depth Description

Axios has to option to "watch" for progress. On each update I update the text on the currently uploading item. When the item changes, the progress gets reset.
I am not sure if this will be a feature in the React-Client, but it would be a nice addon.

## How have you tested this?

Uploading single, multiple items and multi-file items

## Screenshots

<img width="1210" height="306" alt="grafik" src="https://github.com/user-attachments/assets/03abf125-1612-42c7-aa94-fbf7591c5740" />
