### PR TITLE
Add support for custom episode cover art for podcasts

### DIFF
--- a/client/components/app/MediaPlayerContainer.vue
+++ b/client/components/app/MediaPlayerContainer.vue
@@ -1,7 +1,7 @@
 <template>
   <div v-if="streamLibraryItem" id="mediaPlayerContainer" class="w-full fixed bottom-0 left-0 right-0 h-48 lg:h-40 z-50 bg-primary px-2 lg:px-4 pb-1 lg:pb-4 pt-2">
     <div class="absolute left-2 top-2 lg:left-4 cursor-pointer">
-      <covers-book-cover expand-on-click :library-item="streamLibraryItem" :width="bookCoverWidth" :book-cover-aspect-ratio="coverAspectRatio" />
+      <covers-book-cover expand-on-click :library-item="streamLibraryItem" :width="bookCoverWidth" :book-cover-aspect-ratio="coverAspectRatio" :cover-src="currentCoverSrc" />
     </div>
     <div class="flex items-start mb-6 lg:mb-0" :class="isSquareCover ? 'pl-18 sm:pl-24' : 'pl-12 sm:pl-16'">
       <div class="min-w-0 w-full">
@@ -178,6 +178,12 @@ export default {
     },
     playerQueueItems() {
       return this.$store.state.playerQueueItems || []
+    },
+    currentCoverSrc() {
+      if (this.streamEpisode?.coverPath) {
+        return `${this.$store.state.routerBasePath}/api/podcasts/${this.libraryItemId}/episode/${this.streamEpisode.id}/cover?ts=${this.streamEpisode.updatedAt}`
+      }
+      return null
     }
   },
   methods: {
@@ -397,7 +403,7 @@ export default {
           album: this.mediaMetadata.seriesName || '',
           artwork: [
             {
-              src: this.$store.getters['globals/getLibraryItemCoverSrc'](this.streamLibraryItem, '/Logo.png', true)
+              src: this.currentCoverSrc || this.$store.getters['globals/getLibraryItemCoverSrc'](this.streamLibraryItem, '/Logo.png', true)
             }
           ],
           chapterInfo

--- a/client/components/cards/LazyBookCard.vue
+++ b/client/components/cards/LazyBookCard.vue
@@ -230,6 +230,9 @@ export default {
       return this.store.getters['globals/getPlaceholderCoverSrc']
     },
     bookCoverSrc() {
+      if (this.recentEpisode?.coverPath) {
+        return `${this.store.state.routerBasePath}/api/podcasts/${this.libraryItemId}/episode/${this.recentEpisode.id}/cover?ts=${this.recentEpisode.updatedAt}`
+      }
       return this.store.getters['globals/getLibraryItemCoverSrc'](this._libraryItem, this.placeholderUrl)
     },
     libraryItemId() {
@@ -872,7 +875,7 @@ export default {
           subtitle: this.mediaMetadata.title,
           caption: this.recentEpisode.publishedAt ? this.$getString('LabelPublishedDate', [this.$formatDate(this.recentEpisode.publishedAt, this.dateFormat)]) : this.$strings.LabelUnknownPublishDate,
           duration: this.recentEpisode.audioFile.duration || null,
-          coverPath: this.media.coverPath || null
+          coverPath: this.recentEpisode.coverPath || this.media.coverPath || null
         }
       } else {
         queueItem = {
@@ -1032,7 +1035,7 @@ export default {
                   subtitle: this.mediaMetadata.title,
                   caption: episode.publishedAt ? this.$getString('LabelPublishedDate', [this.$formatDate(episode.publishedAt, this.dateFormat)]) : this.$strings.LabelUnknownPublishDate,
                   duration: episode.audioFile.duration || null,
-                  coverPath: this.media.coverPath || null
+                  coverPath: episode.coverPath || this.media.coverPath || null
                 })
               }
             }

--- a/client/components/covers/BookCover.vue
+++ b/client/components/covers/BookCover.vue
@@ -45,7 +45,11 @@ export default {
       default: 120
     },
     expandOnClick: Boolean,
-    bookCoverAspectRatio: Number
+    bookCoverAspectRatio: Number,
+    coverSrc: {
+      type: String,
+      default: null
+    }
   },
   data() {
     return {
@@ -100,6 +104,7 @@ export default {
       return store.getters['globals/getPlaceholderCoverSrc']
     },
     fullCoverUrl() {
+      if (this.coverSrc) return this.coverSrc
       if (!this.libraryItem) return null
       const store = this.$store || this.$nuxt.$store
       return store.getters['globals/getLibraryItemCoverSrc'](this.libraryItem, this.placeholderUrl)

--- a/client/components/modals/podcast/ViewEpisode.vue
+++ b/client/components/modals/podcast/ViewEpisode.vue
@@ -8,7 +8,7 @@
     <div ref="wrapper" class="p-4 w-full text-sm rounded-lg bg-bg shadow-lg border border-black-300 relative overflow-y-auto" style="max-height: 80vh">
       <div class="flex mb-4">
         <div class="w-12 h-12">
-          <covers-book-cover :library-item="libraryItem" :width="48" :book-cover-aspect-ratio="bookCoverAspectRatio" />
+          <covers-book-cover :library-item="libraryItem" :width="48" :book-cover-aspect-ratio="bookCoverAspectRatio" :cover-src="episodeCoverSrc" />
         </div>
         <div class="grow px-2">
           <p class="text-base mb-1">{{ podcastTitle }}</p>
@@ -102,6 +102,12 @@ export default {
     },
     bookCoverAspectRatio() {
       return this.$store.getters['libraries/getBookCoverAspectRatio']
+    },
+    episodeCoverSrc() {
+      if (this.episode?.coverPath) {
+        return `${this.$store.state.routerBasePath}/api/podcasts/${this.libraryItem.id}/episode/${this.episode.id}/cover?ts=${this.episode.updatedAt}`
+      }
+      return null
     }
   },
   methods: {

--- a/client/pages/library/_library/podcast/latest.vue
+++ b/client/pages/library/_library/podcast/latest.vue
@@ -8,11 +8,11 @@
         <p v-if="!recentEpisodes.length && !processing" class="text-center text-xl">{{ $strings.MessageNoEpisodes }}</p>
         <template v-for="(episode, index) in episodesMapped">
           <div :key="episode.id" class="flex py-5 cursor-pointer relative" @click.stop="clickEpisode(episode)">
-            <covers-preview-cover :src="$store.getters['globals/getLibraryItemCoverSrcById'](episode.libraryItemId, episode.updatedAt)" :width="96" :book-cover-aspect-ratio="bookCoverAspectRatio" :show-resolution="false" class="hidden md:block" />
+            <covers-preview-cover :src="getEpisodeCoverSrc(episode)" :width="96" :book-cover-aspect-ratio="bookCoverAspectRatio" :show-resolution="false" class="hidden md:block" />
             <div class="grow pl-4 max-w-2xl">
               <!-- mobile -->
               <div class="flex md:hidden mb-2">
-                <covers-preview-cover :src="$store.getters['globals/getLibraryItemCoverSrcById'](episode.libraryItemId, episode.updatedAt)" :width="48" :book-cover-aspect-ratio="bookCoverAspectRatio" :show-resolution="false" class="md:hidden" />
+                <covers-preview-cover :src="getEpisodeCoverSrc(episode)" :width="48" :book-cover-aspect-ratio="bookCoverAspectRatio" :show-resolution="false" class="md:hidden" />
                 <div class="grow px-2">
                   <div class="flex items-center">
                     <div class="flex" @click.stop>
@@ -145,6 +145,13 @@ export default {
     }
   },
   methods: {
+    getEpisodeCoverSrc(episode) {
+      if (episode.coverPath) {
+        return `${this.$store.state.routerBasePath}/api/podcasts/${episode.libraryItemId}/episode/${episode.id}/cover?ts=${episode.updatedAt}`
+      }
+      // Fallback to podcast cover
+      return this.$store.getters['globals/getLibraryItemCoverSrcById'](episode.libraryItemId, episode.updatedAt)
+    },
     async toggleEpisodeFinished(episode, confirmed = false) {
       if (this.episodesProcessingMap[episode.id]) {
         console.warn('Episode is already processing')
@@ -236,7 +243,7 @@ export default {
             subtitle: episode.podcast.metadata.title,
             caption: episode.publishedAt ? this.$getString('LabelPublishedDate', [this.$formatDate(episode.publishedAt, this.dateFormat)]) : this.$strings.LabelUnknownPublishDate,
             duration: episode.duration || null,
-            coverPath: episode.podcast.coverPath || null
+            coverPath: episode.coverPath || episode.podcast.coverPath || null
           })
         }
       }
@@ -273,7 +280,7 @@ export default {
           subtitle: episode.podcast.metadata.title,
           caption: episode.publishedAt ? this.$getString('LabelPublishedDate', [this.$formatDate(episode.publishedAt, this.dateFormat)]) : this.$strings.LabelUnknownPublishDate,
           duration: episode.duration || null,
-          coverPath: episode.podcast.coverPath || null
+          coverPath: episode.coverPath || episode.podcast.coverPath || null
         }
         this.$store.commit('addItemToQueue', queueItem)
       }

--- a/server/Auth.js
+++ b/server/Auth.js
@@ -18,7 +18,11 @@ const { escapeRegExp } = require('./utils')
 class Auth {
   constructor() {
     const escapedRouterBasePath = escapeRegExp(global.RouterBasePath)
-    this.ignorePatterns = [new RegExp(`^(${escapedRouterBasePath}/api)?/items/[^/]+/cover$`), new RegExp(`^(${escapedRouterBasePath}/api)?/authors/[^/]+/image$`)]
+    this.ignorePatterns = [
+      new RegExp(`^(${escapedRouterBasePath}/api)?/items/[^/]+/cover$`),
+      new RegExp(`^(${escapedRouterBasePath}/api)?/authors/[^/]+/image$`),
+      new RegExp(`^(${escapedRouterBasePath}/api)?/podcasts/[^/]+/episode/[^/]+/cover$`)
+    ]
 
     /** @type {import('express-rate-limit').RateLimitRequestHandler} */
     this.authRateLimiter = RateLimiterFactory.getAuthRateLimiter()

--- a/server/managers/CacheManager.js
+++ b/server/managers/CacheManager.js
@@ -77,7 +77,66 @@ class CacheManager {
     readStream.pipe(res)
   }
 
-  purgeCoverCache(libraryItemId) {
+  /**
+   * @param {import('express').Response} res
+   * @param {string} libraryItemId
+   * @param {string} episodeId
+   * @param {{ format?: string, width?: number, height?: number }} options
+   * @returns {Promise<void>}
+   */
+  async handleEpisodeCoverCache(res, libraryItemId, episodeId, options = {}) {
+    const format = options.format || 'webp'
+    const width = options.width || 400
+    const height = options.height || null
+
+    res.type(`image/${format}`)
+
+    const cachePath = Path.join(this.CoverCachePath, `${libraryItemId}_episode_${episodeId}_${width}${height ? `x${height}` : ''}`) + '.' + format
+
+    // Cache exists
+    if (await fs.pathExists(cachePath)) {
+      if (global.XAccel) {
+        const encodedURI = encodeUriPath(global.XAccel + cachePath)
+        Logger.debug(`Use X-Accel to serve static file ${encodedURI}`)
+        return res.status(204).header({ 'X-Accel-Redirect': encodedURI }).send()
+      }
+
+      const r = fs.createReadStream(cachePath)
+      const ps = new stream.PassThrough()
+      stream.pipeline(r, ps, (err) => {
+        if (err) {
+          console.log(err)
+          return res.sendStatus(500)
+        }
+      })
+      return ps.pipe(res)
+    }
+
+    const episode = await Database.podcastEpisodeModel.findByPk(episodeId)
+    if (!episode || !episode.coverPath || !(await fs.pathExists(episode.coverPath))) {
+      // Fallback to podcast cover
+      return this.handleCoverCache(res, libraryItemId, options)
+    }
+
+    const writtenFile = await resizeImage(episode.coverPath, cachePath, width, height)
+    if (!writtenFile) return res.sendStatus(500)
+
+    if (global.XAccel) {
+      const encodedURI = encodeUriPath(global.XAccel + writtenFile)
+      Logger.debug(`Use X-Accel to serve static file ${encodedURI}`)
+      return res.status(204).header({ 'X-Accel-Redirect': encodedURI }).send()
+    }
+
+    var readStream = fs.createReadStream(writtenFile)
+    readStream.pipe(res)
+  }
+
+  purgeCoverCache(libraryItemId, episodeId = null) {
+    if (libraryItemId && episodeId) {
+      return this.purgeEntityCache(`${libraryItemId}_episode_${episodeId}`, this.CoverCachePath)
+    } else if (!libraryItemId && episodeId) {
+      return this.purgeEntityCache(`episode_${episodeId}`, this.CoverCachePath)
+    }
     return this.purgeEntityCache(libraryItemId, this.CoverCachePath)
   }
 

--- a/server/migrations/v2.30.1-episode-cover-support.js
+++ b/server/migrations/v2.30.1-episode-cover-support.js
@@ -1,0 +1,133 @@
+/**
+ * @typedef MigrationContext
+ * @property {import('sequelize').QueryInterface} queryInterface - a Sequelize QueryInterface object.
+ * @property {import('../Logger')} logger - a Logger object.
+ *
+ * @typedef MigrationOptions
+ * @property {MigrationContext} context - an object containing the migration context.
+ */
+
+const migrationVersion = '2.30.1'
+const migrationName = `${migrationVersion}-episode-cover-support`
+const loggerPrefix = `[${migrationVersion} migration]`
+
+/**
+ * This migration adds support for episode-specific cover art by adding:
+ * - coverPath and imageURL columns to podcastEpisodes table
+ * - episodeCoverURL column to feedEpisodes table
+ *
+ * @param {MigrationOptions} options - an object containing the migration context.
+ * @returns {Promise<void>} - A promise that resolves when the migration is complete.
+ */
+async function up({ context: { queryInterface, logger } }) {
+  logger.info(`${loggerPrefix} UPGRADE BEGIN: ${migrationName}`)
+
+  // Upgrade podcastEpisodes table
+  if (await queryInterface.tableExists('podcastEpisodes')) {
+    const podcastEpisodesDescription = await queryInterface.describeTable('podcastEpisodes')
+
+    // Add coverPath column if it doesn't exist
+    if (!podcastEpisodesDescription.coverPath) {
+      logger.info(`${loggerPrefix} Adding coverPath column to podcastEpisodes table`)
+      await queryInterface.addColumn('podcastEpisodes', 'coverPath', {
+        type: queryInterface.sequelize.Sequelize.DataTypes.STRING,
+        allowNull: true
+      })
+      logger.info(`${loggerPrefix} Added coverPath column to podcastEpisodes table`)
+    } else {
+      logger.info(`${loggerPrefix} coverPath column already exists in podcastEpisodes table`)
+    }
+
+    // Add imageURL column if it doesn't exist
+    if (!podcastEpisodesDescription.imageURL) {
+      logger.info(`${loggerPrefix} Adding imageURL column to podcastEpisodes table`)
+      await queryInterface.addColumn('podcastEpisodes', 'imageURL', {
+        type: queryInterface.sequelize.Sequelize.DataTypes.STRING,
+        allowNull: true
+      })
+      logger.info(`${loggerPrefix} Added imageURL column to podcastEpisodes table`)
+    } else {
+      logger.info(`${loggerPrefix} imageURL column already exists in podcastEpisodes table`)
+    }
+  } else {
+    logger.info(`${loggerPrefix} podcastEpisodes table does not exist`)
+  }
+
+  // Upgrade feedEpisodes table
+  if (await queryInterface.tableExists('feedEpisodes')) {
+    const feedEpisodesDescription = await queryInterface.describeTable('feedEpisodes')
+
+    // Add episodeCoverURL column if it doesn't exist
+    if (!feedEpisodesDescription.episodeCoverURL) {
+      logger.info(`${loggerPrefix} Adding episodeCoverURL column to feedEpisodes table`)
+      await queryInterface.addColumn('feedEpisodes', 'episodeCoverURL', {
+        type: queryInterface.sequelize.Sequelize.DataTypes.STRING,
+        allowNull: true
+      })
+      logger.info(`${loggerPrefix} Added episodeCoverURL column to feedEpisodes table`)
+    } else {
+      logger.info(`${loggerPrefix} episodeCoverURL column already exists in feedEpisodes table`)
+    }
+  } else {
+    logger.info(`${loggerPrefix} feedEpisodes table does not exist`)
+  }
+
+  logger.info(`${loggerPrefix} UPGRADE END: ${migrationName}`)
+}
+
+/**
+ * This migration removes episode-specific cover art support by removing:
+ * - coverPath and imageURL columns from podcastEpisodes table
+ * - episodeCoverURL column from feedEpisodes table
+ *
+ * @param {MigrationOptions} options - an object containing the migration context.
+ * @returns {Promise<void>} - A promise that resolves when the migration is complete.
+ */
+async function down({ context: { queryInterface, logger } }) {
+  logger.info(`${loggerPrefix} DOWNGRADE BEGIN: ${migrationName}`)
+
+  // Downgrade podcastEpisodes table
+  if (await queryInterface.tableExists('podcastEpisodes')) {
+    const podcastEpisodesDescription = await queryInterface.describeTable('podcastEpisodes')
+
+    // Remove coverPath column if it exists
+    if (podcastEpisodesDescription.coverPath) {
+      logger.info(`${loggerPrefix} Removing coverPath column from podcastEpisodes table`)
+      await queryInterface.removeColumn('podcastEpisodes', 'coverPath')
+      logger.info(`${loggerPrefix} Removed coverPath column from podcastEpisodes table`)
+    } else {
+      logger.info(`${loggerPrefix} coverPath column does not exist in podcastEpisodes table`)
+    }
+
+    // Remove imageURL column if it exists
+    if (podcastEpisodesDescription.imageURL) {
+      logger.info(`${loggerPrefix} Removing imageURL column from podcastEpisodes table`)
+      await queryInterface.removeColumn('podcastEpisodes', 'imageURL')
+      logger.info(`${loggerPrefix} Removed imageURL column from podcastEpisodes table`)
+    } else {
+      logger.info(`${loggerPrefix} imageURL column does not exist in podcastEpisodes table`)
+    }
+  } else {
+    logger.info(`${loggerPrefix} podcastEpisodes table does not exist`)
+  }
+
+  // Downgrade feedEpisodes table
+  if (await queryInterface.tableExists('feedEpisodes')) {
+    const feedEpisodesDescription = await queryInterface.describeTable('feedEpisodes')
+
+    // Remove episodeCoverURL column if it exists
+    if (feedEpisodesDescription.episodeCoverURL) {
+      logger.info(`${loggerPrefix} Removing episodeCoverURL column from feedEpisodes table`)
+      await queryInterface.removeColumn('feedEpisodes', 'episodeCoverURL')
+      logger.info(`${loggerPrefix} Removed episodeCoverURL column from feedEpisodes table`)
+    } else {
+      logger.info(`${loggerPrefix} episodeCoverURL column does not exist in feedEpisodes table`)
+    }
+  } else {
+    logger.info(`${loggerPrefix} feedEpisodes table does not exist`)
+  }
+
+  logger.info(`${loggerPrefix} DOWNGRADE END: ${migrationName}`)
+}
+
+module.exports = { up, down }

--- a/server/models/PodcastEpisode.js
+++ b/server/models/PodcastEpisode.js
@@ -45,6 +45,10 @@ class PodcastEpisode extends Model {
     /** @type {Object} */
     this.extraData
     /** @type {string} */
+    this.coverPath
+    /** @type {string} */
+    this.imageURL
+    /** @type {string} */
     this.podcastId
     /** @type {Date} */
     this.createdAt
@@ -75,7 +79,8 @@ class PodcastEpisode extends Model {
       podcastId,
       audioFile: audioFile.toJSON(),
       chapters: [],
-      extraData: {}
+      extraData: {},
+      imageURL: rssPodcastEpisode.image || null
     }
     if (rssPodcastEpisode.guid) {
       podcastEpisode.extraData.guid = rssPodcastEpisode.guid
@@ -117,7 +122,9 @@ class PodcastEpisode extends Model {
 
         audioFile: DataTypes.JSON,
         chapters: DataTypes.JSON,
-        extraData: DataTypes.JSON
+        extraData: DataTypes.JSON,
+        coverPath: DataTypes.STRING,
+        imageURL: DataTypes.STRING
       },
       {
         sequelize,
@@ -156,6 +163,22 @@ class PodcastEpisode extends Model {
 
   get duration() {
     return this.audioFile?.duration || 0
+  }
+
+  /**
+   * Check if episode has a custom cover
+   * @returns {boolean}
+   */
+  hasCover() {
+    return !!this.coverPath
+  }
+
+  /**
+   * Get the cover path for this episode
+   * @returns {string|null}
+   */
+  getCoverPath() {
+    return this.coverPath || null
   }
 
   /**
@@ -223,7 +246,9 @@ class PodcastEpisode extends Model {
       audioFile: structuredClone(this.audioFile),
       publishedAt: this.publishedAt?.valueOf() || null,
       addedAt: this.createdAt.valueOf(),
-      updatedAt: this.updatedAt.valueOf()
+      updatedAt: this.updatedAt.valueOf(),
+      coverPath: this.coverPath || null,
+      imageURL: this.imageURL || null
     }
   }
 

--- a/server/routers/ApiRouter.js
+++ b/server/routers/ApiRouter.js
@@ -251,6 +251,7 @@ class ApiRouter {
     this.router.post('/podcasts/:id/download-episodes', PodcastController.middleware.bind(this), PodcastController.downloadEpisodes.bind(this))
     this.router.post('/podcasts/:id/match-episodes', PodcastController.middleware.bind(this), PodcastController.quickMatchEpisodes.bind(this))
     this.router.get('/podcasts/:id/episode/:episodeId', PodcastController.middleware.bind(this), PodcastController.getEpisode.bind(this))
+    this.router.get('/podcasts/:id/episode/:episodeId/cover', PodcastController.getEpisodeCover.bind(this))
     this.router.patch('/podcasts/:id/episode/:episodeId', PodcastController.middleware.bind(this), PodcastController.updateEpisode.bind(this))
     this.router.delete('/podcasts/:id/episode/:episodeId', PodcastController.middleware.bind(this), PodcastController.removeEpisode.bind(this))
 

--- a/server/utils/podcastUtils.js
+++ b/server/utils/podcastUtils.js
@@ -33,6 +33,7 @@ const Fuse = require('../libs/fusejs')
  * @property {string} chaptersUrl
  * @property {string} chaptersType
  * @property {RssPodcastChapter[]} chapters
+ * @property {string|null} image - Episode-specific iTunes image URL
  */
 
 /**
@@ -211,6 +212,11 @@ function extractEpisodeData(item) {
     }
   }
 
+  // Extract episode image
+  if (item['itunes:image']?.[0]?.['$']?.href) {
+    episode.image = item['itunes:image'][0]['$'].href
+  }
+
   const arrayFields = ['title', 'itunes:episodeType', 'itunes:season', 'itunes:episode', 'itunes:author', 'itunes:duration', 'itunes:explicit', 'itunes:subtitle']
   arrayFields.forEach((key) => {
     const cleanKey = key.split(':').pop()
@@ -282,7 +288,8 @@ function cleanEpisodeData(data) {
     guid: data.guid || null,
     chaptersUrl: data.chaptersUrl || null,
     chaptersType: data.chaptersType || null,
-    chapters: data.chapters || []
+    chapters: data.chapters || [],
+    image: data.image || null
   }
 }
 


### PR DESCRIPTION
## Brief summary

<!-- Please provide a brief summary of what your PR attempts to achieve. -->
This PR adds the feature to download [episode art](https://podcasters.apple.com/support/5516-episode-art-template) for specific episodes. It first checks for the `<itunes:image>` tag, and if it doesn’t exist, it attempts to extract the image from the audio file.

## Which issue is fixed?

<!-- Which issue number does this PR fix? Ex: "Fixes #1234" -->
Fixes #1573 

## In-depth Description

<!--
Describe your solution in more depth.
How does it work? Why is this the best solution?
Does it solve a problem that affects multiple users or is this an edge case for your setup?
-->
This PR updates the Server to attempt to download the episode art from the <itunes:image> tag in the feed. If that’s not possible, it tries to extract the image directly from the audio file.

If an episode doesn’t have a custom cover, the podcast’s main cover will continue to be used.
Since the client is being rewritten, I’ve kept UI changes to a minimum. The updates were applied to the following pages:
 - Latest Episodes page
 - Library home page (Continue Listening shelf)
 - Miniplayer
 - Episode details modal

Once the new UI is ready, I can move these changes there.

Two new columns have been added via migration (sorry, I set a future version for the migration):
 - podcastEpisodes.coverPath — stores the local file path
 - podcastEpisodes.imageURL — stores the RSS feed image URL
 - feedEpisodes.episodeCoverURL — used for RSS feed generation

The episode art are saved on: `metadata/episodes/<EPISODE_ID>/cover.jpg`

I try to replicate in the Cache Manager the same behavior used for caching podcast covers.
Also, I added the podcast cover URL to the exception list in the Auth.js file so that it doesn’t require authentication.

If this PR is integrated, I can create a new PR to add this feature to the mobile app as well.

Also, a new endpoint to return the Episode Art was created: `/podcasts/:id/episode/:episodeId/cover`, this can be used by other application like ShelfPlayer: https://github.com/rasmuslos/ShelfPlayer/issues/175

## How have you tested this?

<!-- Please describe in detail with reproducible steps how you tested your changes. -->
Yes, I tested with two podcasts that have different cover art for specific episodes:
 - In the Dark: https://publicfeeds.net/f/5770/in-the-dark
 - Vortex: https://anchor.fm/s/10a0d0948/podcast/rss
 
Add these podcasts to your library, download a few episodes, and check them on the Latest Episodes page.

## Screenshots

### Library Home
<img width="1318" height="815" alt="Screenshot 2025-11-06 at 18 41 09" src="https://github.com/user-attachments/assets/00440ce6-6ba1-4ce3-9685-1078e86cf094" />

---

### Latest
<img width="788" height="581" alt="Screenshot 2025-11-06 at 18 42 41" src="https://github.com/user-attachments/assets/d39e10f7-324c-4904-986e-313186285631" />

---

### Episode Modal
<img width="615" height="527" alt="Screenshot 2025-11-06 at 18 42 54" src="https://github.com/user-attachments/assets/dc0e32ed-5efe-4b82-8665-4747c5d4d648" />

---

## Demo

https://github.com/user-attachments/assets/2d0ec6e4-b09d-4317-b4fe-61838f3b7a17

