### PR TITLE
Fix screen reader compatability issue for the "jump backwards" button for media controls

### DIFF
--- a/client/components/player/PlayerPlaybackControls.vue
+++ b/client/components/player/PlayerPlaybackControls.vue
@@ -8,7 +8,7 @@
           </button>
         </ui-tooltip>
         <ui-tooltip direction="top" :text="jumpBackwardText">
-          <button :aria-label="jumpForwardText" class="text-gray-300" @mousedown.prevent @mouseup.prevent @click.stop="jumpBackward">
+          <button :aria-label="jumpBackwardText" class="text-gray-300" @mousedown.prevent @mouseup.prevent @click.stop="jumpBackward">
             <span class="material-symbols text-2xl sm:text-3xl">replay</span>
           </button>
         </ui-tooltip>


### PR DESCRIPTION
## Brief summary

Fixes screen reader compatability issue for the "jump backwards" button for media controls

## Which issue is fixed?

Pointed out by jonathan859 on discord

## In-depth Description

Very simple solution, follows the same format as the forward button. 

## How have you tested this?

The program runs fine, I do not have a screen reader to test but considering how small the change is it should work perfectly

## Screenshots
n/a
