### PR TITLE
fix #1617 (useradd: user 'audiobookshelf' already exists)

### DIFF
--- a/build/debian/DEBIAN/preinst
+++ b/build/debian/DEBIAN/preinst
@@ -22,7 +22,7 @@ add_user() {
   declare -r descr="${4:-No description}"
   declare -r shell="${5:-/bin/false}"
 
-  if ! getent passwd | grep -q "^$user:"; then
+  if ! getent passwd "$user" 2>&1 >/dev/null; then
     echo "Creating system user: $user in $group with $descr and shell $shell"
     useradd $uid_flags --gid $group --no-create-home --system --shell $shell -c "$descr" $user
   fi
@@ -39,7 +39,7 @@ add_group() {
     declare -r gid_flags="--gid $gid"
   fi
 
-  if ! getent group | grep -q "^$group:" ; then
+  if ! getent group "$group" 2>&1 >/dev/null; then
     echo "Creating system group: $group"
     groupadd $gid_flags --system $group
   fi


### PR DESCRIPTION
This change fixes the problem of failing upgrades on dpkg-based systems (see #1617) by reworking the check for whether the `audiobookshelf` user/group already exists.