### PR TITLE
feat: env vars to auto-create user during initial setup

### DIFF
--- a/.devcontainer/dev.js
+++ b/.devcontainer/dev.js
@@ -6,5 +6,8 @@ module.exports.config = {
   MetadataPath: Path.resolve('metadata'),
   FFmpegPath: '/usr/bin/ffmpeg',
   FFProbePath: '/usr/bin/ffprobe',
-  SkipBinariesCheck: false
+  SkipBinariesCheck: false,
+  // Auto-create root user during initial setup
+  // InitUserName: 'admin',
+  // InitUserPassword: 'password'
 }

--- a/index.js
+++ b/index.js
@@ -31,6 +31,8 @@ if (isDev || options['prod-with-dev-env']) {
   if (devEnv.AllowIframe) process.env.ALLOW_IFRAME = '1'
   if (devEnv.BackupPath) process.env.BACKUP_PATH = devEnv.BackupPath
   if (devEnv.ReactClientPath) process.env.REACT_CLIENT_PATH = devEnv.ReactClientPath
+  if (devEnv.InitUserName) process.env.INIT_USER_NAME = devEnv.InitUserName
+  if (devEnv.InitUserPassword) process.env.INIT_USER_PASSWORD = devEnv.InitUserPassword
   process.env.SOURCE = 'local'
   process.env.ROUTER_BASE_PATH = devEnv.RouterBasePath ?? '/audiobookshelf'
 }


### PR DESCRIPTION
## Brief summary

Two new environment variables can be set: `INIT_USER_NAME` and `INIT_USER_PASSWORD`.
If specified, Audiobookshelf automatically creates a superuser with the provided username and password at initial run, not asking user to provide this information via web-interface.

## Which issue is fixed?

Fixes #4704

## In-depth Description

Two new environment variables can be set: `INIT_USER_NAME` and `INIT_USER_PASSWORD`. If `INIT_USER_NAME` is set and `INIT_USER_PASSWORD` is not, then a user with empty password is created. If any user already exists, no changes are done.
This allows us to provide root user data in environment variable (which is useful for container deployment) or via dev.js variables  `InitUserName` and `InitUserPassword`. 

## How have you tested this?

Running the container like that:  `docker run -p 8080:80 -e INIT_USER_NAME=admin -e INIT_USER_PASSWORD=1234 ecf6aabecf96`

We can see log messages: 

`[2025-09-29 14:19:40.812] INFO: [Server] Auto-creating root user "admin" from environment variables
[2025-09-29 14:19:40.851] INFO: [Server] Successfully auto-created root user "admin"`

During the login these credentials can be used, no "initial login" page is shown.

## Screenshots

N/A