### PR TITLE
Fix Upload Lookup

### DIFF
--- a/server/controllers/SearchController.js
+++ b/server/controllers/SearchController.js
@@ -88,10 +88,10 @@ class SearchController {
       const provider = getQueryParamAsString(query, 'provider', 'google')
       const title = getQueryParamAsString(query, 'title', '')
       const author = getQueryParamAsString(query, 'author', '')
-      const id = getQueryParamAsString(query, 'id', '', true)
+      const id = getQueryParamAsString(query, 'id', undefined)
 
       // Fetch library item
-      const libraryItem = await SearchController.fetchLibraryItem(id)
+      const libraryItem = id ? await SearchController.fetchLibraryItem(id) : null
 
       const results = await BookFinder.search(libraryItem, provider, title, author)
       res.json(results)

--- a/server/finders/BookFinder.js
+++ b/server/finders/BookFinder.js
@@ -428,7 +428,7 @@ class BookFinder {
       }
     }
 
-    if (books.length) {
+    if (books.length && libraryItem) {
       const isAudibleProvider = provider.startsWith('audible')
       const libraryItemDurationMinutes = libraryItem?.media?.duration ? libraryItem.media.duration / 60 : null
 


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

When uploading a book through the interface and pressing the "Automatically fetch..." button, it fails because a recent refactor in the finder logic now requires a libraryId to be provided. Since any item not yet uploaded has no id, this caused the error.  
This PR fixes the issue and makes the button work again.  
It also disables the heuristic for scoring and sorting since it is not available anyway if there is no id available. Currently, the API returns a low confidence score when not providing an id, which is incorrect.

## Which issue is fixed?

DC

## In-depth Description

See above

## How have you tested this?

Uploaded and matched book

## Screenshots

<!-- If your PR includes any changes to the web client, please include screenshots or a short video from before and after your changes. -->
