### PR TITLE
move socket toast to top of the page

### DIFF
--- a/client/assets/app.css
+++ b/client/assets/app.css
@@ -250,3 +250,12 @@ Bookshelf Label
 .abs-btn:disabled::before {
   background-color: rgba(0, 0, 0, 0.2);
 }
+
+/* Padding for toastification toasts on the bottom to not cover media player*/
+.media-player .Vue-Toastification__toast.toast-mb-40 {
+  margin-bottom: calc(var(--spacing) * 40);
+}
+
+.media-player .Vue-Toastification__toast.toast-mb-48 {
+  margin-bottom: calc(var(--spacing) * 48);
+}

--- a/client/layouts/default.vue
+++ b/client/layouts/default.vue
@@ -7,7 +7,7 @@
       <Nuxt :key="currentLang" />
     </div>
 
-    <app-media-player-container ref="mediaPlayerContainer" :class="{ 'media-player': isShowingMediaPlayer }" />
+    <app-media-player-container ref="mediaPlayerContainer" />
 
     <modals-item-edit-modal />
     <modals-collections-add-create-modal />
@@ -49,6 +49,13 @@ export default {
 
       this.$store.commit('globals/resetSelectedMediaItems', [])
       this.updateBodyClass()
+    },
+    '$store.state.streamLibraryItem'(newVal) {
+      if (newVal) {
+        document.body.classList.add('media-player')
+      } else {
+        document.body.classList.remove('media-player')
+      }
     }
   },
   computed: {
@@ -70,14 +77,6 @@ export default {
     },
     appContentMarginLeft() {
       return this.isShowingSideRail ? 80 : 0
-    },
-    isShowingMediaPlayer() {
-      if (this.$store.state.streamLibraryItem) {
-        document.body.classList.add('media-player')
-      } else {
-        document.body.classList.remove('media-player')
-      }
-      return this.$store.state.streamLibraryItem
     }
   },
   methods: {
@@ -657,14 +656,6 @@ export default {
 <style>
 .Vue-Toastification__toast-body.custom-class-1 {
   font-size: 14px;
-}
-
-.media-player .Vue-Toastification__toast.toast-mb-40 {
-  margin-bottom: calc(var(--spacing) * 40);
-}
-
-.media-player .Vue-Toastification__toast.toast-mb-48 {
-  margin-bottom: calc(var(--spacing) * 48);
 }
 
 #app-content {


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

<!-- Please provide a brief summary of what your PR attempts to achieve. -->
Minor change to move the websocket message/error toast to the top of the screen on the web client.

## Which issue is fixed?

<!-- Which issue number does this PR fix? Ex: "Fixes #1234" -->
Enhancment https://github.com/advplyr/audiobookshelf/issues/4772

## In-depth Description

<!--
Describe your solution in more depth.
How does it work? Why is this the best solution?
Does it solve a problem that affects multiple users or is this an edge case for your setup?
-->

Play/Pause button would become inaccessible when the websocket message or error was displayed.

<img width="2025" height="254" alt="Screenshot from 2025-10-29 14-55-31" src="https://github.com/user-attachments/assets/b40f44ec-38f5-4f40-9a4e-f4790c33e03e" />

Moving the toast message to the top of the screen is a minimal change to prevent this.

<img width="2025" height="254" alt="Screenshot from 2025-10-29 15-06-44" src="https://github.com/user-attachments/assets/bd1a367b-d20a-4cc1-aff4-2e3506ed7b48" />

## How have you tested this?

<!-- Please describe in detail with reproducible steps how you tested your changes. -->

Opened and played an audiobook.
Turned off dev server to produce  websocket disconnect error.
Toast now shows at top of page rather than covering the pause button at the bottom.

## Screenshots

<!-- If your PR includes any changes to the web client, please include screenshots or a short video from before and after your changes. -->
