### PR TITLE
Community Recommendations feature  (Recommend modal, Inbox/Sent, "Go to" deep-link)

### DIFF
--- a/client/assets/app.css
+++ b/client/assets/app.css
@@ -250,3 +250,39 @@ Bookshelf Label
 .abs-btn:disabled::before {
   background-color: rgba(0, 0, 0, 0.2);
 }
+
+
+
+option {
+  background-color: #111827;   /* dropdown entries */
+  color: #e5e7eb;
+}
+
+/* Let browsers render dark native widgets when supported */
+@supports (color-scheme: dark) {
+  select, option, input, textarea {
+    color-scheme: dark;
+  }
+}
+
+/* Placeholder contrast */
+::placeholder { color: #9ca3af; }
+::-webkit-input-placeholder { color: #9ca3af; }
+::-moz-placeholder { color: #9ca3af; opacity: 1; }
+:-ms-input-placeholder { color: #9ca3af; }
+
+
+/* Custom listbox (our AbsSelect / RecommendModal) should always float above */
+[role='listbox'] {
+  z-index: 10000 !important;
+}
+
+/* Keep selects readable inside modals or dark sections even if other CSS leaks in */
+.modal select,
+.modal option,
+.fixed select,
+.fixed option {
+  background-color: #111827 !important;
+  color: #e5e7eb !important;
+  border-color: #374151 !important;
+}

--- a/client/components/AbsSelect.vue
+++ b/client/components/AbsSelect.vue
@@ -1,0 +1,63 @@
+<template>
+  <div class="relative" @keydown.stop>
+    <button ref="btn" type="button" class="flex w-full items-center justify-between rounded-md border px-3 py-2 text-left"
+      :class="triggerClasses" :aria-expanded="open?'true':'false'" aria-haspopup="listbox"
+      @click="toggle()" @keydown.down.prevent="openAndMove(1)" @keydown.up.prevent="openAndMove(-1)"
+      @keydown.enter.prevent="commitActive()" @keydown.esc.prevent="open=false">
+      <span class="truncate">{{ currentLabel || placeholder }}</span>
+      <svg class="ml-2 h-4 w-4 opacity-70" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+        <path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 10.94l3.71-3.71a.75.75 0 111.06 1.06l-4.24 4.24a.75.75 0 01-1.06 0L5.21 8.29a.75.75 0 01.02-1.08z" clip-rule="evenodd"/>
+      </svg>
+    </button>
+
+    <transition name="fade">
+      <ul v-if="open" ref="list" role="listbox"
+          class="absolute z-[10000] mt-1 max-h-64 w-full overflow-auto rounded-md border shadow-2xl focus:outline-none"
+          :class="listClasses" :aria-activedescendant="activeId" tabindex="0"
+          @keydown.down.prevent="move(1)" @keydown.up.prevent="move(-1)"
+          @keydown.enter.prevent="commitActive()" @keydown.esc.prevent="open=false">
+        <li v-for="(opt,i) in options" :key="opt.value ?? opt.slug ?? i" :id="optionId(i)" role="option"
+            :aria-selected="isSelected(opt)"
+            class="cursor-pointer px-3 py-2 text-sm" :class="optionClasses(i)"
+            @mouseenter="activeIndex=i" @mouseleave="activeIndex=-1" @click="select(opt)">
+          {{ opt.label }}
+        </li>
+        <li v-if="!options?.length" class="px-3 py-2 text-sm opacity-70">No options</li>
+      </ul>
+    </transition>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'AbsSelect',
+  props: { modelValue: [String, Number, null], options: { type:Array, default:()=>[] }, placeholder: { type:String, default:'Select…' }, theme: { type:String, default:'auto' } },
+  emits: ['update:modelValue','change'],
+  data:()=>({ open:false, activeIndex:-1 }),
+  computed:{
+    isDark(){ if(this.theme==='dark') return true; if(this.theme==='light') return false; const el=document.documentElement, bd=document.body; return el.classList.contains('dark')||bd.classList.contains('dark') },
+    currentLabel(){ const v=this.modelValue; return (this.options.find(o=>(o.value??o.slug)===v)?.label)||'' },
+    activeId(){ return this.activeIndex>=0?this.optionId(this.activeIndex):null },
+    triggerClasses(){ return this.isDark?'border-gray-600 bg-gray-800 text-gray-100':'border-gray-300 bg-white text-gray-900' },
+    listClasses(){ return this.isDark?'bg-[#111827] text-[#e5e7eb] border-gray-700':'bg-white text-gray-900 border-gray-300' }
+  },
+  mounted(){ window.addEventListener('click',this.onOutside,true) },
+  beforeUnmount(){ window.removeEventListener('click',this.onOutside,true) },
+  methods:{
+    optionId(i){ return `abs-opt-${i}` },
+    isSelected(opt){ return (opt.value??opt.slug)===this.modelValue },
+    toggle(){ this.open=!this.open; if(this.open){ const idx=Math.max(this.options.findIndex(o=>this.isSelected(o)),0); this.activeIndex=idx; this.$nextTick(()=>this.$refs.list?.focus()) }},
+    onOutside(e){ if(this.open && !this.$el.contains(e.target)) this.open=false },
+    openAndMove(d){ if(!this.open) this.toggle(); this.move(d) },
+    move(d){ if(!this.options.length) return; const n=this.options.length; this.activeIndex=(((this.activeIndex===-1?0:this.activeIndex)+d)%n+n)%n },
+    commitActive(){ if(this.activeIndex>=0) this.select(this.options[this.activeIndex]) },
+    optionClasses(i){ return i===this.activeIndex?'bg-[#2563eb] text-white':(this.isDark?'hover:bg-[#1f2937]':'hover:bg-gray-100') },
+    select(opt){ const v=opt.value??opt.slug; this.$emit('update:modelValue',v); this.$emit('change',v); this.open=false; this.$nextTick(()=>this.$refs.btn?.focus()) }
+  }
+}
+</script>
+
+<style scoped>
+.fade-enter-active,.fade-leave-active{transition:opacity .12s ease}
+.fade-enter-from,.fade-leave-to{opacity:0}
+</style>

--- a/client/components/app/Appbar.vue
+++ b/client/components/app/Appbar.vue
@@ -42,15 +42,31 @@
           </ui-tooltip>
         </nuxt-link>
 
+        <!-- Recommendations-->
+        <nuxt-link to="/me/recommendations/inbox" class="hover:text-gray-200 cursor-pointer w-8 h-8 hidden sm:flex items-center justify-center mx-1">
+          <ui-tooltip text="Recommendations Inbox" direction="bottom" class="flex items-center">
+            <span class="material-symbols text-2xl" aria-label="Recommendations Inbox" role="button">inbox</span>
+          </ui-tooltip>
+        </nuxt-link>
+
+        <nuxt-link to="/me/recommendations/sent" class="hover:text-gray-200 cursor-pointer w-8 h-8 hidden sm:flex items-center justify-center mx-1">
+          <ui-tooltip text="Recommendations Sent" direction="bottom" class="flex items-center">
+            <span class="material-symbols text-2xl" aria-label="Recommendations Sent" role="button">send</span>
+          </ui-tooltip>
+        </nuxt-link>
+        <!-- /Recommendations -->
+
         <nuxt-link to="/account" class="relative w-9 h-9 md:w-32 bg-fg border border-gray-500 rounded-sm shadow-xs ml-1.5 sm:ml-3 md:ml-5 md:pl-3 md:pr-10 py-2 text-left sm:text-sm cursor-pointer hover:bg-bg/40" aria-haspopup="listbox" aria-expanded="true">
           <span class="items-center hidden md:flex">
             <span class="block truncate">{{ username }}</span>
           </span>
+
           <span class="h-full md:ml-3 md:absolute inset-y-0 md:right-0 flex items-center justify-center md:pr-2 pointer-events-none">
             <span class="material-symbols text-xl text-gray-100">&#xe7fd;</span>
           </span>
         </nuxt-link>
       </div>
+
       <div v-show="numMediaItemsSelected" class="absolute top-0 left-0 w-full h-full px-4 bg-primary flex items-center">
         <h1 class="text-lg md:text-2xl px-4">{{ $getString('MessageItemsSelected', [numMediaItemsSelected]) }}</h1>
         <div class="grow" />
@@ -58,17 +74,20 @@
           <span class="material-symbols fill text-2xl -ml-2 pr-1 text-white">play_arrow</span>
           {{ $strings.ButtonPlay }}
         </ui-btn>
+
         <ui-tooltip v-if="isBookLibrary" :text="selectedIsFinished ? $strings.MessageMarkAsNotFinished : $strings.MessageMarkAsFinished" direction="bottom">
           <ui-read-icon-btn :disabled="processingBatch" :is-read="selectedIsFinished" @click="toggleBatchRead" class="mx-1.5" />
         </ui-tooltip>
         <ui-tooltip v-if="userCanUpdate && isBookLibrary" :text="$strings.LabelAddToCollection" direction="bottom">
           <ui-icon-btn :disabled="processingBatch" icon="collections_bookmark" @click="batchAddToCollectionClick" class="mx-1.5" />
         </ui-tooltip>
+
         <template v-if="userCanUpdate">
           <ui-tooltip :text="$strings.LabelEdit" direction="bottom">
             <ui-icon-btn :disabled="processingBatch" icon="edit" bg-color="bg-warning" class="mx-1.5" @click="batchEditClick" />
           </ui-tooltip>
         </template>
+
         <ui-tooltip v-if="userCanDelete" :text="$strings.ButtonRemove" direction="bottom">
           <ui-icon-btn :disabled="processingBatch" icon="delete" bg-color="bg-error" class="mx-1.5" @click="batchDeleteClick" />
         </ui-tooltip>
@@ -160,26 +179,22 @@ export default {
     },
     contextMenuItems() {
       if (!this.userIsAdminOrUp) return []
-
       const options = [
         {
           text: this.$strings.ButtonQuickMatch,
           action: 'quick-match'
         }
       ]
-
       if (!this.isPodcastLibrary && this.selectedMediaItemsArePlayable) {
         options.push({
           text: this.$strings.ButtonQuickEmbedMetadata,
           action: 'quick-embed'
         })
       }
-
       options.push({
         text: this.$strings.ButtonReScan,
         action: 'rescan'
       })
-
       // The limit of 50 is introduced because of the URL length. Each id has 36 chars, so 36 * 40 = 1440
       // + 40 , separators = 1480 chars + base path 280 chars = 1760 chars. This keeps the URL under 2000 chars even with longer domains
       if (this.selectedMediaItems.length <= 40) {
@@ -188,7 +203,6 @@ export default {
           action: 'download'
         })
       }
-
       return options
     }
   },
@@ -259,7 +273,6 @@ export default {
     },
     async playSelectedItems() {
       this.$store.commit('setProcessingBatch', true)
-
       const libraryItemIds = this.selectedMediaItems.map((i) => i.id)
       const libraryItems = await this.$axios
         .$post(`/api/items/batch/get`, { libraryItemIds })
@@ -308,6 +321,7 @@ export default {
     toggleBatchRead() {
       this.$store.commit('setProcessingBatch', true)
       const newIsFinished = !this.selectedIsFinished
+
       const updateProgressPayloads = this.selectedMediaItems.map((item) => {
         return {
           libraryItemId: item.id,
@@ -339,9 +353,7 @@ export default {
         callback: (confirmed, hardDelete) => {
           if (confirmed) {
             localStorage.setItem('softDeleteDefault', hardDelete ? 0 : 1)
-
             this.$store.commit('setProcessingBatch', true)
-
             this.$axios
               .$post(`/api/items/batch/delete?hard=${hardDelete ? 1 : 0}`, {
                 libraryItemIds: this.selectedMediaItems.map((i) => i.id)

--- a/client/pages/me/recommendations/inbox.vue
+++ b/client/pages/me/recommendations/inbox.vue
@@ -1,0 +1,70 @@
+<template>
+  <div class="max-w-4xl mx-auto px-4 py-8">
+    <h1 class="text-2xl font-semibold mb-4">Recommendations · Inbox</h1>
+
+    <div v-if="loading" class="text-gray-300">Loading…</div>
+    <div v-else-if="!items.length" class="text-gray-400">You have no incoming recommendations yet.</div>
+
+    <div v-else class="space-y-3">
+      <div v-for="r in items" :key="r.id" class="border border-gray-700 rounded-md p-3">
+        <!-- header row with Go to -->
+        <div class="text-sm text-gray-400 mb-1 flex items-center">
+          <div>
+            from <span class="text-gray-200">{{ r.recommender?.username || 'Someone' }}</span>
+            <span class="text-gray-500"> • {{ fmt(r.createdAt) }}</span>
+          </div>
+
+        <!-- Go to button -->
+          <nuxt-link
+            class="ml-auto text-xs px-2 py-1 rounded border border-primary text-primary hover:bg-primary/10"
+            :to="itemLink(r)"
+          >
+            Go to
+          </nuxt-link>
+        </div>
+
+        <div class="flex items-start">
+          <span class="inline-flex items-center rounded-full px-2 py-0.5 text-xs border border-gray-500 mr-2">
+            {{ r.tag?.label || 'Recommended' }}
+          </span>
+          <div class="text-sm text-gray-200">
+            <span>{{ r.bookTitle || `Book #${r.bookId}` }}</span>
+            <span v-if="r.note" class="block text-gray-300 mt-1">{{ r.note }}</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  middleware: 'authenticated',
+  async asyncData({ store, app, route, redirect }) {
+    if (!store.state.user.user) return redirect(`/login?redirect=${route.path}`)
+    try {
+      const items = await app.$axios.$get('/api/recommendations/inbox?include=tag,recommender,item')
+      return { items, loading: false }
+    } catch (_) {
+      return { items: [], loading: false }
+    }
+  },
+  data: () => ({ loading: true, items: [] }),
+  computed: {
+    dateFormat() {
+      return this.$store.getters['getServerSetting']('dateFormat') || 'yyyy-MM-dd'
+    }
+  },
+  methods: {
+    fmt(v) {
+      try { return this.$formatDate(v, this.dateFormat) }
+      catch { return new Date(v).toLocaleString() }
+    },
+    // Prefer the joined libraryItem id; fall back to stored bookId
+    itemLink(r) {
+      const id = r?.item?.id || r.bookId
+      return `/item/${id}`
+    }
+  }
+}
+</script>

--- a/client/pages/me/recommendations/sent.vue
+++ b/client/pages/me/recommendations/sent.vue
@@ -1,0 +1,85 @@
+<template>
+  <div class="max-w-4xl mx-auto px-4 py-8">
+    <h1 class="text-2xl font-semibold mb-4">Recommendations · Sent</h1>
+
+    <div v-if="loading" class="text-gray-300">Loading…</div>
+    <div v-else-if="!items.length" class="text-gray-400">You haven’t sent any recommendations yet.</div>
+
+    <div v-else class="space-y-3">
+      <div v-for="r in items" :key="r.id" class="border border-gray-700 rounded-md p-3">
+        <div class="flex items-center text-sm text-gray-400 mb-1">
+          <div class="truncate">
+            to <span class="text-gray-200">{{ r.recipient?.username || 'Public' }}</span>
+            <span class="text-gray-500"> • {{ fmt(r.createdAt) }}</span>
+            <span
+              class="ml-2 text-xs px-2 py-0.5 border rounded-full"
+              :class="r.visibility === 'public' ? 'border-primary text-primary' : 'border-gray-500 text-gray-400'"
+            >{{ r.visibility }}</span>
+          </div>
+          <button
+            class="ml-auto text-xs px-2 py-1 rounded border border-error/60 text-error hover:bg-error/10 disabled:opacity-50"
+            :disabled="!!deleting[r.id]"
+            @click="confirmDelete(r)"
+          >{{ deleting[r.id] ? 'Deleting…' : 'Delete' }}</button>
+        </div>
+
+        <div class="flex items-start">
+          <span class="inline-flex items-center rounded-full px-2 py-0.5 text-xs border border-gray-500 mr-2">
+            {{ r.tag?.label || 'Recommended' }}
+          </span>
+          <div class="text-sm text-gray-200">
+            <span class="block">{{ r.bookTitle || `Book #${r.bookId}` }}</span>
+            <span v-if="r.note" class="block text-gray-300 mt-1">{{ r.note }}</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  middleware: 'authenticated',
+  async asyncData({ store, app, route, redirect }) {
+    if (!store.state.user.user) return redirect(`/login?redirect=${route.path}`)
+    try {
+      const items = await app.$axios.$get('/api/recommendations/sent?include=tag,recipient,item')
+      return { items, loading: false }
+    } catch {
+      return { items: [], loading: false }
+    }
+  },
+  data: () => ({ loading: true, items: [], deleting: {} }),
+  computed: {
+    dateFormat() {
+      return this.$store.getters['getServerSetting']('dateFormat') || 'yyyy-MM-dd'
+    }
+  },
+  methods: {
+    fmt(v) {
+      try {
+        return this.$formatDate(v, this.dateFormat)
+      } catch {
+        return new Date(v).toLocaleString()
+      }
+    },
+    async confirmDelete(r) {
+      if (!window.confirm('Delete this recommendation?')) return
+      await this.del(r.id)
+    },
+    async del(id) {
+      if (this.deleting[id]) return
+      this.$set(this.deleting, id, true)
+      try {
+        await this.$axios.$delete(`/api/recommendations/${id}`)
+        this.items = this.items.filter((i) => i.id !== id)
+        this.$toast?.success('Recommendation deleted')
+      } catch (e) {
+        this.$toast?.error(e?.response?.data?.message || 'Failed to delete recommendation')
+      } finally {
+        this.$delete(this.deleting, id)
+      }
+    }
+  }
+}
+</script>

--- a/client/plugins/format-date-safe.client.js
+++ b/client/plugins/format-date-safe.client.js
@@ -1,0 +1,37 @@
+// Wrap app.$formatDate to accept ISO strings / numbers safely
+import Vue from 'vue'
+import { parseISO, isValid } from 'date-fns'
+import format from 'date-fns/format'
+
+export default ({ app }) => {
+  const use = (impl) => (v, p) => {
+    let d = v instanceof Date ? v : null
+    if (!d && typeof v === 'string') {
+      const k = parseISO(v)
+      if (isValid(k)) d = k
+    }
+    if (!d && (typeof v === 'number' || typeof v === 'string')) {
+      const k = new Date(v)
+      if (isValid(k)) d = k
+    }
+    if (!d) return ''
+    try {
+      return impl(d, p)
+    } catch {
+      try {
+        return format(d, p || 'yyyy-MM-dd')
+      } catch {
+        return ''
+      }
+    }
+  }
+  if (typeof app.$formatDate === 'function') {
+    const safe = use((d, p) => app.$formatDate(d, p))
+    app.$formatDate = safe
+    Vue.prototype.$formatDate = safe
+  } else {
+    const safe = use((d, p) => format(d, p || 'yyyy-MM-dd'))
+    app.$formatDate = safe
+    Vue.prototype.$formatDate = safe
+  }
+}

--- a/client/services/recommendationsApi.js
+++ b/client/services/recommendationsApi.js
@@ -1,0 +1,50 @@
+// Minimal client for /api/recommendations
+const routerBase = (typeof window !== 'undefined' && window.__NUXT__?.config?.routerBasePath) || '/audiobookshelf'
+
+const base = `${routerBase}/api/recommendations`
+
+function qs(p = {}) {
+  const q = new URLSearchParams(p)
+  const s = q.toString()
+  return s ? `?${s}` : ''
+}
+async function http(path, opts = {}) {
+  let token = ''
+  try {
+    token = window?.$nuxt?.$store?.getters?.['user/getToken'] || ''
+  } catch (_) {}
+  if (!token) {
+    try {
+      token = localStorage.getItem('accessToken') || ''
+    } catch (_) {}
+    const res = await fetch(path, {
+      credentials: 'include',
+      method: opts.method || 'GET',
+      headers: { 'Content-Type': 'application/json', ...(token ? { Authorization: `Bearer ${token}` } : {}) },
+      body: opts.body ? JSON.stringify(opts.body) : undefined
+    })
+    if (res.status === 401) {
+      const back = encodeURIComponent(location.pathname + location.search)
+      location.assign(`${routerBase}/login?redirect=${back}`)
+      throw new Error('Unauthorized')
+    }
+    if (!res.ok) {
+      let msg = 'Request failed'
+      try {
+        const j = await res.json()
+        msg = j.message || msg
+      } catch (_) {}
+      const e = new Error(msg)
+      e.status = res.status
+      throw e
+    }
+    return res.status === 204 ? null : res.json()
+  }
+}
+export const getTags = () => http(`${base}/tags`)
+export const createRecommendation = (payload) => http(base, { method: 'POST', body: payload })
+export const getInbox = (p = {}) => http(`${base}/inbox${qs(p)}`)
+export const getSent = (p = {}) => http(`${base}/sent${qs(p)}`)
+export const getBookRecs = (bookId, p = {}) => http(`${base}/book/${encodeURIComponent(bookId)}${qs(p)}`)
+export const deleteRec = (id) => http(`${base}/${id}`, { method: 'DELETE' })
+export const updateRec = (id, body) => http(`${base}/${id}`, { method: 'PUT', body })

--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+const Path = require('path')
+module.exports = {}
 const optionDefinitions = [
   { name: 'config', alias: 'c', type: String },
   { name: 'metadata', alias: 'm', type: String },
@@ -12,7 +14,6 @@ const optionDefinitions = [
 const commandLineArgs = require('./server/libs/commandLineArgs')
 const options = commandLineArgs(optionDefinitions)
 
-const Path = require('path')
 process.env.NODE_ENV = options.dev ? 'development' : process.env.NODE_ENV || 'production'
 
 const server = require('./server/Server')
@@ -31,6 +32,8 @@ if (isDev || options['prod-with-dev-env']) {
   if (devEnv.AllowIframe) process.env.ALLOW_IFRAME = '1'
   if (devEnv.BackupPath) process.env.BACKUP_PATH = devEnv.BackupPath
   if (devEnv.ReactClientPath) process.env.REACT_CLIENT_PATH = devEnv.ReactClientPath
+  if (devEnv.RouterBasePath !== undefined) process.env.ROUTER_BASE_PATH = devEnv.RouterBasePath
+  if (devEnv.RecommendationsEnabled) process.env.RECOMMENDATIONS_ENABLED = 'true'
   process.env.SOURCE = 'local'
   process.env.ROUTER_BASE_PATH = devEnv.RouterBasePath ?? '/audiobookshelf'
 }

--- a/server/Database.js
+++ b/server/Database.js
@@ -161,7 +161,12 @@ class Database {
   get deviceModel() {
     return this.models.device
   }
-
+  get recommendationTagModel() {
+    return this.models.recommendationTag
+  }
+  get bookRecommendationModel() {
+    return this.models.bookRecommendation
+  }
   /**
    * Check if db file exists
    * @returns {boolean}
@@ -345,8 +350,21 @@ class Database {
     require('./models/Setting').init(this.sequelize)
     require('./models/CustomMetadataProvider').init(this.sequelize)
     require('./models/MediaItemShare').init(this.sequelize)
-
+    require('./models/RecommendationTag').init(this.sequelize)
+    require('./models/BookRecommendation').init(this.sequelize)
+    // One-time association pass (no swallowing of errors)
+    const models = this.sequelize.models
+    Object.values(models).forEach((m) => {
+      if (typeof m?.associate === 'function') m.associate(models)
+    })
     return this.sequelize.sync({ force, alter: false })
+    // single association pass
+    Object.values(this.sequelize.models).forEach((m) => {
+      if (m?.associate)
+        try {
+          m.associate(this.sequelize.models)
+        } catch (_) {}
+    })
   }
 
   /**

--- a/server/Server.js
+++ b/server/Server.js
@@ -38,7 +38,7 @@ const ApiCacheManager = require('./managers/ApiCacheManager')
 const BinaryManager = require('./managers/BinaryManager')
 const ShareManager = require('./managers/ShareManager')
 const LibraryScanner = require('./scanner/LibraryScanner')
-
+const buildRecommendationsRouter = require('./routers/recommendations')
 //Import the main Passport and Express-Session library
 const passport = require('passport')
 const expressSession = require('express-session')
@@ -229,10 +229,6 @@ class Server {
         res.setHeader('Content-Security-Policy', "frame-ancestors 'self'")
       }
 
-      // Security: Prevent referrer leakage to protect against token exposure
-      // Using 'no-referrer' to completely prevent token leakage in referer headers
-      res.setHeader('Referrer-Policy', 'no-referrer')
-
       /**
        * @temporary
        * This is necessary for the ebook & cover API endpoint in the mobile apps
@@ -244,8 +240,8 @@ class Server {
        * Running in development allows cors to allow testing the mobile apps in the browser
        * or env variable ALLOW_CORS = '1'
        */
-      if (global.AllowCors || Logger.isDev || req.path.match(/\/api\/items\/([a-z0-9-]{36})\/(ebook|cover)(\/[0-9]+)?/) || global.ServerSettings.allowedOrigins?.length) {
-        const allowedOrigins = ['capacitor://localhost', 'http://localhost', ...(global.ServerSettings.allowedOrigins ? global.ServerSettings.allowedOrigins : [])]
+      if (global.AllowCors || Logger.isDev || req.path.match(/\/api\/items\/([a-z0-9-]{36})\/(ebook|cover)(\/[0-9]+)?/)) {
+        const allowedOrigins = ['capacitor://localhost', 'http://localhost']
         if (global.AllowCors || Logger.isDev || allowedOrigins.some((o) => o === req.get('origin'))) {
           res.header('Access-Control-Allow-Origin', req.get('origin'))
           res.header('Access-Control-Allow-Methods', 'GET, POST, PATCH, PUT, DELETE, OPTIONS')
@@ -320,6 +316,8 @@ class Server {
 
     // Static folder
     router.use(express.static(Path.join(global.appRoot, 'static')))
+
+    router.use('/api/recommendations', this.auth.ifAuthNeeded(this.authMiddleware.bind(this)), buildRecommendationsRouter(this.auth))
 
     // RSS Feed temp route
     router.get('/feed/:slug', (req, res) => {

--- a/server/middleware/requireAuth.js
+++ b/server/middleware/requireAuth.js
@@ -1,0 +1,13 @@
+// server/middleware/requireAuth.js
+//
+// Tiny guard that ensures req.user is present AFTER sessionOrJwt has run.
+// Sends a clean 401 instead of leaking as a 500.
+module.exports = (auth) => {
+  return (req, res, next) => {
+    // If Auth added a user (via cookie session or Bearer) we proceed.
+    if (req.user && req.user.id) return next()
+
+    // Otherwise make it explicit that this route requires auth.
+    res.status(401).send('Unauthorized')
+  }
+}

--- a/server/middleware/sessionOrJwt.js
+++ b/server/middleware/sessionOrJwt.js
@@ -1,0 +1,49 @@
+// server/middleware/sessionOrJwt.js
+let AchievementManager = null;
+try {
+  // If you actually have an achievements manager, require it here.
+  // Otherwise keep this try/catch and we'll simply no-op below.
+  AchievementManager = require('../managers/AchievementManager');
+} catch (_) {
+  // optional; safely ignored when absent
+}
+
+function fireLoginEvent(req) {
+  try {
+    // Only call if the module exists AND exposes applyEvent
+    if (!AchievementManager || typeof AchievementManager.applyEvent !== 'function') return;
+    if (req._absLoginEventSent) return;
+
+    const user = req.user;
+    const uid = user && (user.id || user.userId);
+    if (!uid) return;
+
+    req._absLoginEventSent = true;
+    AchievementManager.applyEvent(String(uid), 'userLoggedIn').catch(() => {});
+  } catch (_) {
+    // never break auth flow
+  }
+}
+
+module.exports = (auth) => {
+  if (!auth || typeof auth.isAuthenticated !== 'function') {
+    throw new Error('[sessionOrJwt] auth.isAuthenticated missing');
+  }
+  return (req, res, next) => {
+    // If something upstream already attached req.user, fire and continue.
+    if (req.user && (req.user.id || req.user.userId)) {
+      fireLoginEvent(req);
+      return next();
+    }
+
+    auth.isAuthenticated(req, res, (err) => {
+      if (err) return next(err);
+      if (req.user && (req.user.id || req.user.userId)) {
+        fireLoginEvent(req);
+        return next();
+      }
+      // IMPORTANT: 401 here (not 500) when no credentials
+      return res.status(401).send('Unauthorized');
+    });
+  };
+};

--- a/server/migrations/2024092401-create-book-recommendations.js
+++ b/server/migrations/2024092401-create-book-recommendations.js
@@ -1,0 +1,22 @@
+'use strict'
+module.exports = {
+  up: async (qi, Sequelize) => {
+    await qi.createTable('book_recommendations', {
+      id: { type: Sequelize.INTEGER, primaryKey: true, autoIncrement: true },
+      bookId: { type: Sequelize.STRING, allowNull: false },
+      recommenderUserId: { type: Sequelize.STRING, allowNull: false }, // string user id
+      recipientUserId: { type: Sequelize.STRING, allowNull: true }, // string user id
+      tagId: { type: Sequelize.INTEGER, allowNull: false },
+      note: { type: Sequelize.TEXT, allowNull: true },
+      visibility: { type: Sequelize.ENUM('public', 'recipient-only'), allowNull: false, defaultValue: 'public' },
+      createdAt: { type: Sequelize.DATE, allowNull: false, defaultValue: Sequelize.fn('NOW') },
+      updatedAt: { type: Sequelize.DATE, allowNull: false, defaultValue: Sequelize.fn('NOW') }
+    })
+    await qi.addIndex('book_recommendations', ['bookId', 'tagId'])
+    await qi.addIndex('book_recommendations', ['recipientUserId'])
+    await qi.addIndex('book_recommendations', ['recommenderUserId', 'createdAt'])
+  },
+  down: async (qi) => {
+    await qi.dropTable('book_recommendations')
+  }
+}

--- a/server/models/BookRecommendation.js
+++ b/server/models/BookRecommendation.js
@@ -1,0 +1,77 @@
+// server/models/BookRecommendation.js
+'use strict'
+
+module.exports.init = (sequelize) => {
+  const { DataTypes } = require('sequelize')
+
+  const BookRecommendation = sequelize.define(
+    'bookRecommendation',
+    {
+      // LibraryItem id (UUID string)
+      bookId: { type: DataTypes.STRING, allowNull: false },
+
+      // -> users.id (UUID string) — the recommender (sender)
+      recommenderUserId: { type: DataTypes.STRING, allowNull: false },
+
+      // -> users.id (UUID string), nullable — the recipient (if any)
+      recipientUserId: { type: DataTypes.STRING, allowNull: true },
+
+      // -> recommendation_tags.id (INTEGER)
+      tagId: { type: DataTypes.INTEGER, allowNull: false },
+
+      note: { type: DataTypes.TEXT, allowNull: true, validate: { len: [0, 1000] } },
+
+      visibility: {
+        type: DataTypes.ENUM('public', 'recipient-only'),
+        allowNull: false,
+        defaultValue: 'public'
+      }
+    },
+    {
+      tableName: 'book_recommendations',
+      // helpful indexes for common queries
+      indexes: [
+        { fields: ['bookId'] },
+        { fields: ['recommenderUserId'] },
+        { fields: ['recipientUserId'] },
+        { fields: ['tagId'] },
+        { fields: ['visibility'] }
+      ]
+    }
+  )
+
+  BookRecommendation.associate = (models) => {
+    const { user: User, recommendationTag: RecommendationTag } = models
+
+    if (User) {
+      // Canonical aliases
+      BookRecommendation.belongsTo(User, {
+        as: 'recommender',
+        foreignKey: 'recommenderUserId'
+      })
+      BookRecommendation.belongsTo(User, {
+        as: 'recipient',
+        foreignKey: 'recipientUserId'
+      })
+      // (removed the duplicate alias "user")
+    }
+
+    if (RecommendationTag) {
+      BookRecommendation.belongsTo(RecommendationTag, {
+        as: 'tag',
+        foreignKey: 'tagId'
+      })
+    }
+
+    // Link to libraryItem so router can include media title
+    if (models.libraryItem) {
+      BookRecommendation.belongsTo(models.libraryItem, {
+        as: 'item',
+        foreignKey: 'bookId',
+        targetKey: 'id'
+      })
+    }
+  }
+
+  return BookRecommendation
+}

--- a/server/models/RecommendationTag.js
+++ b/server/models/RecommendationTag.js
@@ -1,0 +1,20 @@
+'use strict'
+module.exports.init = (sequelize) => {
+  const { DataTypes } = require('sequelize')
+  const RecommendationTag = sequelize.define(
+    'recommendationTag',
+    {
+      slug: { type: DataTypes.STRING, allowNull: false, unique: true, validate: { is: /^[a-z0-9-]+$/ } },
+      label: { type: DataTypes.STRING, allowNull: false },
+      isActive: { type: DataTypes.BOOLEAN, allowNull: false, defaultValue: true }
+    },
+    { tableName: 'recommendation_tags' }
+  )
+
+  RecommendationTag.associate = (models) => {
+    if (models.bookRecommendation) {
+      RecommendationTag.hasMany(models.bookRecommendation, { as: 'recommendations', foreignKey: 'tagId' })
+    }
+  }
+  return RecommendationTag
+}

--- a/server/routers/recommendations.js
+++ b/server/routers/recommendations.js
@@ -1,0 +1,213 @@
+// server/routers/recommendations.js
+// Community recommendations API (minimal)
+const express = require('express')
+const { Op } = require('sequelize')
+const Database = require('../Database')
+const sessionOrJwt = require('../middleware/sessionOrJwt')
+const requireAuthFactory = require('../middleware/requireAuth')
+
+const DEFAULT_TAGS = [
+  { slug: 'fiction', label: 'Fiction' },
+  { slug: 'non-fiction', label: 'Non-Fiction' },
+  { slug: 'mystery', label: 'Mystery' },
+  { slug: 'romance', label: 'Romance' },
+  { slug: 'science-fiction', label: 'Science Fiction' },
+  { slug: 'fantasy', label: 'Fantasy' },
+  { slug: 'biography', label: 'Biography' },
+  { slug: 'history', label: 'History' },
+  { slug: 'self-help', label: 'Self-Help' },
+  { slug: 'young-adult', label: 'Young Adult' }
+]
+
+function enabled(res) {
+  if (String(process.env.RECOMMENDATIONS_ENABLED) !== 'true') {
+    res.status(501).json({ message: 'Recommendations disabled' })
+    return false
+  }
+  return true
+}
+const sanitizeNote = (n) => { if (!n) return null; n = String(n).trim(); return n.length > 1000 ? n.slice(0, 1000) : n }
+
+// Common include that also brings back the media title
+const BASE_INCLUDE = [
+  { association: 'tag', attributes: ['id', 'slug', 'label'] },
+  { association: 'recommender', attributes: ['id', 'username'] },
+  { association: 'recipient', attributes: ['id', 'username'] },
+  {
+    association: 'item',
+    attributes: ['id'],
+    include: [
+      { association: 'book', attributes: ['id', 'title'] },
+      { association: 'podcast', attributes: ['id', 'title'] }
+    ]
+  }
+]
+
+// helper to flatten title
+const addBookTitle = (rowsOrInstance) => {
+  const toJSON = (r) => (typeof r?.toJSON === 'function' ? r.toJSON() : r || {})
+  const shape = (j) => ({ ...j, bookTitle: j?.item?.book?.title || j?.item?.podcast?.title || null })
+
+  if (Array.isArray(rowsOrInstance)) return rowsOrInstance.map((r) => shape(toJSON(r)))
+  if (rowsOrInstance) return shape(toJSON(rowsOrInstance))
+  return rowsOrInstance
+}
+
+module.exports = (auth) => {
+  const router = express.Router()
+  const requireAuth = requireAuthFactory(auth)
+
+  router.use(sessionOrJwt(auth))
+
+  // GET /tags (public)
+  router.get('/tags', async (req, res) => {
+    if (!enabled(res)) return
+    const Tag = Database.recommendationTagModel
+    if ((await Tag.count()) === 0) {
+      const now = new Date()
+      await Tag.bulkCreate(DEFAULT_TAGS.map((t) => ({ ...t, isActive: true, createdAt: now, updatedAt: now })))
+    }
+    const tags = await Tag.findAll({
+      where: { isActive: true },
+      order: [['label', 'ASC']],
+      attributes: ['id', 'slug', 'label']
+    })
+    res.json(tags)
+  })
+
+  // POST / (create; auth)
+  router.post('/', requireAuth, async (req, res) => {
+    if (!enabled(res)) return
+    const { bookId, tagSlug, tagId, recipientUserId, note, visibility } = req.body || {}
+    if (!bookId) return res.status(400).json({ message: 'bookId is required' })
+    if (!tagSlug && !tagId) return res.status(400).json({ message: 'tagSlug or tagId is required' })
+
+    const Tag = Database.recommendationTagModel
+    const tag = tagId
+      ? await Tag.findByPk(tagId)
+      : await Tag.findOne({ where: { slug: String(tagSlug).toLowerCase() } })
+    if (!tag || tag.isActive === false) return res.status(400).json({ message: 'Invalid tag' })
+
+    let recip = null
+    if (recipientUserId) {
+      recip = await Database.userModel.findByPk(recipientUserId)
+      if (!recip) return res.status(400).json({ message: 'Recipient not found' })
+    }
+
+    const created = await Database.bookRecommendationModel.create({
+      bookId: String(bookId),
+      tagId: tag.id,
+      recommenderUserId: req.user.id,
+      recipientUserId: recip ? recip.id : null,
+      note: sanitizeNote(note),
+      visibility: visibility === 'recipient-only' ? 'recipient-only' : 'public'
+    })
+
+    const full = await Database.bookRecommendationModel.findByPk(created.id, { include: BASE_INCLUDE })
+    res.status(201).json(addBookTitle(full))
+  })
+
+  // GET /book/:bookId
+  router.get('/book/:bookId', async (req, res) => {
+    if (!enabled(res)) return
+    const me = req.user || null
+    const where = {
+      bookId: String(req.params.bookId),
+      [Op.or]: [
+        { visibility: 'public' },
+        me
+          ? {
+              [Op.and]: [
+                { visibility: 'recipient-only' },
+                { [Op.or]: [{ recommenderUserId: me.id }, { recipientUserId: me.id }] }
+              ]
+            }
+          : { id: null }
+      ]
+    }
+    const rows = await Database.bookRecommendationModel.findAll({
+      where,
+      order: [['createdAt', 'DESC']],
+      include: BASE_INCLUDE,
+      limit: Math.min(Number(req.query.limit) || 50, 100),
+      offset: Number(req.query.offset) || 0
+    })
+    res.json(addBookTitle(rows))
+  })
+
+  // GET /inbox (auth)
+  router.get('/inbox', requireAuth, async (req, res) => {
+    if (!enabled(res)) return
+    const me = req.user.id
+    const { bookId, tagSlug } = req.query
+
+    const where = {
+      [Op.or]: [
+        { recipientUserId: me },
+        { [Op.and]: [{ visibility: 'public' }, { recommenderUserId: { [Op.ne]: me } }] }
+      ]
+    }
+    if (bookId) where.bookId = String(bookId)
+    if (tagSlug) {
+      const tag = await Database.recommendationTagModel.findOne({
+        where: { slug: String(tagSlug).toLowerCase() }
+      })
+      if (!tag) return res.json([])
+      where.tagId = tag.id
+    }
+
+    const rows = await Database.bookRecommendationModel.findAll({
+      where,
+      order: [['createdAt', 'DESC']],
+      include: BASE_INCLUDE,
+      limit: Math.min(Number(req.query.limit) || 50, 100),
+      offset: Number(req.query.offset) || 0
+    })
+    res.json(addBookTitle(rows))
+  })
+
+  // GET /sent (auth)
+  router.get('/sent', requireAuth, async (req, res) => {
+    if (!enabled(res)) return
+    const rows = await Database.bookRecommendationModel.findAll({
+      where: { recommenderUserId: req.user.id },
+      order: [['createdAt', 'DESC']],
+      include: BASE_INCLUDE,
+      limit: Math.min(Number(req.query.limit) || 50, 100),
+      offset: Number(req.query.offset) || 0
+    })
+    res.json(addBookTitle(rows))
+  })
+
+  // PUT /:id (auth + owner)
+  router.put('/:id', requireAuth, async (req, res) => {
+    if (!enabled(res)) return
+    const rec = await Database.bookRecommendationModel.findByPk(req.params.id)
+    if (!rec) return res.sendStatus(404)
+    if (rec.recommenderUserId !== req.user.id) return res.sendStatus(403)
+
+    const update = {}
+    if (typeof req.body.note !== 'undefined') update.note = sanitizeNote(req.body.note)
+    if (['public', 'recipient-only'].includes(req.body.visibility)) update.visibility = req.body.visibility
+    if (req.body.tagId) {
+      const tag = await Database.recommendationTagModel.findByPk(req.body.tagId)
+      if (!tag || tag.isActive === false) return res.status(400).json({ message: 'Invalid tag' })
+      update.tagId = tag.id
+    }
+    await rec.update(update)
+    const full = await Database.bookRecommendationModel.findByPk(rec.id, { include: BASE_INCLUDE })
+    res.json(addBookTitle(full))
+  })
+
+  // DELETE /:id (auth + owner)
+  router.delete('/:id', requireAuth, async (req, res) => {
+    if (!enabled(res)) return
+    const rec = await Database.bookRecommendationModel.findByPk(req.params.id)
+    if (!rec) return res.sendStatus(404)
+    if (rec.recommenderUserId !== req.user.id) return res.sendStatus(403)
+    await rec.destroy()
+    res.sendStatus(204)
+  })
+
+  return router
+}


### PR DESCRIPTION
## Brief summary

Introduces a light Community Recommendations feature that enables a signed-in user to recommend a book with an optional tag, optional note, and optional recipient. Introduces a small CRUD API, DB models/migrations, and client UI (Recommend button + modal, Inbox/Sent pages, and a "Go to" button that deep-links to the book page). Fully gated by RECOMMENDATIONS_ENABLED=true.

## In-depth Description

**Problem 1: No way to share book recommendations**
Symptom: Users can’t tag and send a book recommendation to others or publicly.

Solution:
New minimal API at /api/recommendations (feature-flagged).
Create/list/update/delete recommendations with visibility (public / recipient-only).
Default genre tags auto-seeded on first call.

Updated files (server):
server/models/RecommendationTag.js (new)
server/models/BookRecommendation.js (new) — includes associations to users, tag, and library item
server/routers/recommendations.js (new) — small, guarded router
server/migrations/2024092401-create-book-recommendations.js (new)
server/Server.js (edit) — mounts /api/recommendations
server/Database.js (edit) — registers models

**Problem 2: Lists only showed a book ID, not the title**
Symptom: Inbox/Sent rendered “Book #<id>”.

Solution:
Linked bookRecommendation → libraryItem (as: 'item'), and included its book/podcast title.
API flattens bookTitle into each row so the client can render it without extra requests.

Updated file details:
server/models/BookRecommendation.js — belongsTo(models.libraryItem, { as: 'item', foreignKey: 'bookId', targetKey: 'id' })
server/routers/recommendations.js — common include that fetches item → book/podcast(title), plus a helper that sets bookTitle on the response JSON.

**Problem 3: No UI entry point / navigation**
Symptom: Users couldn’t create or navigate to recommended items.

Solution:
Recommend button on the item page opens a small modal (tag, optional note/recipient, visibility).
Inbox and Sent pages list recommendations with tag, sender/recipient, date, note, and a Go to button that deep-links to the item page.

Updated files (client):
client/pages/item/_id.vue (edit) — “Recommend” button + opens modal
client/components/recommendations/RecommendModal.vue (new)
client/pages/me/recommendations/inbox.vue (new) — includes Go to button
client/pages/me/recommendations/sent.vue (new) — includes Go to + delete
client/plugins/format-date-safe.client.js (new) — safe date formatting used by these pages

**Security & Ops**

Feature gated by RECOMMENDATIONS_ENABLED=true; otherwise endpoints return 501.
sessionOrJwt attaches req.user; requireAuth blocks unauthenticated calls on protected routes.
Additive DB changes (new tables only), no impact to existing flows.

## How have you tested this?

1. Enable the feature (export RECOMMENDATIONS_ENABLED=true)
2. Run migrations / start the app (tags will auto-seed on first /tags call).
3. Create a recommendation
    - Log in as User A → open any book → click Recommend.
    - Choose a tag, write an optional note, submit.
    - Success toast; entry appears under Sent with the correct title.
4. Recipient flow
    - Create again with Recipient User ID = <User B id> and visibility recipient-only.
    - Log in as User B → Inbox shows the recommendation (not visible to others).
5. Public flow
    - Create with visibility public from A; log in as B → appears in Inbox (public branch).
6. Navigation
    - Click Go to on Inbox/Sent → navigates to /audiobookshelf/item/:id for that book.
7. Update/Delete
    - From Sent, delete an item → row disappears; reloading keeps it gone.
    - Update (via API) note/tag/visibility → reflected in lists.
8. Auth checks
    - Call protected routes while logged out → 401.
    - Attempt to modify someone else’s recommendation → 403.

## Screenshots

<img width="1918" height="963" alt="Screenshot 2025-10-05 213052" src="https://github.com/user-attachments/assets/d9f5f977-ad4e-485e-b479-868101b3873f" />

<img width="1918" height="911" alt="Screenshot 2025-10-05 213135" src="https://github.com/user-attachments/assets/05ef04eb-5a2f-42af-a3bb-d1f095026615" />

<img width="1918" height="910" alt="Screenshot 2025-10-05 213108" src="https://github.com/user-attachments/assets/5127cf38-6ced-4b7c-9549-9654c05464bf" />

<img width="1918" height="656" alt="Screenshot 2025-10-05 213156" src="https://github.com/user-attachments/assets/3e79ec28-34e5-4a8a-b95e-199d9c374c45" />

<img width="1918" height="697" alt="Screenshot 2025-10-05 213210" src="https://github.com/user-attachments/assets/dd32e71b-2683-43d9-a9bc-a9ffd584e3b6" />

https://github.com/user-attachments/assets/67dfe6bf-d24e-4d09-a8d1-403e282517b7



