### PR TITLE
Bug in matching author of a book when this author already exists in the db.

### DIFF
--- a/server/scanner/Scanner.js
+++ b/server/scanner/Scanner.js
@@ -260,16 +260,16 @@ class Scanner {
             // Update filter data
             Database.addAuthorToFilterData(libraryItem.libraryId, author.name, author.id)
           }
-            await Database.bookAuthorModel
-              .create({
-                authorId: author.id,
-                bookId: libraryItem.media.id
-              })
-              .then(() => {
-                Logger.info(`[Scanner] quickMatchBookBuildUpdatePayload: Added author "${author.name}" to "${libraryItem.media.title}"`)
-                libraryItem.media.authors.push(author)
-                hasAuthorUpdates = true
-              })
+          await Database.bookAuthorModel
+            .create({
+              authorId: author.id,
+              bookId: libraryItem.media.id
+            })
+            .then(() => {
+              Logger.info(`[Scanner] quickMatchBookBuildUpdatePayload: Added author "${author.name}" to "${libraryItem.media.title}"`)
+              libraryItem.media.authors.push(author)
+              hasAuthorUpdates = true
+            })
         }
         const authorsRemoved = libraryItem.media.authors.filter((a) => !matchData.author.find((ma) => ma.toLowerCase() === a.name.toLowerCase()))
         if (authorsRemoved.length) {


### PR DESCRIPTION
## Brief summary

I found a bug which causes the author field to remain empty when: 
- using a custom metadata provider
- using "Match Books" action for a whole library
- there is more than 1 book from the same author
- author is identified and added to the db for the first book
- next book is properly matched -> here we expect a full match, but the author field is not populated (remains empty)

## Which issue is fixed?

I didn't find any reported issues, but initially the behavior seemed random and related to the custom provider.

## In-depth Description

For a new author the current code goes through the whole `if (!existingAuthor)` and everything works fine. But when the autor is already in the db, then the 

            await Database.bookAuthorModel
              .create({
                authorId: author.id,
                bookId: libraryItem.media.id
              })
              .then(() => {
                Logger.info(`[Scanner] quickMatchBookBuildUpdatePayload: Added author "${author.name}" to "${libraryItem.media.title}"`)
                libraryItem.media.authors.push(author)
                hasAuthorUpdates = true
              })

is not executed and author field remains empty.

## How have you tested this?

Steps to reproduce:
- configure custom metadata provider
- create a new library in a new audiobookshelf instance (empty db!) 
- as a source, use a directory with at least 2 books from the same author (no metadata in .json, mp3 tags, etc.)
- scan the library, then use "Match Books" option 
<img width="910" height="246" alt="image" src="https://github.com/user-attachments/assets/7e4a7f8b-c90f-4751-a5b5-76d0632914fb" />

The result is that the first matched book (usually the last one when sorting by directory name) will have the author field populated. The next one will be missing an author. Other fields seem to work fine. 

After the code change all the books get the author field populated correctly.