### PR TITLE
Add a script to build an uncompressed windows executable

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "client": "cd client && npm ci && npm run generate",
     "prod": "npm run client && npm ci && node index.js",
     "build-win": "npm run client && pkg -t node20-win-x64 -o ./dist/win/audiobookshelf -C GZip .",
+    "build-win-no-compress": "npm run client && pkg -t node20-win-x64 -o ./dist/win/audiobookshelf .",
     "build-linux": "build/linuxpackager",
     "docker": "docker buildx build --platform linux/amd64,linux/arm64 --push .  -t advplyr/audiobookshelf",
     "docker-amd64-local": "docker buildx build --platform linux/amd64 --load .  -t advplyr/audiobookshelf-amd64-local",


### PR DESCRIPTION
## Brief summary

This is a simple change to add a package.json script that build an uncompressed windows executable.

## Which issue is fixed?

If I'm right about this, this should fix #2998.

## In-depth Description

I've done some additional analysis of the code in pkg bootstrap.js in which all of the crashes are reported.
It looks like this code path (which decompresses files into an external temp directory) is only reached when the `-C` option is used in the `pkg` command line.

I went through the code with chatgpt, and it seems like there's a potential stale caching bug in the code path that crashes, but until I nail it down fully, modify the code, and pass through yao-pkg code review, it looks like just removing the `-C` option will mitigiate the issue.

Another indicator that this might be the issue is that `linuxpackager` does not use the `-C` option, and we've never seen reports on this issue from linux users.

The uncompressed version doesn't weight a lot more than the compressed one - about 40% larger - and hopefully this is a temporary change and we'll be able to move back to compressed executables when the pkg bug is fixed.

## How have you tested this?

This doesn't change anything in the server code itself. 
I intend to replcace the compressed version with the uncompressed one in the Windows installer, check it and let the latest reporter check it, and see if it resolves the issue for them.