### PR TITLE
When adding items to playlist, sort the playlist sections alphabetically.

### DIFF
--- a/client/components/modals/playlists/AddCreateModal.vue
+++ b/client/components/modals/playlists/AddCreateModal.vue
@@ -97,7 +97,10 @@ export default {
             ...playlist
           }
         })
-        .sort((a, b) => (a.isItemIncluded ? -1 : 1))
+        .sort((a, b) => {
+          if (a.isItemIncluded !== b.isItemIncluded) return a.isItemIncluded ? -1 : 1
+          return a.name.localeCompare(b.name)
+        })
     },
     isBatch() {
       return this.selectedPlaylistItems.length > 1


### PR DESCRIPTION
## Brief summary

When adding items to playlist I noticed they are not sorted alphabetically like they are on the playlist page. I have one named `_Up Next`, named that way so it always shows up on top, but when adding items to playlist it's not sorted alphabetically.

This PR sorts the playlist.

## Which issue is fixed?

None

## In-depth Description

I just modified `sortedPlaylists()` on the playlist modal to ensure playlist that are selected (`isItemsIncluded`) come before those that are not, and if the items are in the same group to sort by name.
This makes each section sorted alphabetically (playlist the item is added to and the rest of the playlist)

## How have you tested this?

I ended up using github's codespaces, uploaded some small .mp3s and used them as "audiobooks" to test the playlist modal.

## Screenshots
Current:
<img width="354" height="472" alt="image" src="https://github.com/user-attachments/assets/96a0fa50-74f8-4978-9444-0d6cb80af050" />
After changes:
<img width="382" height="461" alt="image" src="https://github.com/user-attachments/assets/91a506ad-407e-4b8a-ace0-4406b30431d9" />
