### PR TITLE
Implement experimental DNS pre-resolution, enabling Podcast downloads even with partial DNS resolution failures

### DIFF
--- a/server/Server.js
+++ b/server/Server.js
@@ -2,13 +2,12 @@ const Path = require('path')
 const Sequelize = require('sequelize')
 const express = require('express')
 const http = require('http')
+const https = require('https')
 const util = require('util')
 const fs = require('./libs/fsExtra')
 const fileUpload = require('./libs/expressFileupload')
 const cookieParser = require('cookie-parser')
 const axios = require('axios')
-const { AxiosError } = require('axios')
-const dns = require('dns').promises
 
 const { version } = require('../package.json')
 
@@ -17,6 +16,7 @@ const is = require('./libs/requestIp/isJs')
 const fileUtils = require('./utils/fileUtils')
 const { toNumber } = require('./utils/index')
 const { getRequestOrigin } = require('./utils/requestUtils')
+const { resilientLookup } = require('./utils/resilientDns')
 const Logger = require('./Logger')
 
 const Auth = require('./Auth')
@@ -91,78 +91,12 @@ class Server {
     }
 
     if (process.env.EXP_DNS_RESOLUTION === '1') {
-      // https://github.com/advplyr/audiobookshelf/pull/3754
+      // https://github.com/advplyr/audiobookshelf/pull/4885
       Logger.info(`[Server] Experimental DNS Resolution Enabled`)
 
-      // Resolve DNS using dns package before making request
-      axios.interceptors.request.use(async (config) => {
-        try {
-          const urlObj = new URL(config.url)
-          const hostname = urlObj.hostname
-          let resolved = false
-
-          const resolvers = [
-            { protocol: 'IPv4', method: dns.resolve4, format: (ip) => ip },
-            { protocol: 'IPv6', method: dns.resolve6, format: (ip) => `[${ip}]` }
-          ]
-          if (process.env.PREFER_IPV6 === '1') {
-            resolvers.reverse()
-          }
-
-          for (const { protocol, method, format } of resolvers) {
-            const addresses = await method(hostname).catch(() => null)
-            if (addresses?.length > 0) {
-              const ip = format(addresses[0])
-              urlObj.hostname = ip
-              config.url = urlObj.toString()
-              config.headers = { ...config.headers, Host: hostname }
-              Logger.debug(`[Server] Resolved ${hostname} -> ${addresses[0]} (${protocol})`)
-              resolved = true
-              break
-            }
-          }
-
-          if (!resolved) {
-            throw new Error(`Could not resolve hostname ${hostname} to any IP address`)
-          }
-        } catch (err) {
-          Logger.warn(`[Server] DNS pre-resolution error: ${err.message}`)
-        }
-        return config
-      })
-
-      // Manually handle redirects, otherwise axios would bypass custom dns resolution on redirects
-      const maxRedirects = axios.defaults.maxRedirects || 21 // axios default
-      axios.defaults.maxRedirects = 0
-      axios.interceptors.response.use(
-        (response) => response,
-        async (error) => {
-          if (error.response && [301, 302, 303, 307, 308].includes(error.response.status) && error.response.headers.location) {
-            const redirectUrl = error.response.headers.location
-            if (!error.config._redirectCount) {
-              error.config._redirectCount = 0
-              error.config._redirectUrls = new Set()
-            }
-            if (error.config._redirectUrls.has(redirectUrl)) {
-              const visitedUrls = Array.from(error.config._redirectUrls).join(' -> ')
-              Logger.error(`[Server] Redirect loop detected: ${visitedUrls} -> ${redirectUrl}`)
-              return Promise.reject(new AxiosError(`Redirect loop detected: ${redirectUrl}`, 'ERR_FR_TOO_MANY_REDIRECTS', error.config, error.request))
-            }
-            if (error.config._redirectCount >= maxRedirects) {
-              Logger.error(`[Server] Maximum redirect limit (${maxRedirects}) exceeded`)
-              return Promise.reject(new AxiosError(`Maximum number of redirects exceeded (${maxRedirects})`, 'ERR_FR_TOO_MANY_REDIRECTS', error.config, error.request))
-            }
-            Logger.debug(`[Server] Following ${error.response.status} redirect to ${redirectUrl} (${error.config._redirectCount + 1}/${maxRedirects})`)
-            error.config._redirectUrls.add(redirectUrl)
-            error.config._redirectCount++
-            return axios({
-              ...error.config,
-              url: redirectUrl
-            })
-          }
-          return Promise.reject(error)
-        }
-      )
+      // Requests passing explicit agents (SSRF-filtered) get the same lookup via getAgentsForUrl
+      axios.defaults.httpAgent = new http.Agent({ lookup: resilientLookup })
+      axios.defaults.httpsAgent = new https.Agent({ lookup: resilientLookup })
     }
 
     global.PodcastDownloadTimeout = toNumber(process.env.PODCAST_DOWNLOAD_TIMEOUT, 30000)

--- a/server/Server.js
+++ b/server/Server.js
@@ -129,6 +129,23 @@ class Server {
         }
         return config
       })
+
+      // Manually handle redirects, otherwise axios would bypass custom dns resolution on redirects
+      axios.defaults.maxRedirects = 0
+      axios.interceptors.response.use(
+        (response) => response,
+        async (error) => {
+          if (error.response && [301, 302, 303, 307, 308].includes(error.response.status) && error.response.headers.location) {
+            const redirectUrl = error.response.headers.location
+            Logger.debug(`[Server] Following ${error.response.status} redirect to ${redirectUrl}`)
+            return axios({
+              ...error.config,
+              url: redirectUrl
+            })
+          }
+          return Promise.reject(error)
+        }
+      )
     }
 
     global.PodcastDownloadTimeout = toNumber(process.env.PODCAST_DOWNLOAD_TIMEOUT, 30000)

--- a/server/Server.js
+++ b/server/Server.js
@@ -7,6 +7,7 @@ const fs = require('./libs/fsExtra')
 const fileUpload = require('./libs/expressFileupload')
 const cookieParser = require('cookie-parser')
 const axios = require('axios')
+const { AxiosError } = require('axios')
 const dns = require('dns').promises
 
 const { version } = require('../package.json')
@@ -131,13 +132,29 @@ class Server {
       })
 
       // Manually handle redirects, otherwise axios would bypass custom dns resolution on redirects
+      const maxRedirects = axios.defaults.maxRedirects || 21 // axios default
       axios.defaults.maxRedirects = 0
       axios.interceptors.response.use(
         (response) => response,
         async (error) => {
           if (error.response && [301, 302, 303, 307, 308].includes(error.response.status) && error.response.headers.location) {
             const redirectUrl = error.response.headers.location
-            Logger.debug(`[Server] Following ${error.response.status} redirect to ${redirectUrl}`)
+            if (!error.config._redirectCount) {
+              error.config._redirectCount = 0
+              error.config._redirectUrls = new Set()
+            }
+            if (error.config._redirectUrls.has(redirectUrl)) {
+              const visitedUrls = Array.from(error.config._redirectUrls).join(' -> ')
+              Logger.error(`[Server] Redirect loop detected: ${visitedUrls} -> ${redirectUrl}`)
+              return Promise.reject(new AxiosError(`Redirect loop detected: ${redirectUrl}`, 'ERR_FR_TOO_MANY_REDIRECTS', error.config, error.request))
+            }
+            if (error.config._redirectCount >= maxRedirects) {
+              Logger.error(`[Server] Maximum redirect limit (${maxRedirects}) exceeded`)
+              return Promise.reject(new AxiosError(`Maximum number of redirects exceeded (${maxRedirects})`, 'ERR_FR_TOO_MANY_REDIRECTS', error.config, error.request))
+            }
+            Logger.debug(`[Server] Following ${error.response.status} redirect to ${redirectUrl} (${error.config._redirectCount + 1}/${maxRedirects})`)
+            error.config._redirectUrls.add(redirectUrl)
+            error.config._redirectCount++
             return axios({
               ...error.config,
               url: redirectUrl

--- a/server/Server.js
+++ b/server/Server.js
@@ -7,6 +7,7 @@ const fs = require('./libs/fsExtra')
 const fileUpload = require('./libs/expressFileupload')
 const cookieParser = require('cookie-parser')
 const axios = require('axios')
+const dns = require('dns').promises
 
 const { version } = require('../package.json')
 
@@ -87,6 +88,49 @@ class Server {
         global.DisableSsrfRequestFilter = (url) => whitelistedUrls.includes(new URL(url).hostname)
       }
     }
+
+    if (process.env.EXP_DNS_RESOLUTION === '1') {
+      // https://github.com/advplyr/audiobookshelf/pull/3754
+      Logger.info(`[Server] Experimental DNS Resolution Enabled`)
+
+      // Resolve DNS using dns package before making request
+      axios.interceptors.request.use(async (config) => {
+        try {
+          const urlObj = new URL(config.url)
+          const hostname = urlObj.hostname
+          let resolved = false
+
+          const resolvers = [
+            { protocol: 'IPv4', method: dns.resolve4, format: (ip) => ip },
+            { protocol: 'IPv6', method: dns.resolve6, format: (ip) => `[${ip}]` }
+          ]
+          if (process.env.PREFER_IPV6 === '1') {
+            resolvers.reverse()
+          }
+
+          for (const { protocol, method, format } of resolvers) {
+            const addresses = await method(hostname).catch(() => null)
+            if (addresses?.length > 0) {
+              const ip = format(addresses[0])
+              urlObj.hostname = ip
+              config.url = urlObj.toString()
+              config.headers = { ...config.headers, Host: hostname }
+              Logger.debug(`[Server] Resolved ${hostname} -> ${addresses[0]} (${protocol})`)
+              resolved = true
+              break
+            }
+          }
+
+          if (!resolved) {
+            throw new Error(`Could not resolve hostname ${hostname} to any IP address`)
+          }
+        } catch (err) {
+          Logger.warn(`[Server] DNS pre-resolution error: ${err.message}`)
+        }
+        return config
+      })
+    }
+
     global.PodcastDownloadTimeout = toNumber(process.env.PODCAST_DOWNLOAD_TIMEOUT, 30000)
     global.MaxFailedEpisodeChecks = toNumber(process.env.MAX_FAILED_EPISODE_CHECKS, 24)
 

--- a/server/utils/fileUtils.js
+++ b/server/utils/fileUtils.js
@@ -1,6 +1,6 @@
 const axios = require('axios')
 const Path = require('path')
-const ssrfFilter = require('ssrf-req-filter')
+const { getAgentsForUrl } = require('./resilientDns')
 const exec = require('child_process').exec
 const fs = require('../libs/fsExtra')
 const rra = require('../libs/recursiveReaddirAsync')
@@ -306,8 +306,7 @@ module.exports.downloadFile = (url, filepath, contentTypeFilter = null) => {
         'User-Agent': 'audiobookshelf (+https://audiobookshelf.org)'
       },
       timeout: 30000,
-      httpAgent: global.DisableSsrfRequestFilter?.(url) ? null : ssrfFilter(url),
-      httpsAgent: global.DisableSsrfRequestFilter?.(url) ? null : ssrfFilter(url)
+      ...getAgentsForUrl(url)
     })
       .then((response) => {
         // Validate content type

--- a/server/utils/podcastUtils.js
+++ b/server/utils/podcastUtils.js
@@ -1,5 +1,5 @@
 const axios = require('axios')
-const ssrfFilter = require('ssrf-req-filter')
+const { getAgentsForUrl } = require('./resilientDns')
 const Logger = require('../Logger')
 const { xmlToJSON, timestampToSeconds } = require('./index')
 const htmlSanitizer = require('../utils/htmlSanitizer')
@@ -373,8 +373,7 @@ module.exports.getPodcastFeed = (feedUrl, excludeEpisodeMetadata = false) => {
       'Accept-Encoding': 'gzip, compress, deflate',
       'User-Agent': userAgent
     },
-    httpAgent: global.DisableSsrfRequestFilter?.(feedUrl) ? null : ssrfFilter(feedUrl),
-    httpsAgent: global.DisableSsrfRequestFilter?.(feedUrl) ? null : ssrfFilter(feedUrl)
+    ...getAgentsForUrl(feedUrl)
   })
     .then(async (data) => {
       // Adding support for ios-8859-1 encoded RSS feeds.

--- a/server/utils/resilientDns.js
+++ b/server/utils/resilientDns.js
@@ -1,0 +1,77 @@
+const dns = require('dns')
+const http = require('http')
+const https = require('https')
+const ssrfFilter = require('ssrf-req-filter')
+
+/**
+ * Drop-in replacement for dns.lookup, usable as the `lookup` option of http/https Agents.
+ *
+ * Tries the system resolver (getaddrinfo) first, so /etc/hosts and nsswitch keep working.
+ * On EAI_AGAIN it falls back to direct DNS queries, which tolerate one address family
+ * failing while the other resolves. musl-based environments (Alpine) fail the entire
+ * getaddrinfo call with EAI_AGAIN when either the A or AAAA query gets a SERVFAIL,
+ * even if the other family returned valid addresses.
+ *
+ * @param {string} hostname
+ * @param {Object|Function} options dns.lookup options, or the callback
+ * @param {Function} [callback]
+ */
+function resilientLookup(hostname, options, callback) {
+  if (typeof options === 'function') {
+    callback = options
+    options = {}
+  }
+
+  dns.lookup(hostname, options, (error, address, family) => {
+    if (!error || error.code !== 'EAI_AGAIN') return callback(error, address, family)
+
+    const done = (addresses, resolvedFamily) => {
+      if (options.all) {
+        return callback(
+          null,
+          addresses.map((addr) => ({ address: addr, family: resolvedFamily })),
+          resolvedFamily
+        )
+      }
+      callback(null, addresses[0], resolvedFamily)
+    }
+
+    const familyOrder = process.env.PREFER_IPV6 === '1' ? [6, 4] : [4, 6]
+    const resolveFamily = (resolvedFamily, cb) => (resolvedFamily === 4 ? dns.resolve4 : dns.resolve6)(hostname, cb)
+
+    resolveFamily(familyOrder[0], (primaryError, primaryAddresses) => {
+      if (!primaryError && primaryAddresses?.length) return done(primaryAddresses, familyOrder[0])
+      resolveFamily(familyOrder[1], (secondaryError, secondaryAddresses) => {
+        if (!secondaryError && secondaryAddresses?.length) return done(secondaryAddresses, familyOrder[1])
+        callback(error, address, family)
+      })
+    })
+  })
+}
+
+/**
+ * Builds the httpAgent/httpsAgent pair for an outgoing request to the given url,
+ * applying the SSRF request filter unless disabled for the url, and the resilient
+ * DNS lookup when EXP_DNS_RESOLUTION is enabled.
+ *
+ * @param {string} url
+ * @returns {{ httpAgent: http.Agent|null, httpsAgent: https.Agent|null }}
+ */
+function getAgentsForUrl(url) {
+  const ssrfDisabled = !!global.DisableSsrfRequestFilter?.(url)
+
+  if (process.env.EXP_DNS_RESOLUTION !== '1') {
+    const agent = ssrfDisabled ? null : ssrfFilter(url)
+    return { httpAgent: agent, httpsAgent: agent }
+  }
+
+  const httpAgent = new http.Agent({ lookup: resilientLookup })
+  const httpsAgent = new https.Agent({ lookup: resilientLookup })
+  if (!ssrfDisabled) {
+    ssrfFilter.requestFilterHandler(httpAgent)
+    ssrfFilter.requestFilterHandler(httpsAgent)
+  }
+  return { httpAgent, httpsAgent }
+}
+
+module.exports = { resilientLookup, getAgentsForUrl }

--- a/test/server/utils/resilientDns.test.js
+++ b/test/server/utils/resilientDns.test.js
@@ -1,0 +1,167 @@
+const { expect } = require('chai')
+const sinon = require('sinon')
+const dns = require('dns')
+const http = require('http')
+const https = require('https')
+
+const { resilientLookup, getAgentsForUrl } = require('../../../server/utils/resilientDns')
+
+describe('resilientDns', () => {
+  afterEach(() => {
+    sinon.restore()
+    delete process.env.PREFER_IPV6
+    delete process.env.EXP_DNS_RESOLUTION
+  })
+
+  describe('resilientLookup', () => {
+    it('returns getaddrinfo result when dns.lookup succeeds', (done) => {
+      sinon.stub(dns, 'lookup').callsFake((hostname, options, callback) => callback(null, '1.2.3.4', 4))
+      const resolve4 = sinon.stub(dns, 'resolve4')
+
+      resilientLookup('example.com', {}, (err, address, family) => {
+        expect(err).to.be.null
+        expect(address).to.equal('1.2.3.4')
+        expect(family).to.equal(4)
+        expect(resolve4.called).to.be.false
+        done()
+      })
+    })
+
+    it('propagates non-EAI_AGAIN errors without fallback', (done) => {
+      const error = Object.assign(new Error('getaddrinfo ENOTFOUND example.com'), { code: 'ENOTFOUND' })
+      sinon.stub(dns, 'lookup').callsFake((hostname, options, callback) => callback(error))
+      const resolve4 = sinon.stub(dns, 'resolve4')
+
+      resilientLookup('example.com', {}, (err) => {
+        expect(err).to.equal(error)
+        expect(resolve4.called).to.be.false
+        done()
+      })
+    })
+
+    it('falls back to IPv4 DNS resolution on EAI_AGAIN', (done) => {
+      const error = Object.assign(new Error('getaddrinfo EAI_AGAIN example.com'), { code: 'EAI_AGAIN' })
+      sinon.stub(dns, 'lookup').callsFake((hostname, options, callback) => callback(error))
+      sinon.stub(dns, 'resolve4').callsFake((hostname, callback) => callback(null, ['1.2.3.4', '5.6.7.8']))
+
+      resilientLookup('example.com', {}, (err, address, family) => {
+        expect(err).to.be.null
+        expect(address).to.equal('1.2.3.4')
+        expect(family).to.equal(4)
+        done()
+      })
+    })
+
+    it('falls back to IPv6 when IPv4 resolution fails', (done) => {
+      const error = Object.assign(new Error('getaddrinfo EAI_AGAIN example.com'), { code: 'EAI_AGAIN' })
+      sinon.stub(dns, 'lookup').callsFake((hostname, options, callback) => callback(error))
+      sinon.stub(dns, 'resolve4').callsFake((hostname, callback) => callback(Object.assign(new Error('SERVFAIL'), { code: 'ESERVFAIL' })))
+      sinon.stub(dns, 'resolve6').callsFake((hostname, callback) => callback(null, ['2001:db8::1']))
+
+      resilientLookup('example.com', {}, (err, address, family) => {
+        expect(err).to.be.null
+        expect(address).to.equal('2001:db8::1')
+        expect(family).to.equal(6)
+        done()
+      })
+    })
+
+    it('returns the original getaddrinfo error when both fallbacks fail', (done) => {
+      const error = Object.assign(new Error('getaddrinfo EAI_AGAIN example.com'), { code: 'EAI_AGAIN' })
+      sinon.stub(dns, 'lookup').callsFake((hostname, options, callback) => callback(error))
+      sinon.stub(dns, 'resolve4').callsFake((hostname, callback) => callback(Object.assign(new Error('SERVFAIL'), { code: 'ESERVFAIL' })))
+      sinon.stub(dns, 'resolve6').callsFake((hostname, callback) => callback(Object.assign(new Error('SERVFAIL'), { code: 'ESERVFAIL' })))
+
+      resilientLookup('example.com', {}, (err) => {
+        expect(err).to.equal(error)
+        done()
+      })
+    })
+
+    it('returns all addresses when options.all is set', (done) => {
+      const error = Object.assign(new Error('getaddrinfo EAI_AGAIN example.com'), { code: 'EAI_AGAIN' })
+      sinon.stub(dns, 'lookup').callsFake((hostname, options, callback) => callback(error))
+      sinon.stub(dns, 'resolve4').callsFake((hostname, callback) => callback(null, ['1.2.3.4', '5.6.7.8']))
+
+      resilientLookup('example.com', { all: true }, (err, addresses) => {
+        expect(err).to.be.null
+        expect(addresses).to.deep.equal([
+          { address: '1.2.3.4', family: 4 },
+          { address: '5.6.7.8', family: 4 }
+        ])
+        done()
+      })
+    })
+
+    it('prefers IPv6 in fallback when PREFER_IPV6 is set', (done) => {
+      process.env.PREFER_IPV6 = '1'
+      const error = Object.assign(new Error('getaddrinfo EAI_AGAIN example.com'), { code: 'EAI_AGAIN' })
+      sinon.stub(dns, 'lookup').callsFake((hostname, options, callback) => callback(error))
+      const resolve4 = sinon.stub(dns, 'resolve4')
+      sinon.stub(dns, 'resolve6').callsFake((hostname, callback) => callback(null, ['2001:db8::1']))
+
+      resilientLookup('example.com', {}, (err, address, family) => {
+        expect(err).to.be.null
+        expect(address).to.equal('2001:db8::1')
+        expect(family).to.equal(6)
+        expect(resolve4.called).to.be.false
+        done()
+      })
+    })
+
+    it('supports callback as second argument', (done) => {
+      sinon.stub(dns, 'lookup').callsFake((hostname, options, callback) => callback(null, '1.2.3.4', 4))
+
+      resilientLookup('example.com', (err, address, family) => {
+        expect(err).to.be.null
+        expect(address).to.equal('1.2.3.4')
+        expect(family).to.equal(4)
+        done()
+      })
+    })
+  })
+
+  describe('getAgentsForUrl', () => {
+    afterEach(() => {
+      delete global.DisableSsrfRequestFilter
+    })
+
+    it('uses SSRF filter agents without custom lookup when flag is off', () => {
+      const { httpAgent, httpsAgent } = getAgentsForUrl('https://example.com/feed')
+      expect(httpsAgent).to.be.an.instanceOf(https.Agent)
+      expect(httpAgent).to.equal(httpsAgent)
+      expect(httpsAgent.options.lookup).to.be.undefined
+    })
+
+    it('returns null agents when flag is off and SSRF filter is disabled for the url', () => {
+      global.DisableSsrfRequestFilter = () => true
+      const { httpAgent, httpsAgent } = getAgentsForUrl('https://example.com/feed')
+      expect(httpAgent).to.be.null
+      expect(httpsAgent).to.be.null
+    })
+
+    it('attaches resilientLookup to both agents when flag is on', () => {
+      process.env.EXP_DNS_RESOLUTION = '1'
+      const { httpAgent, httpsAgent } = getAgentsForUrl('https://example.com/feed')
+      expect(httpAgent).to.be.an.instanceOf(http.Agent)
+      expect(httpsAgent).to.be.an.instanceOf(https.Agent)
+      expect(httpAgent.options.lookup).to.equal(resilientLookup)
+      expect(httpsAgent.options.lookup).to.equal(resilientLookup)
+      // ssrf-req-filter wraps createConnection as an own property on the agent
+      expect(Object.prototype.hasOwnProperty.call(httpAgent, 'createConnection')).to.be.true
+      expect(Object.prototype.hasOwnProperty.call(httpsAgent, 'createConnection')).to.be.true
+    })
+
+    it('keeps custom lookup agents unfiltered when SSRF filter is disabled for the url', () => {
+      process.env.EXP_DNS_RESOLUTION = '1'
+      const filtered = []
+      global.DisableSsrfRequestFilter = (url) => {
+        filtered.push(url)
+        return true
+      }
+      const { httpsAgent } = getAgentsForUrl('https://example.com/feed')
+      expect(filtered).to.deep.equal(['https://example.com/feed'])
+      expect(httpsAgent.options.lookup).to.equal(resilientLookup)
+    })
+  })
+})


### PR DESCRIPTION
## Brief summary

This PR introduces an optional configuration parameter `EXP_DNS_RESOLUTION`. When enabled, the server attaches a custom `lookup` function to the http/https agents used for outgoing requests (axios). The lookup tries the system resolver (`getaddrinfo`) first, and only when that fails with `EAI_AGAIN` falls back to explicit `A`/`AAAA` queries via Node's `dns.resolve4`/`dns.resolve6` (c-ares), which tolerate one address family failing while the other resolves.

This enables successful web requests in situations that would otherwise fail due to partial DNS resolution failures, i.e. when a DNS query resolves an `A` record of a hostname while rejecting requests for `AAAA` records (`SERVFAIL` or `REFUSED`), or vice versa. This failure mode is specific to the Alpine (musl) container environment; see root cause below.

## Root cause

Node's `dns.lookup` (used by axios for name resolution) calls libc `getaddrinfo`. For an unspecified address family, musl sends the `A` and `AAAA` queries in parallel and fails the **entire** lookup with `EAI_AGAIN` if **either** response carries rcode `SERVFAIL`, even when the other family returned valid addresses. This is deliberate musl behavior and still present in current musl master, in `name_from_dns` ([`src/network/lookup_name.c`](https://git.musl-libc.org/cgit/musl/tree/src/network/lookup_name.c)):

```c
for (i=0; i<nq; i++) {
    if (alens[i] < 4 || (abuf[i][3] & 15) == 2) return EAI_AGAIN;
```

glibc returns the successfully resolved family instead, which is why this only reproduces in the Alpine-based Docker image and not when running the server on glibc systems. Upgrading Alpine/musl does not fix it.

Reproduction with a stub DNS server that answers `A` normally and `SERVFAIL` for `AAAA`:

| Environment | Call | Result |
|---|---|---|
| `node:20-alpine` (musl) | `dns.lookup` | `EAI_AGAIN`, request fails |
| `node:20-slim` (glibc) | `dns.lookup` | returns the A record |
| `node:20-alpine` | `dns.resolve4` (c-ares) | returns the A record |

## Implementation notes

- `server/utils/resilientDns.js` exports `resilientLookup` (drop-in replacement for `dns.lookup`, usable as the `lookup` option of `http.Agent`/`https.Agent`) and `getAgentsForUrl` (builds the agent pair for a request, composing the SSRF request filter with the custom lookup via `ssrf-req-filter`'s exported `requestFilterHandler`).
- With `EXP_DNS_RESOLUTION=1`, `Server.js` sets `axios.defaults.httpAgent`/`httpsAgent` with the custom lookup; the SSRF-filtered call sites (`podcastUtils.getPodcastFeed`, `fileUtils.downloadFile`) get it through `getAgentsForUrl`.
- Because request URLs are never rewritten, TLS/SNI and certificate validation follow the normal path, and axios' native redirect handling (`follow-redirects`) stays active. Redirect hops resolve through the same agents, so no manual redirect or loop handling is needed.
- `getaddrinfo` remains the primary resolver, so `/etc/hosts`, nsswitch, and container DNS behave exactly as before; the fallback only engages on `EAI_AGAIN`. With healthy DNS the flag is a no-op.
- `PREFER_IPV6=1` switches the fallback order to `AAAA` before `A`.
- Unit tests in `test/server/utils/resilientDns.test.js`; verified end-to-end in the Alpine image against a stub DNS server (default lookup fails with `EAI_AGAIN`, custom lookup succeeds, SSRF filter still blocks private-range targets with the custom lookup active).

## Which issue is fixed?

- https://github.com/advplyr/audiobookshelf/issues/4887
- https://github.com/advplyr/audiobookshelf/issues/4011
- https://github.com/advplyr/audiobookshelf/issues/3876
- https://github.com/advplyr/audiobookshelf/issues/3680
- https://github.com/advplyr/audiobookshelf/issues/3579
- https://github.com/advplyr/audiobookshelf/issues/3346

Additionally, a discussion of the issue server side can be found here:
- https://talk.lagedernation.org/t/lage-cdn-dns-issues/27017/18?u=passionatebytes

## Example of the failure mode

The German news podcast 'Lage der Nation' hosted their feeds on a DNS setup that consistently answered `SERVFAIL` for `AAAA` queries while resolving `A` records fine (since fixed on their side, but the same misconfiguration exists elsewhere):

```bash
$ nslookup feeds.lagedernation.org
Server:		127.0.0.53
Address:	127.0.0.53#53

Non-authoritative answer:
Name:	feeds.lagedernation.org
Address: 139.162.176.53
;; Got SERVFAIL reply from 127.0.0.53
** server can't find feeds.lagedernation.org: SERVFAIL
```

In the Alpine container this made every request to that host fail with:

```
ERROR: [podcastUtils] getPodcastFeed Error AxiosError: getaddrinfo EAI_AGAIN feeds.lagedernation.org
```

For those wanting to try an up-to-date build including this patch: https://hub.docker.com/r/passionatebytessolutions/audiobookshelf
