### PR TITLE
Display localized/styled text for selected filter.

### DIFF
--- a/client/components/controls/LibraryFilterSelect.vue
+++ b/client/components/controls/LibraryFilterSelect.vue
@@ -338,6 +338,18 @@ export default {
             const series = this.series.find((se) => se.id == decoded)
             if (series) filterValue = series.name
           }
+        } else if (parts[0] === 'progress') {
+          const item = this.progress.find((p) => p.id == decoded)
+          if (item) filterValue = item.name
+        } else if (parts[0] === 'tracks') {
+          const item = this.tracks.find((t) => t.id == decoded)
+          if (item) filterValue = item.name
+        } else if (parts[0] === 'ebooks') {
+          const item = this.ebooks.find((e) => e.id == decoded)
+          if (item) filterValue = item.name
+        } else if (parts[0] === 'missing') {
+          const item = this.missing.find((m) => m.id == decoded)
+          if (item) filterValue = item.name
         } else {
           filterValue = decoded
         }


### PR DESCRIPTION
## Brief summary

Currently the selected filter drop down displays the id used to do the filtering by the server. This change aims to use the friendly / localized value instead of the id.

## Which issue is fixed?

None, discussed in discord.

## In-depth Description

The drop down is populated by `selectedText()`, and it handles quite a few edge cases. I just added 4 more filter types to the list. If a filter is selected it'll look up the friendly name from the drop down's value list and select it based on the selected id.

## How have you tested this?

Ran it on my dev instance.

## Screenshots

Original uses ids in the drop down:
<img width="256" height="237" alt="17673071721087171548396986289613" src="https://github.com/user-attachments/assets/d95c32ae-3243-4582-8250-28c79a265291" />

After the change it'll use the friendly name:
<img width="210" height="225" alt="image" src="https://github.com/user-attachments/assets/58f2dd3b-fc85-4e5d-b376-5a1d58123b85" />
