### PR TITLE
Change token expiry

### DIFF
--- a/server/auth/TokenManager.js
+++ b/server/auth/TokenManager.js
@@ -12,9 +12,9 @@ class TokenManager {
 
   constructor() {
     /** @type {number} Refresh token expiry in seconds */
-    this.RefreshTokenExpiry = parseInt(process.env.REFRESH_TOKEN_EXPIRY) || 7 * 24 * 60 * 60 // 7 days
+    this.RefreshTokenExpiry = parseInt(process.env.REFRESH_TOKEN_EXPIRY) || 30 * 24 * 60 * 60 // 30 days
     /** @type {number} Access token expiry in seconds */
-    this.AccessTokenExpiry = parseInt(process.env.ACCESS_TOKEN_EXPIRY) || 12 * 60 * 60 // 12 hours
+    this.AccessTokenExpiry = parseInt(process.env.ACCESS_TOKEN_EXPIRY) || 1 * 60 * 60 // 1 hour
 
     if (parseInt(process.env.REFRESH_TOKEN_EXPIRY) > 0) {
       Logger.info(`[TokenManager] Refresh token expiry set from ENV variable to ${this.RefreshTokenExpiry} seconds`)


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

This increases the default tokenExpiry for the refresh and access token. 

## Which issue is fixed?

/

## In-depth Description

It was discussed some time ago that the default duration might eventually be increased /decreased. 
Since there have been no reports of authentication issues related to them, imho I think it's fair to say that the time has come where it should be safe to increase the refresh token and decrease the access token.
Especially for people switching between apps, 7 days can easily be reached.

## How have you tested this?

/

## Screenshots

/
