### PR TITLE
Make the download icon easier to see on share page for books with light covers

### DIFF
--- a/client/pages/share/_slug.vue
+++ b/client/pages/share/_slug.vue
@@ -14,7 +14,7 @@
         </div>
 
         <ui-tooltip v-if="mediaItemShare.isDownloadable" direction="bottom" :text="$strings.LabelDownload" class="absolute top-0 left-0 m-4">
-          <button aria-label="Download" class="text-gray-300 hover:text-white" @click="downloadShareItem"><span class="material-symbols text-2xl sm:text-3xl">download</span></button>
+          <button aria-label="Download" :class="downloadIconClass" @click="downloadShareItem"><span class="material-symbols text-2xl sm:text-3xl">download</span></button>
         </ui-tooltip>
       </div>
     </div>
@@ -107,6 +107,9 @@ export default {
     },
     coverHeight() {
       return this.coverWidth * this.coverAspectRatio
+    },
+    downloadIconClass() {
+      return this.coverBgIsLight ? ['text-black', 'hover:text-gray-800'] : ['text-white', 'hover:text-gray-300']
     }
   },
   methods: {


### PR DESCRIPTION
## Brief summary

This change improves the accessibility of the download icon on the share page.

## Which issue is fixed?

n/a

## In-depth Description

The current page always displays a light icon, but it's can be quite invisible for books with light covers. This just takes advantage of a property that's already being set (`this.coverBgIsLight`) to use a dark icon if the cover/background is light.

## How have you tested this?

Tested on dev instance with light cover, dark cover, and no cover.

## Screenshots

pre change:
<img width="155" height="148" alt="image" src="https://github.com/user-attachments/assets/547dba4d-60bc-4d07-bb07-1f0e0819fa0e" />
<img width="114" height="128" alt="image" src="https://github.com/user-attachments/assets/2b5cf34f-81cc-4855-bd06-883874dc1735" />

post change:
light cover:
<img width="69" height="73" alt="image" src="https://github.com/user-attachments/assets/5dfa0a95-f5b2-4d55-b786-504f1541609e" />
<img width="73" height="76" alt="image" src="https://github.com/user-attachments/assets/aba35d59-d5f6-4014-a48a-b21bfb7396da" />

dark cover:
<img width="59" height="57" alt="image" src="https://github.com/user-attachments/assets/c5d97b76-3b77-4591-9628-28a2116a316a" />
<img width="70" height="78" alt="image" src="https://github.com/user-attachments/assets/826136d5-ccf9-488b-bf1a-9dbffa1844d9" />

no cover (uses the dark cover color):
<img width="50" height="60" alt="image" src="https://github.com/user-attachments/assets/1be71a98-ee9b-483b-bcd6-9113b23983ac" />
