### PR TITLE
Add support that API-Keys authenticate sockets

### DIFF
--- a/server/auth/TokenManager.js
+++ b/server/auth/TokenManager.js
@@ -68,7 +68,6 @@ class TokenManager {
   /**
    * Function to validate a jwt token for a given user
    * Used to authenticate socket connections
-   * TODO: Support API keys for web socket connections
    *
    * @param {string} token
    * @returns {Object} tokens data


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

This pull request adds support for authenticating WebSocket connections using API keys in addition to the JWT-based authentication. The main logic was "inspired :)" by the already existing code in the `TokenManager.js`. 

## Which issue is fixed?

None, but "fixes" TODO and fixes a user complaint about my autoconverter, which is based on websockets and could not use API keys

## In-depth Description

Adds the same mechanisms and fallback the current jwtAuthCheck already has. I copied over the comments and the main "logic" behind it. This also allows using websockets with the API Keys which currently end up in an unauthenticated state.
I also added the expiration to the websocket emit, but realisticly it will not do that much as it would get invalidated by the http request. But just to make sure if a user only uses the key for websockets this would be prevented now too. To my knowledge there is nothing one could to over websockets that affects anything, but in theory one token would never be set to inactive if I understand the code correctly

## How have you tested this?

Used the websocket example as testing. Works now with the API token

## Screenshots

<!-- If your PR includes any changes to the web client, please include screenshots or a short video from before and after your changes. -->
