### PR TITLE
[Enhancement] Clairfy when user has insufficent permissions to delete items from issues tab

### DIFF
--- a/client/components/app/BookShelfToolbar.vue
+++ b/client/components/app/BookShelfToolbar.vue
@@ -74,6 +74,9 @@
         <!-- issues page remove all button -->
         <ui-btn v-if="isIssuesFilter && userCanDelete && !isBatchSelecting" :loading="processingIssues" color="bg-error" small class="ml-4" @click="removeAllIssues">{{ $strings.ButtonRemoveAll }} {{ $formatNumber(numShowing) }} {{ entityName }}</ui-btn>
 
+        <!-- issues page remove all button user does not have permissions to delete -->
+        <ui-btn v-if="isIssuesFilter && !userCanDelete && !isBatchSelecting" :title="$strings.ButtonRemoveAllInsufficientPermissions" color="bg-error" small class="ml-4" disabled>{{ $strings.ButtonRemoveAll }} {{ $formatNumber(numShowing) }} {{ entityName }}</ui-btn>
+
         <ui-context-menu-dropdown v-if="contextMenuItems.length" :items="contextMenuItems" :menu-width="110" class="ml-2" @action="contextMenuAction" />
       </template>
       <!-- search page -->

--- a/client/strings/en-us.json
+++ b/client/strings/en-us.json
@@ -80,6 +80,7 @@
   "ButtonRefresh": "Refresh",
   "ButtonRemove": "Remove",
   "ButtonRemoveAll": "Remove All",
+  "ButtonRemoveAllInsufficientPermissions": "User has insufficient permissions to remove items.",
   "ButtonRemoveAllLibraryItems": "Remove All Library Items",
   "ButtonRemoveFromContinueListening": "Remove from Continue Listening",
   "ButtonRemoveFromContinueReading": "Remove from Continue Reading",


### PR DESCRIPTION
## Brief summary

Add tool tip to disabled delete button when user does not have permissions to delete items on issues tab.

## Which issue is fixed?

https://github.com/advplyr/audiobookshelf/issues/3765

## In-depth Description

It's unclear that the permissions to delete an item that has issues require permissions a user may not have. When you visit the issues tab logged in as a user that does not have permissions there is no indication that the user has no permission to delete it just doesn't show the button. It would be helpful to know in that case that the user needs to either log into an account with permissions to delete or contact someone that can delete that item from the library.

Example attached:

<img width="951" height="650" alt="Screenshot (115)" src="https://github.com/user-attachments/assets/46c8ae8b-67c6-4596-9df0-2f47ae325c95" />

## How have you tested this?

Logged in via a user that does not have permission to delete and see the disabled button, hovering over the disabled button the tool tip displays a message explaining that the user does not have permission to delete:

<img width="959" height="656" alt="Screenshot (113)" src="https://github.com/user-attachments/assets/3473d4f0-d8aa-4f56-b797-a7524d0b8500" />

Regression tested with a user that has permissions to delete:

<img width="956" height="713" alt="Screenshot (114)" src="https://github.com/user-attachments/assets/16cdd018-a946-4b00-98a7-a08a950ac8f5" />

## Screenshots

Attached under testing instructions and PR description.