### PR TITLE
Added Started to Series Progress filter list on Series view

### DIFF
--- a/client/components/controls/LibraryFilterSelect.vue
+++ b/client/components/controls/LibraryFilterSelect.vue
@@ -389,7 +389,7 @@ export default {
       return this.filterData.publishedDecades || []
     },
     progress() {
-      return [
+      const items = [
         {
           id: 'finished',
           name: this.$strings.LabelFinished
@@ -398,6 +398,15 @@ export default {
           id: 'in-progress',
           name: this.$strings.LabelInProgress
         },
+      ]
+      // only add "started series" filter in series view
+      if (this.isSeries) {
+        items.push({
+          id: 'started-series',
+          name: this.$strings.LabelStarted
+        })
+      }
+      items.push(
         {
           id: 'not-started',
           name: this.$strings.LabelNotStarted
@@ -406,7 +415,8 @@ export default {
           id: 'not-finished',
           name: this.$strings.LabelNotFinished
         }
-      ]
+      )
+      return items
     },
     tracks() {
       return [

--- a/server/utils/queries/seriesFilters.js
+++ b/server/utils/queries/seriesFilters.js
@@ -83,6 +83,9 @@ module.exports = {
         const progQuery = 'SELECT count(*) FROM books b, bookSeries bs LEFT OUTER JOIN mediaProgresses mp ON mp.mediaItemId = b.id AND mp.userId = :userId WHERE bs.seriesId = series.id AND bs.bookId = b.id AND (mp.isFinished = 1 OR mp.currentTime > 0)'
         seriesWhere.push(Sequelize.where(Sequelize.literal(`(${progQuery})`), 0))
         userPermissionBookWhere.replacements.userId = user.id
+      } else if (filterValue === 'started-series') {
+        attrQuery = 'SELECT count(*) FROM books b, bookSeries bs LEFT OUTER JOIN mediaProgresses mp ON mp.mediaItemId = b.id AND mp.userId = :userId WHERE bs.seriesId = series.id AND bs.bookId = b.id AND (mp.isFinished = 1 OR mp.currentTime > 0 OR mp.ebookProgress > 0)'
+        userPermissionBookWhere.replacements.userId = user.id
       } else if (filterValue === 'in-progress') {
         attrQuery = 'SELECT count(*) FROM books b, bookSeries bs LEFT OUTER JOIN mediaProgresses mp ON mp.mediaItemId = b.id AND mp.userId = :userId WHERE bs.seriesId = series.id AND bs.bookId = b.id AND (mp.currentTime > 0 OR mp.ebookProgress > 0) AND mp.isFinished = 0'
         userPermissionBookWhere.replacements.userId = user.id


### PR DESCRIPTION
## Brief summary

Adds a `Started` item to the `Series Progress` filter. This will only show up in the Series Progress filter (on the Series page), the Progress filter in the Library/bookshelf view will not change. This allows people to see all Series they have started, but not finished.

## Which issue is fixed?

An alternate solution that would resolve #3220

## In-depth Description

There is no way to view all Series you've made progress on. The `in-progress` filter only shows series that have books that are started and not finished. This view makes sense, but it would be nice to have one that shows all series that have progress on them, hence the new `started` filter.

This change adds the new filter option, and server side support for the new filter type. I just mirrored how the `in-progress` filter worked, but modified the query to include finished books for the series.

## How have you tested this?

I tested this in a dev instance.

## Screenshots

<img width="213" height="255" alt="image" src="https://github.com/user-attachments/assets/6fdd7586-605a-4ce2-aa31-0717a152e55a" />
<img width="959" height="346" alt="image" src="https://github.com/user-attachments/assets/9802409e-553d-48e1-90f7-e27e0c7f18f0" />
<img width="1316" height="377" alt="image" src="https://github.com/user-attachments/assets/a79e1d41-4ed8-46b9-9494-4588982717a2" />

