### PR TITLE
Update Debian preinst for [Bug]: Debian ugprade fails with exit 9 #4888

### DIFF
--- a/build/debian/DEBIAN/preinst
+++ b/build/debian/DEBIAN/preinst
@@ -22,7 +22,7 @@ add_user() {
   declare -r descr="${4:-No description}"
   declare -r shell="${5:-/bin/false}"
 
-  if ! getent passwd | grep -q "^$user:"; then
+  if ! (getent passwd ; true) | grep -q "^$user:"; then
     echo "Creating system user: $user in $group with $descr and shell $shell"
     useradd $uid_flags --gid $group --no-create-home --system --shell $shell -c "$descr" $user
   fi
@@ -39,7 +39,7 @@ add_group() {
     declare -r gid_flags="--gid $gid"
   fi
 
-  if ! getent group | grep -q "^$group:" ; then
+  if ! (getent group; true) | grep -q "^$group:" ; then
     echo "Creating system group: $group"
     groupadd $gid_flags --system $group
   fi


### PR DESCRIPTION
## Brief summary

grep -q stops the getent execution because it finds the searched expression, this causes an non zero exitcode which stops the script because of the "set -o pipefail". This is only if the user already exists.

## Which issue is fixed?
Fixes #4888

## In-depth Description
add a true to the getent, makes sure the if condition above uses the exitcode of the grep instead of the getent.


## How have you tested this?
manually patched current package and installation worked fine.