### PR TITLE
Explicitly launch OpenID Connect authentication with ?autoLaunch=1

### DIFF
--- a/client/pages/login.vue
+++ b/client/pages/login.vue
@@ -299,8 +299,8 @@ export default {
       }
 
       if (authMethods.includes('openid')) {
-        // Auto redirect unless query string ?autoLaunch=0
-        if (this.authFormData?.authOpenIDAutoLaunch && this.$route.query?.autoLaunch !== '0') {
+        // Auto redirect unless query string ?autoLaunch=0 OR when explicity requested through ?autoLaunch=1
+        if ((this.authFormData?.authOpenIDAutoLaunch && this.$route.query?.autoLaunch !== '0') || this.$route.query?.autoLaunch == '1') {
           window.location.href = this.openidAuthUri
         }
 


### PR DESCRIPTION
This change extends OIDC authentication by enabling explicit redirection to the OAuth provider when navigating to the login page with the manual override parameter `/login?autoLaunch=1`.

Use case: directly launch _audiobookshelf_ from within e.g. _Nextcloud_ using the external sites app pointed at `https://abs.example.org/login?autoLaunch=1` while keeping the possibility to use _audiobookshelf_  standalone using its built-in authentication mechanism since `Auto Launch` is disabled in the _OpenID Connect Authentication_ settings page. Assuming the username or mail address used in _Nextcloud_ and _audiobookshelf_ is identical the user will be logged in to his or her account no matter which method is used.
