### PR TITLE
Move to a non-root model.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
+# globally defining Arguments and Defaults
 ARG NUSQLITE3_DIR="/usr/local/lib/nusqlite3"
 ARG NUSQLITE3_PATH="${NUSQLITE3_DIR}/libnusqlite3.so"
+# default Process user id and group id
+ARG PUID=1000
+ARG PGID=1000
 
 ### STAGE 0: Build client ###
 FROM node:20-alpine AS build-client
@@ -25,7 +29,7 @@ RUN apk add --no-cache --update \
   unzip
 
 WORKDIR /server
-COPY index.js package* /server
+COPY index.js package* /server/
 COPY /server /server/server
 
 RUN case "$TARGETPLATFORM" in \
@@ -45,19 +49,28 @@ FROM node:20-alpine
 
 ARG NUSQLITE3_DIR
 ARG NUSQLITE3_PATH
+ARG PUID
+ARG PGID
 
 # Install only runtime dependencies
 RUN apk add --no-cache --update \
   tzdata \
   ffmpeg \
-  tini
+  tini \
+  shadow \
+  && groupmod -g ${PGID} -n audiobookshelf node\
+  && usermod -u ${PUID} -l audiobookshelf -d /home/audiobookshelf -m node \
+  && apk del shadow \
+  && mkdir -p /config /metadata \
+  && chown -R audiobookshelf:audiobookshelf /config /metadata \
+  && chmod a=rwx /config /metadata
 
 WORKDIR /app
 
 # Copy compiled frontend and server from build stages
-COPY --from=build-client /client/dist /app/client/dist
-COPY --from=build-server /server /app
-COPY --from=build-server ${NUSQLITE3_PATH} ${NUSQLITE3_PATH}
+COPY --chmod=755 --from=build-client /client/dist /app/client/dist
+COPY --chmod=755 --from=build-server /server /app
+COPY --chmod=755 --from=build-server ${NUSQLITE3_PATH} ${NUSQLITE3_PATH}
 
 EXPOSE 80
 
@@ -69,5 +82,6 @@ ENV SOURCE="docker"
 ENV NUSQLITE3_DIR=${NUSQLITE3_DIR}
 ENV NUSQLITE3_PATH=${NUSQLITE3_PATH}
 
+USER audiobookshelf
 ENTRYPOINT ["tini", "--"]
 CMD ["node", "index.js"]


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

Moved to non-root user model.

## Which issue is fixed?

Related to questions in #4471
Superseeds #4700 

## In-depth Description

- Added buildargs to specify the User ID and Group IDs.
- entrypoint now defaults to running as 1000:1000 rather then 0:0.
I noticed myself I had some issues initially running with the user directive. 

## How have you tested this?

I'm running on a build with this change incorporated and VOLUME Instruction  added to docker file.
ghcr.io/vylyne/audiobookshelf:latest

## Screenshots

<!-- If your PR includes any changes to the web client, please include screenshots or a short video from before and after your changes. -->
