### PR TITLE
Enable HTTP response compression for API and static assets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "GPL-3.0",
       "dependencies": {
         "axios": "^0.27.2",
+        "compression": "^1.8.1",
         "cookie-parser": "^1.4.6",
         "express": "^4.17.1",
         "express-rate-limit": "^7.5.1",
@@ -1375,6 +1376,50 @@
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
       "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
       "dev": true
+    },
+    "node_modules/compressible": {
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
+      "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
+      "dependencies": {
+        "mime-db": ">= 1.43.0 < 2"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/compression": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.8.1.tgz",
+      "integrity": "sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w==",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "compressible": "~2.0.18",
+        "debug": "2.6.9",
+        "negotiator": "~0.6.4",
+        "on-headers": "~1.1.0",
+        "safe-buffer": "5.2.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/compression/node_modules/negotiator": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
+      "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/compression/node_modules/on-headers": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+      "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "license": "GPL-3.0",
   "dependencies": {
     "axios": "^0.27.2",
+    "compression": "^1.8.1",
     "cookie-parser": "^1.4.6",
     "express": "^4.17.1",
     "express-rate-limit": "^7.5.1",

--- a/server/Server.js
+++ b/server/Server.js
@@ -6,6 +6,7 @@ const util = require('util')
 const fs = require('./libs/fsExtra')
 const fileUpload = require('./libs/expressFileupload')
 const cookieParser = require('cookie-parser')
+const compression = require('compression')
 const axios = require('axios')
 
 const { version } = require('../package.json')
@@ -282,6 +283,9 @@ class Server {
     app.use(this.auth.ifAuthNeeded(passport.session()))
     // config passport.js
     await this.auth.initPassportJs()
+
+    // init compression middleware
+    app.use(compression({ level: 6, threshold: 1024 }))
 
     const router = express.Router()
 


### PR DESCRIPTION
## Brief summary

This introduces response compression using Express’s [compression](https://www.npmjs.com/package/compression) middleware.

## Which issue is fixed?

N/A

## In-depth Description

A response is only compressed if:
- Client sends Accept-Encoding: gzip (or br, or both)
- Response type is compressible (e.g. application/json, not image/jpeg)
- Response size is > 1kb (this is the library default, but I thought it better to be explicit)

Note that this also compresses static js/etc files served for the web app, not just API requests.

## How have you tested this?

Manual testing by directly hitting the API and navigating around the web/mobile apps.

Some unscientific before/after numbers:

### UI Page Loads
| View | Uncompressed | Compressed | Reduction |
|------|---------------|-------------|------------|
| Home tab | 2.15 MB | 1.42 MB | 34% smaller |
| Library tab | 2.43 MB | 1.74 MB | 28% smaller |

### API Endpoints
| Endpoint | Page Size | Uncompressed | Compressed | Reduction |
|-----------|------------|---------------|-------------|------------|
| `/api/libraries/<id>/items` | 50 | 130 KB | 41 KB | 68% smaller |
| `/api/items/<id>` | - | 22 KB | 3 KB | 86% smaller |

## Screenshots

N/A