### PR TITLE
Add a 'Match after scan' option to the schedule scan config

### DIFF
--- a/client/components/modals/libraries/EditModal.vue
+++ b/client/components/modals/libraries/EditModal.vue
@@ -126,6 +126,7 @@ export default {
           skipMatchingMediaWithIsbn: false,
           autoScanCronExpression: null,
           matchAfterScan: false,
+          matchMinConfidence: 0,
           hideSingleBookSeries: false,
           onlyShowLaterBooksInContinueSeries: false,
           metadataPrecedence: ['folderStructure', 'audioMetatags', 'nfoFile', 'txtFiles', 'opfFile', 'absMetadata'],

--- a/client/components/modals/libraries/EditModal.vue
+++ b/client/components/modals/libraries/EditModal.vue
@@ -125,6 +125,7 @@ export default {
           skipMatchingMediaWithAsin: false,
           skipMatchingMediaWithIsbn: false,
           autoScanCronExpression: null,
+          matchAfterScan: false,
           hideSingleBookSeries: false,
           onlyShowLaterBooksInContinueSeries: false,
           metadataPrecedence: ['folderStructure', 'audioMetatags', 'nfoFile', 'txtFiles', 'opfFile', 'absMetadata'],

--- a/client/components/modals/libraries/ScheduleScan.vue
+++ b/client/components/modals/libraries/ScheduleScan.vue
@@ -4,7 +4,12 @@
       <p class="text-base md:text-xl font-semibold">{{ $strings.HeaderScheduleLibraryScans }}</p>
       <ui-checkbox v-model="enableAutoScan" @input="toggleEnableAutoScan" :label="$strings.LabelEnable" medium checkbox-bg="bg" label-class="pl-2 text-base md:text-lg" />
     </div>
-    <widgets-cron-expression-builder ref="cronExpressionBuilder" v-if="enableAutoScan" v-model="cronExpression" @input="updatedCron" />
+    <div v-if="enableAutoScan">
+      <widgets-cron-expression-builder ref="cronExpressionBuilder" v-model="cronExpression" @input="updatedCron" />
+      <div class="mt-4">
+        <ui-checkbox v-model="matchAfterScan" @input="updateMatchAfterScan" :label="$strings.LabelMatchAfterScan" medium checkbox-bg="bg" label-class="pl-2 text-base" />
+      </div>
+    </div>
     <div v-else>
       <p class="text-yellow-400 text-base">{{ $strings.MessageScheduleLibraryScanNote }}</p>
     </div>
@@ -23,7 +28,8 @@ export default {
   data() {
     return {
       cronExpression: null,
-      enableAutoScan: false
+      enableAutoScan: false,
+      matchAfterScan: false
     }
   },
   computed: {},
@@ -47,9 +53,17 @@ export default {
         }
       })
     },
+    updateMatchAfterScan(value) {
+      this.$emit('update', {
+        settings: {
+          matchAfterScan: value
+        }
+      })
+    },
     init() {
       this.cronExpression = this.library.settings.autoScanCronExpression
       this.enableAutoScan = !!this.cronExpression
+      this.matchAfterScan = this.library.settings.matchAfterScan
     }
   },
   mounted() {

--- a/client/components/modals/libraries/ScheduleScan.vue
+++ b/client/components/modals/libraries/ScheduleScan.vue
@@ -9,6 +9,10 @@
       <div class="mt-4">
         <ui-checkbox v-model="matchAfterScan" @input="updateMatchAfterScan" :label="$strings.LabelMatchAfterScan" medium checkbox-bg="bg" label-class="pl-2 text-base" />
       </div>
+      <div class="mt-4" v-if="matchAfterScan">
+        <label class="px-1 text-sm font-semibold">{{ $strings.LabelMatchMinConfidence }}</label>
+        <ui-range-input v-model.number="matchMinConfidencePercentage" :min="0" :max="100" :step="1" />
+      </div>
     </div>
     <div v-else>
       <p class="text-yellow-400 text-base">{{ $strings.MessageScheduleLibraryScanNote }}</p>
@@ -29,10 +33,21 @@ export default {
     return {
       cronExpression: null,
       enableAutoScan: false,
-      matchAfterScan: false
+      matchAfterScan: false,
+      matchMinConfidence: 0
     }
   },
-  computed: {},
+  computed: {
+    matchMinConfidencePercentage: {
+      get() {
+        return this.matchMinConfidence * 100
+      },
+      set(val) {
+        this.matchMinConfidence = val / 100
+        this.updateMatchMinConfidence()
+      }
+    }
+  },
   methods: {
     checkBlurExpressionInput() {
       // returns true if advanced cron input is focused
@@ -60,10 +75,18 @@ export default {
         }
       })
     },
+    updateMatchMinConfidence() {
+      this.$emit('update', {
+        settings: {
+          matchMinConfidence: this.matchMinConfidence
+        }
+      })
+    },
     init() {
       this.cronExpression = this.library.settings.autoScanCronExpression
       this.enableAutoScan = !!this.cronExpression
       this.matchAfterScan = this.library.settings.matchAfterScan
+      this.matchMinConfidence = this.library.settings.matchMinConfidence || 0
     }
   },
   mounted() {

--- a/client/strings/en-us.json
+++ b/client/strings/en-us.json
@@ -449,6 +449,7 @@
   "LabelLowestPriority": "Lowest Priority",
   "LabelMatchConfidence": "Confidence",
   "LabelMatchAfterScan": "Run 'Match Books' after scan",
+  "LabelMatchMinConfidence": "Minimum match confidence (0-100)",
   "LabelMatchExistingUsersBy": "Match existing users by",
   "LabelMatchExistingUsersByDescription": "Used for connecting existing users. Once connected, users will be matched by a unique id from your SSO provider",
   "LabelMaxEpisodesToDownload": "Max # of episodes to download. Use 0 for unlimited.",

--- a/client/strings/en-us.json
+++ b/client/strings/en-us.json
@@ -448,6 +448,7 @@
   "LabelLookForNewEpisodesAfterDate": "Look for new episodes after this date",
   "LabelLowestPriority": "Lowest Priority",
   "LabelMatchConfidence": "Confidence",
+  "LabelMatchAfterScan": "Run 'Match Books' after scan",
   "LabelMatchExistingUsersBy": "Match existing users by",
   "LabelMatchExistingUsersByDescription": "Used for connecting existing users. Once connected, users will be matched by a unique id from your SSO provider",
   "LabelMaxEpisodesToDownload": "Max # of episodes to download. Use 0 for unlimited.",

--- a/server/controllers/LibraryController.js
+++ b/server/controllers/LibraryController.js
@@ -354,6 +354,15 @@ class LibraryController {
             updatedSettings[key] = req.body.settings[key] === null ? null : Number(req.body.settings[key])
             Logger.debug(`[LibraryController] Library "${req.library.name}" updating setting "${key}" to "${updatedSettings[key]}"`)
           }
+        } else if (key === 'matchAfterScan') {
+          if (typeof req.body.settings[key] !== 'boolean') {
+            return res.status(400).send('Invalid request. Setting "matchAfterScan" must be a boolean')
+          }
+          if (req.body.settings[key] !== updatedSettings[key]) {
+            hasUpdates = true
+            updatedSettings[key] = req.body.settings[key]
+            Logger.debug(`[LibraryController] Library "${req.library.name}" updating setting "${key}" to "${updatedSettings[key]}"`)
+          }
         } else {
           if (typeof req.body.settings[key] !== typeof updatedSettings[key]) {
             Logger.error(`[LibraryController] Invalid request. Setting "${key}" must be of type ${typeof updatedSettings[key]}`)

--- a/server/controllers/LibraryController.js
+++ b/server/controllers/LibraryController.js
@@ -354,6 +354,19 @@ class LibraryController {
             updatedSettings[key] = req.body.settings[key] === null ? null : Number(req.body.settings[key])
             Logger.debug(`[LibraryController] Library "${req.library.name}" updating setting "${key}" to "${updatedSettings[key]}"`)
           }
+        } else if (key === 'matchMinConfidence') {
+          if (req.body.settings[key] !== null && isNaN(req.body.settings[key])) {
+            Logger.error(`[LibraryController] Invalid request. Setting "${key}" must be a number`)
+            return res.status(400).send(`Invalid request. Setting "${key}" must be a number`)
+          } else if (req.body.settings[key] !== null && (Number(req.body.settings[key]) < 0 || Number(req.body.settings[key]) > 1)) {
+            Logger.error(`[LibraryController] Invalid request. Setting "${key}" must be between 0 and 1`)
+            return res.status(400).send(`Invalid request. Setting "${key}" must be between 0 and 1`)
+          }
+          if (req.body.settings[key] !== updatedSettings[key]) {
+            hasUpdates = true
+            updatedSettings[key] = req.body.settings[key] === null ? null : Number(req.body.settings[key])
+            Logger.debug(`[LibraryController] Library "${req.library.name}" updating setting "${key}" to "${updatedSettings[key]}"`)
+          }
         } else if (key === 'matchAfterScan') {
           if (typeof req.body.settings[key] !== 'boolean') {
             return res.status(400).send('Invalid request. Setting "matchAfterScan" must be a boolean')

--- a/server/managers/CronManager.js
+++ b/server/managers/CronManager.js
@@ -84,7 +84,9 @@ class CronManager {
             checkRemoveEmptySeries,
             checkRemoveAuthorsWithNoBooks
           }
-          Scanner.matchLibraryItems(apiRouterCtx, library)
+          Scanner.matchLibraryItems(apiRouterCtx, library, {
+            minConfidence: library.settings.matchMinConfidence
+          })
         }
       }
     })

--- a/server/models/Library.js
+++ b/server/models/Library.js
@@ -69,6 +69,7 @@ class Library extends Model {
         disableWatcher: false,
         autoScanCronExpression: null,
         matchAfterScan: false,
+        matchMinConfidence: 0,
         skipMatchingMediaWithAsin: false,
         skipMatchingMediaWithIsbn: false,
         audiobooksOnly: false,

--- a/server/models/Library.js
+++ b/server/models/Library.js
@@ -68,6 +68,7 @@ class Library extends Model {
         coverAspectRatio: 1, // Square
         disableWatcher: false,
         autoScanCronExpression: null,
+        matchAfterScan: false,
         skipMatchingMediaWithAsin: false,
         skipMatchingMediaWithIsbn: false,
         audiobooksOnly: false,

--- a/server/routers/ApiRouter.js
+++ b/server/routers/ApiRouter.js
@@ -35,6 +35,7 @@ const MiscController = require('../controllers/MiscController')
 const ShareController = require('../controllers/ShareController')
 const StatsController = require('../controllers/StatsController')
 const ApiKeyController = require('../controllers/ApiKeyController')
+const { checkRemoveEmptySeries, checkRemoveAuthorsWithNoBooks } = require('../utils/cleanup')
 
 class ApiRouter {
   constructor(Server) {
@@ -405,54 +406,7 @@ class ApiRouter {
    * @param {string[]} seriesIds
    */
   async checkRemoveEmptySeries(seriesIds) {
-    if (!seriesIds?.length) return
-
-    const transaction = await Database.sequelize.transaction()
-    try {
-      const seriesToRemove = (
-        await Database.seriesModel.findAll({
-          where: [
-            {
-              id: seriesIds
-            },
-            sequelize.where(sequelize.literal('(SELECT count(*) FROM bookSeries bs WHERE bs.seriesId = series.id)'), 0)
-          ],
-          attributes: ['id', 'name', 'libraryId'],
-          include: {
-            model: Database.bookModel,
-            attributes: ['id'],
-            required: false // Ensure it includes series even if no books exist
-          },
-          transaction
-        })
-      ).map((s) => ({ id: s.id, name: s.name, libraryId: s.libraryId }))
-
-      if (seriesToRemove.length) {
-        await Database.seriesModel.destroy({
-          where: {
-            id: seriesToRemove.map((s) => s.id)
-          },
-          transaction
-        })
-      }
-
-      await transaction.commit()
-
-      seriesToRemove.forEach(({ id, name, libraryId }) => {
-        Logger.info(`[ApiRouter] Series "${name}" is now empty. Removing series`)
-
-        // Remove series from library filter data
-        Database.removeSeriesFromFilterData(libraryId, id)
-        SocketAuthority.emitter('series_removed', { id: id, libraryId: libraryId })
-      })
-      // Close rss feeds - remove from db and emit socket event
-      if (seriesToRemove.length) {
-        await RssFeedManager.closeFeedsForEntityIds(seriesToRemove.map((s) => s.id))
-      }
-    } catch (error) {
-      await transaction.rollback()
-      Logger.error(`[ApiRouter] Error removing empty series: ${error.message}`)
-    }
+    return checkRemoveEmptySeries(seriesIds)
   }
 
   /**
@@ -463,56 +417,7 @@ class ApiRouter {
    * @returns {Promise<void>}
    */
   async checkRemoveAuthorsWithNoBooks(authorIds) {
-    if (!authorIds?.length) return
-
-    const transaction = await Database.sequelize.transaction()
-    try {
-      // Select authors with locking to prevent concurrent updates
-      const bookAuthorsToRemove = (
-        await Database.authorModel.findAll({
-          where: [
-            {
-              id: authorIds,
-              asin: {
-                [sequelize.Op.or]: [null, '']
-              },
-              description: {
-                [sequelize.Op.or]: [null, '']
-              },
-              imagePath: {
-                [sequelize.Op.or]: [null, '']
-              }
-            },
-            sequelize.where(sequelize.literal('(SELECT count(*) FROM bookAuthors ba WHERE ba.authorId = author.id)'), 0)
-          ],
-          attributes: ['id', 'name', 'libraryId'],
-          raw: true,
-          transaction
-        })
-      ).map((au) => ({ id: au.id, name: au.name, libraryId: au.libraryId }))
-
-      if (bookAuthorsToRemove.length) {
-        await Database.authorModel.destroy({
-          where: {
-            id: bookAuthorsToRemove.map((au) => au.id)
-          },
-          transaction
-        })
-      }
-
-      await transaction.commit()
-
-      // Remove all book authors after completing remove from database
-      bookAuthorsToRemove.forEach(({ id, name, libraryId }) => {
-        Database.removeAuthorFromFilterData(libraryId, id)
-        // TODO: Clients were expecting full author in payload but its unnecessary
-        SocketAuthority.emitter('author_removed', { id, libraryId })
-        Logger.info(`[ApiRouter] Removed author "${name}" with no books`)
-      })
-    } catch (error) {
-      await transaction.rollback()
-      Logger.error(`[ApiRouter] Error removing authors: ${error.message}`)
-    }
+    return checkRemoveAuthorsWithNoBooks(authorIds)
   }
 
   async getUserListeningSessionsHelper(userId) {

--- a/server/utils/cleanup.js
+++ b/server/utils/cleanup.js
@@ -1,0 +1,126 @@
+const sequelize = require('sequelize')
+const Logger = require('../Logger')
+const Database = require('../Database')
+const SocketAuthority = require('../SocketAuthority')
+const RssFeedManager = require('../managers/RssFeedManager')
+
+/**
+ * After deleting book(s), remove empty series
+ *
+ * @param {string[]} seriesIds
+ */
+async function checkRemoveEmptySeries(seriesIds) {
+  if (!seriesIds?.length) return
+
+  const transaction = await Database.sequelize.transaction()
+  try {
+    const seriesToRemove = (
+      await Database.seriesModel.findAll({
+        where: [
+          {
+            id: seriesIds
+          },
+          sequelize.where(sequelize.literal('(SELECT count(*) FROM bookSeries bs WHERE bs.seriesId = series.id)'), 0)
+        ],
+        attributes: ['id', 'name', 'libraryId'],
+        include: {
+          model: Database.bookModel,
+          attributes: ['id'],
+          required: false // Ensure it includes series even if no books exist
+        },
+        transaction
+      })
+    ).map((s) => ({ id: s.id, name: s.name, libraryId: s.libraryId }))
+
+    if (seriesToRemove.length) {
+      await Database.seriesModel.destroy({
+        where: {
+          id: seriesToRemove.map((s) => s.id)
+        },
+        transaction
+      })
+    }
+
+    await transaction.commit()
+
+    seriesToRemove.forEach(({ id, name, libraryId }) => {
+      Logger.info(`[ApiRouter] Series "${name}" is now empty. Removing series`)
+
+      // Remove series from library filter data
+      Database.removeSeriesFromFilterData(libraryId, id)
+      SocketAuthority.emitter('series_removed', { id: id, libraryId: libraryId })
+    })
+    // Close rss feeds - remove from db and emit socket event
+    if (seriesToRemove.length) {
+      await RssFeedManager.closeFeedsForEntityIds(seriesToRemove.map((s) => s.id))
+    }
+  } catch (error) {
+    await transaction.rollback()
+    Logger.error(`[ApiRouter] Error removing empty series: ${error.message}`)
+  }
+}
+
+/**
+ * Remove authors with no books and unset asin, description and imagePath
+ * Note: Other implementation is in BookScanner.checkAuthorsRemovedFromBooks (can be merged)
+ *
+ * @param {string[]} authorIds
+ * @returns {Promise<void>}
+ */
+async function checkRemoveAuthorsWithNoBooks(authorIds) {
+  if (!authorIds?.length) return
+
+  const transaction = await Database.sequelize.transaction()
+  try {
+    // Select authors with locking to prevent concurrent updates
+    const bookAuthorsToRemove = (
+      await Database.authorModel.findAll({
+        where: [
+          {
+            id: authorIds,
+            asin: {
+              [sequelize.Op.or]: [null, '']
+            },
+            description: {
+              [sequelize.Op.or]: [null, '']
+            },
+            imagePath: {
+              [sequelize.Op.or]: [null, '']
+            }
+          },
+          sequelize.where(sequelize.literal('(SELECT count(*) FROM bookAuthors ba WHERE ba.authorId = author.id)'), 0)
+        ],
+        attributes: ['id', 'name', 'libraryId'],
+        raw: true,
+        transaction
+      })
+    ).map((au) => ({ id: au.id, name: au.name, libraryId: au.libraryId }))
+
+    if (bookAuthorsToRemove.length) {
+      await Database.authorModel.destroy({
+        where: {
+          id: bookAuthorsToRemove.map((au) => au.id)
+        },
+        transaction
+      })
+    }
+
+    await transaction.commit()
+
+    // Remove all book authors after completing remove from database
+    bookAuthorsToRemove.forEach(({ id, name, libraryId }) => {
+      Database.removeAuthorFromFilterData(libraryId, id)
+      // TODO: Clients were expecting full author in payload but its unnecessary
+      SocketAuthority.emitter('author_removed', { id, libraryId })
+      Logger.info(`[ApiRouter] Removed author "${name}" with no books`)
+    })
+  } catch (error) {
+    await transaction.rollback()
+    Logger.error(`[ApiRouter] Error removing authors: ${error.message}`)
+  }
+}
+
+module.exports = {
+  checkRemoveEmptySeries,
+  checkRemoveAuthorsWithNoBooks
+}


### PR DESCRIPTION
## Brief summary

Adds an optional configuration toggle to the "Schedule" tab in edit library to also run "Match Books" after the manually scheduled scans take place. Includes a slider for minimum confidence level threshold to accept the match.

## Which issue is fixed?

I'm not aware of an open issue for this feature. Allows for manually scheduling matching to be performed at a regular cadence.

## In-depth Description

Adds a boolean to the library settings model and confidence level threshold, then uses these in the CronManager to execute the match after the scan completes. Refactors ApiRouter a bit to avoid a circular dependency with the CronManager.

## How have you tested this?

Manually triggered in my dev build and ran npm test in both the root and client folders (are there other tests I should run?).

## Screenshots

<img width="820" height="604" alt="image" src="https://github.com/user-attachments/assets/d6b62058-d25f-433f-b6dc-301eb6b48230" />


<img width="820" height="646" alt="image" src="https://github.com/user-attachments/assets/34ee5df0-1032-481c-ba2a-e6b9f0af511f" />

