### PR TITLE
Support eac3 and ac3 in transcodes

### DIFF
--- a/server/objects/Stream.js
+++ b/server/objects/Stream.js
@@ -275,7 +275,7 @@ class Stream extends EventEmitter {
 
     const codecOptions = [`-loglevel ${logLevel}`, '-map 0:a']
 
-    if (this.codecsToForceAAC.slice(1, 3).includes(this.tracksCodec) && this.tracks.length > 0 && this.tracks[0].bitRate && this.tracks[0].channels) {
+    if (['ac3', 'eac3'].includes(this.tracksCodec) && this.tracks.length > 0 && this.tracks[0].bitRate && this.tracks[0].channels) {
       // In case for ac3/eac3 it needs to be passed the bitrate and channels to avoid ffmpeg errors
       codecOptions.push(`-c:a ${audioCodec}`, `-b:a ${this.tracks[0].bitRate}`, `-ac ${this.tracks[0].channels}`)
     } else {


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary
Basically, HLS allows AC-3. The problem is that if the browser does not support AC-3, it fails again. Since the MIME type is MP4, we have to force the codec by codec. 
This has the downside that browsers that fail and transcode an AC-3 file will only get an AAC file. But I think this should never happen because it would then perform a direct play. So this should fix EAC-3/AC-3 not playable

## Which issue is fixed?

#4798 

## In-depth Description

See the conversation in the attached issue and my short description

## How have you tested this?

Tried to play an EAC-3 file with Firefox which does not support it. Before it failed. Now it worked. It should not affect any other codecs. So nothing that was not broken should be able to be broken now.

Thanks to @TheStaticTurtle

## Screenshots

<!-- If your PR includes any changes to the web client, please include screenshots or a short video from before and after your changes. -->
