### PR TITLE
Don't require listening today for 'Days in a row' stat

### DIFF
--- a/client/components/stats/DailyListeningChart.vue
+++ b/client/components/stats/DailyListeningChart.vue
@@ -186,14 +186,14 @@ export default {
     daysInARow() {
       var count = 0
       while (true) {
-        var _date = this.$addDaysToToday((count * -1) - 1)
-        var datestr = this.$formatJsDate(_date, 'yyyy-MM-dd')
+        const _date = this.$addDaysToToday(count * -1 - 1)
+        const datestr = this.$formatJsDate(_date, 'yyyy-MM-dd')
 
         if (!this.listeningStatsDays[datestr] || this.listeningStatsDays[datestr] === 0) {
           // don't require listening today to count towards days in a row, but do count it if already listened today
-          var today = this.$formatJsDate(new Date(), 'yyyy-MM-dd');
+          const today = this.$formatJsDate(new Date(), 'yyyy-MM-dd')
           if (this.listeningStatsDays[today]) {
-            count++;
+            count++
           }
 
           return count


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

<!-- Please provide a brief summary of what your PR attempts to achieve. -->

Adjust logic for calculating 'Days in a row' stat to not require listening on the current day.

I usually listen at the end of the day, so this allows viewing the stat before you've listened for the day.

## Which issue is fixed?

<!-- Which issue number does this PR fix? Ex: "Fixes #1234" -->

N/A - no associated issue currently

## In-depth Description

<!--
Describe your solution in more depth.
How does it work? Why is this the best solution?
Does it solve a problem that affects multiple users or is this an edge case for your setup?
-->

Changes day counting logic to start counting from yesterday instead of today, so that there doesn't need to be any activity for the current day.

If there is activity for the current day this is counted at the end once the last day with no activity has been found.

## How have you tested this?

<!-- Please describe in detail with reproducible steps how you tested your changes. -->

Set some temporary test data in the `ApiRouter.getUserListeningStatsHelpers` method to mock appropriate activity on dates:
<img width="336" height="139" alt="image" src="https://github.com/user-attachments/assets/54917c49-0030-41d4-bea0-af10b37bbb5b" />


## Screenshots

<!-- If your PR includes any changes to the web client, please include screenshots or a short video from before and after your changes. -->

No visual changes, only change is to the value shown for "Days in a row".

With no activity on the current day:
<img width="797" height="336" alt="image" src="https://github.com/user-attachments/assets/af81eff5-7cb3-4e0b-826c-7a71c71638c3" />


With activity on the current day:
<img width="802" height="344" alt="image" src="https://github.com/user-attachments/assets/94b54bfa-b970-4816-ad3b-71b7c8596dc1" />


