### PR TITLE
Add HOST environment variable to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,6 +62,7 @@ COPY --from=build-server ${NUSQLITE3_PATH} ${NUSQLITE3_PATH}
 EXPOSE 80
 
 ENV PORT=80
+ENV HOST=0.0.0.0
 ENV NODE_ENV=production
 ENV CONFIG_PATH="/config"
 ENV METADATA_PATH="/metadata"


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

This PR fixes the `HOST` being `undefined` on Docker

## Which issue is fixed?

This fixes the container's web UI not being accessible 

## In-depth Description

<!--
Describe your solution in more depth.
How does it work? Why is this the best solution?
Does it solve a problem that affects multiple users or is this an edge case for your setup?
-->

## How have you tested this?

The workaround it is set `HOST=0.0.0.0` as a Docker environment variable.


## Screenshots

This is the default output in the console (without the proposed changed)
<img width="1673" height="518" alt="Screenshot 2025-12-15 at 10-18-41 Portainer local" src="https://github.com/user-attachments/assets/7d544b26-49c7-4ca9-9d8c-1814adb6c044" />

This is the console output with the proposed changed

<img width="1673" height="518" alt="Screenshot 2025-12-15 at 10-20-38 Portainer local" src="https://github.com/user-attachments/assets/ee3d5fb2-dfc3-4361-ba2a-cdb7d842c1ef" />
