### PR TITLE
Added support for authenticated podcast feeds

### DIFF
--- a/client/components/modals/podcast/NewModal.vue
+++ b/client/components/modals/podcast/NewModal.vue
@@ -29,14 +29,17 @@
           </div>
         </div>
         <div class="flex flex-wrap">
-          <div class="md:w-1/4 p-2">
+          <div class="w-full md:w-1/4 p-2">
             <ui-dropdown :label="$strings.LabelPodcastType" v-model="podcast.type" :items="podcastTypes" small />
           </div>
-          <div class="md:w-1/4 p-2">
+          <div class="w-full md:w-1/4 p-2">
             <ui-text-input-with-label v-model="podcast.language" :label="$strings.LabelLanguage" />
           </div>
-          <div class="md:w-1/4 px-2 pt-7">
+          <div class="w-full md:w-1/4 px-2 pt-7">
             <ui-checkbox v-model="podcast.explicit" :label="$strings.LabelExplicit" checkbox-bg="primary" border-color="gray-600" label-class="pl-2 text-base font-semibold" />
+          </div>
+          <div class="w-full md:w-1/4 px-2 pt-7">
+            <ui-checkbox v-model="podcast.isAuthenticatedFeed" :label="$strings.LabelAuthenticatedFeed" checkbox-bg="primary" border-color="gray-600" label-class="pl-2 text-base font-semibold" />
           </div>
         </div>
         <div class="p-2 w-full">
@@ -96,6 +99,7 @@ export default {
         autoDownloadEpisodes: false,
         language: '',
         explicit: false,
+        isAuthenticatedFeed: false,
         type: ''
       }
     }
@@ -194,6 +198,7 @@ export default {
             itunesArtistId: this.podcast.itunesArtistId,
             language: this.podcast.language,
             explicit: this.podcast.explicit,
+            isAuthenticatedFeed: this.podcast.isAuthenticatedFeed,
             type: this.podcast.type
           },
           autoDownloadEpisodes: this.podcast.autoDownloadEpisodes
@@ -234,6 +239,7 @@ export default {
       this.podcast.type = this._podcastData.type || this.feedMetadata.type || 'episodic'
 
       this.podcast.explicit = this._podcastData.explicit || this.feedMetadata.explicit === 'yes' || this.feedMetadata.explicit == 'true'
+      this.podcast.isAuthenticatedFeed = this._podcastData.isAuthenticatedFeed || false
       if (this.folderItems[0]) {
         this.selectedFolderId = this.folderItems[0].value
         this.folderUpdated()

--- a/client/components/widgets/PodcastDetailsEdit.vue
+++ b/client/components/widgets/PodcastDetailsEdit.vue
@@ -34,8 +34,9 @@
           <ui-text-input-with-label ref="languageInput" v-model="details.language" :label="$strings.LabelLanguage" trim-whitespace @input="handleInputChange" />
         </div>
         <div class="grow px-1 pt-6">
-          <div class="flex justify-center">
+          <div class="flex justify-center space-x-4">
             <ui-checkbox v-model="details.explicit" :label="$strings.LabelExplicit" checkbox-bg="primary" border-color="gray-600" label-class="pl-2 text-base font-semibold" @input="handleInputChange" />
+            <ui-checkbox v-model="details.isAuthenticatedFeed" :label="$strings.LabelAuthenticatedFeed" checkbox-bg="primary" border-color="gray-600" label-class="pl-2 text-base font-semibold" @input="handleInputChange" />
           </div>
         </div>
       </div>
@@ -70,6 +71,7 @@ export default {
         itunesId: null,
         itunesArtistId: null,
         explicit: false,
+        isAuthenticatedFeed: false,
         language: null,
         type: null
       },
@@ -241,6 +243,7 @@ export default {
       this.details.itunesArtistId = this.mediaMetadata.itunesArtistId || ''
       this.details.language = this.mediaMetadata.language || ''
       this.details.explicit = !!this.mediaMetadata.explicit
+      this.details.isAuthenticatedFeed = !!this.mediaMetadata.isAuthenticatedFeed
       this.details.type = this.mediaMetadata.type || 'episodic'
 
       this.newTags = [...(this.media.tags || [])]

--- a/client/strings/en-us.json
+++ b/client/strings/en-us.json
@@ -366,6 +366,7 @@
   "LabelExplicit": "Explicit",
   "LabelExplicitChecked": "Explicit (checked)",
   "LabelExplicitUnchecked": "Not Explicit (unchecked)",
+  "LabelAuthenticatedFeed": "Authenticated Feed",
   "LabelExportOPML": "Export OPML",
   "LabelFeedURL": "Feed URL",
   "LabelFetchingMetadata": "Fetching Metadata",

--- a/server/migrations/v2.30.1-add-is-authenticated-feed.js
+++ b/server/migrations/v2.30.1-add-is-authenticated-feed.js
@@ -1,0 +1,68 @@
+/**
+ * @typedef MigrationContext
+ * @property {import('sequelize').QueryInterface} queryInterface - a suquelize QueryInterface object.
+ * @property {import('../Logger')} logger - a Logger object.
+ *
+ * @typedef MigrationOptions
+ * @property {MigrationContext} context - an object containing the migration context.
+ */
+
+const migrationVersion = '2.30.1'
+const migrationName = `${migrationVersion}-add-is-authenticated-feed`
+const loggerPrefix = `[${migrationVersion} migration]`
+
+/**
+ * This upward migration adds the isAuthenticatedFeed column to the podcasts table.
+ *
+ * @param {MigrationOptions} options - an object containing the migration context.
+ * @returns {Promise<void>} - A promise that resolves when the migration is complete.
+ */
+async function up({ context: { queryInterface, logger } }) {
+  // Upwards migration script
+  logger.info(`${loggerPrefix} UPGRADE BEGIN: ${migrationName}`)
+
+  const DataTypes = queryInterface.sequelize.Sequelize.DataTypes
+
+  // Check if column exists
+  const tableDescription = await queryInterface.describeTable('podcasts')
+  if (tableDescription.isAuthenticatedFeed) {
+    logger.info(`${loggerPrefix} column "isAuthenticatedFeed" already exists in "podcasts" table`)
+  } else {
+    // Add column
+    logger.info(`${loggerPrefix} adding column "isAuthenticatedFeed" to "podcasts" table`)
+    await queryInterface.addColumn('podcasts', 'isAuthenticatedFeed', {
+      type: DataTypes.BOOLEAN,
+      defaultValue: false,
+      allowNull: false
+    })
+    logger.info(`${loggerPrefix} added column "isAuthenticatedFeed" to "podcasts" table`)
+  }
+
+  logger.info(`${loggerPrefix} UPGRADE COMPLETE: ${migrationName}`)
+}
+
+/**
+ * This downward migration removes the isAuthenticatedFeed column from the podcasts table.
+ *
+ * @param {MigrationOptions} options - an object containing the migration context.
+ * @returns {Promise<void>} - A promise that resolves when the migration is complete.
+ */
+async function down({ context: { queryInterface, logger } }) {
+  // Downwards migration script
+  logger.info(`${loggerPrefix} DOWNGRADE BEGIN: ${migrationName}`)
+
+  // Check if column exists
+  const tableDescription = await queryInterface.describeTable('podcasts')
+  if (!tableDescription.isAuthenticatedFeed) {
+    logger.info(`${loggerPrefix} column "isAuthenticatedFeed" does not exist in "podcasts" table`)
+  } else {
+    // Remove column
+    logger.info(`${loggerPrefix} removing column "isAuthenticatedFeed" from "podcasts" table`)
+    await queryInterface.removeColumn('podcasts', 'isAuthenticatedFeed')
+    logger.info(`${loggerPrefix} removed column "isAuthenticatedFeed" from "podcasts" table`)
+  }
+
+  logger.info(`${loggerPrefix} DOWNGRADE COMPLETE: ${migrationName}`)
+}
+
+module.exports = { up, down }

--- a/server/models/Podcast.js
+++ b/server/models/Podcast.js
@@ -44,6 +44,8 @@ class Podcast extends Model {
     /** @type {boolean} */
     this.explicit
     /** @type {boolean} */
+    this.isAuthenticatedFeed
+    /** @type {boolean} */
     this.autoDownloadEpisodes
     /** @type {string} */
     this.autoDownloadSchedule
@@ -104,6 +106,7 @@ class Podcast extends Model {
         language: typeof payload.metadata.language === 'string' ? payload.metadata.language : null,
         podcastType: typeof payload.metadata.type === 'string' ? payload.metadata.type : null,
         explicit: !!payload.metadata.explicit,
+        isAuthenticatedFeed: !!payload.metadata.isAuthenticatedFeed,
         autoDownloadEpisodes: !!payload.autoDownloadEpisodes,
         autoDownloadSchedule: autoDownloadSchedule || global.ServerSettings.podcastEpisodeSchedule,
         lastEpisodeCheck: new Date(),
@@ -141,6 +144,7 @@ class Podcast extends Model {
         language: DataTypes.STRING,
         podcastType: DataTypes.STRING,
         explicit: DataTypes.BOOLEAN,
+        isAuthenticatedFeed: DataTypes.BOOLEAN,
 
         autoDownloadEpisodes: DataTypes.BOOLEAN,
         autoDownloadSchedule: DataTypes.STRING,
@@ -249,6 +253,11 @@ class Podcast extends Model {
 
       if (payload.metadata.explicit !== undefined && payload.metadata.explicit !== this.explicit) {
         this.explicit = !!payload.metadata.explicit
+        hasUpdates = true
+      }
+
+      if (payload.metadata.isAuthenticatedFeed !== undefined && payload.metadata.isAuthenticatedFeed !== this.isAuthenticatedFeed) {
+        this.isAuthenticatedFeed = !!payload.metadata.isAuthenticatedFeed
         hasUpdates = true
       }
 
@@ -407,6 +416,7 @@ class Podcast extends Model {
       itunesId: this.itunesId,
       itunesArtistId: this.itunesArtistId,
       explicit: this.explicit,
+      isAuthenticatedFeed: this.isAuthenticatedFeed,
       language: this.language,
       type: this.podcastType
     }

--- a/server/utils/ffmpegHelpers.js
+++ b/server/utils/ffmpegHelpers.js
@@ -108,19 +108,33 @@ module.exports.downloadPodcastEpisode = (podcastEpisodeDownload) => {
     // See: https://github.com/advplyr/audiobookshelf/issues/4401 (requires no iTMS user agent)
     const userAgents = ['audiobookshelf (+https://audiobookshelf.org; like iTMS)', 'audiobookshelf (+https://audiobookshelf.org)']
 
+    let refererHeader = null
+    const feedURL = podcastEpisodeDownload.libraryItem?.media?.feedURL
+    const isAuthenticatedFeed = podcastEpisodeDownload.libraryItem?.media?.isAuthenticatedFeed || false
+
+    if (feedURL && isAuthenticatedFeed) {
+      refererHeader = feedURL
+    }
+
     let response = null
     let lastError = null
 
     for (const userAgent of userAgents) {
       try {
+        const headers = {
+          Accept: '*/*',
+          'User-Agent': userAgent
+        }
+
+        if (refererHeader) {
+          headers['Referer'] = refererHeader
+        }
+
         response = await axios({
           url: podcastEpisodeDownload.url,
           method: 'GET',
           responseType: 'stream',
-          headers: {
-            Accept: '*/*',
-            'User-Agent': userAgent
-          },
+          headers,
           timeout: global.PodcastDownloadTimeout
         })
 


### PR DESCRIPTION
No Issue created -> New Proposed Feature (Could be considered a fix as well?)

Added user-configurable "Authenticated Feed" option for podcast downloads such as from the Verge's add-free podcast feeds. 

I added a an option for a user to set a new flag `isAuthenticatedFeed` as I thought that doing it based on URL string values would be far too "hacky". 

Previously the episode downloads would fail as the HTTP request headers were missing the `['referer']` value which is simply the feeds URL. I believe we could simply send the missing `['referer']` value into the header with no consequences and that would simplify my code. I didn't do that simply because I am not an expert on the norms around podcast feeds and certain servers 'could" reject the request if the header was unneeded. If someone has more experience I would appreciate their thoughts.  Therefore the changes I made to fix the issue are:

- Backend logic in `ffmpegHelpers.js` to conditionally add Referer header
- UI components to allow users to set the flag
- Updated Podcast model to handle the new field

I tophatted the changes and found that episode downloads worked in my instance when going through the modal for Episodes and I requested a download there, or when the CRON job would run. 

I did not add a test since the initial code was not tested. 

Note: Hopefully all required information is provided, please let me know if there are any issues as I tried to follow the documentation for supporting the project as best as could. 

