### PR TITLE
Fix case-insensitive lookup for series and authors during import

### DIFF
--- a/server/Database.js
+++ b/server/Database.js
@@ -624,7 +624,9 @@ class Database {
     if (!this.libraryFilterData[libraryId]) {
       return (await this.authorModel.getByNameAndLibrary(authorName, libraryId))?.id || null
     }
-    return this.libraryFilterData[libraryId].authors.find((au) => au.name === authorName)?.id || null
+    // Case-insensitive comparison to match getByNameAndLibrary behavior
+    const authorNameLower = authorName.toLowerCase()
+    return this.libraryFilterData[libraryId].authors.find((au) => au.name.toLowerCase() === authorNameLower)?.id || null
   }
 
   /**
@@ -638,7 +640,9 @@ class Database {
     if (!this.libraryFilterData[libraryId]) {
       return (await this.seriesModel.getByNameAndLibrary(seriesName, libraryId))?.id || null
     }
-    return this.libraryFilterData[libraryId].series.find((se) => se.name === seriesName)?.id || null
+    // Case-insensitive comparison to match getByNameAndLibrary behavior
+    const seriesNameLower = seriesName.toLowerCase()
+    return this.libraryFilterData[libraryId].series.find((se) => se.name.toLowerCase() === seriesNameLower)?.id || null
   }
 
   /**


### PR DESCRIPTION
## Brief summary

Prevent duplicate series and authors from being created when names differ only in casing (e.g., "Harry Potter" vs "harry potter") during library scanning/import.

## Which issue is fixed?

Fixes #4255

Related to #4033 and #4934

## In-depth Description

When importing books, the code has two paths for looking up existing series/authors:

1. **Database fallback** (`getByNameAndLibrary`) - uses `fn('lower', col('name'))` for case-insensitive matching ✅
2. **Filter data cache** - was using `se.name === seriesName` for case-sensitive matching ❌

This inconsistency meant:
- First scan (no filter data loaded): Case-insensitive lookup → correct
- Subsequent scans (filter data cached): Case-sensitive lookup → creates duplicates!

**The fix:** Changed both `getSeriesIdByName` and `getAuthorIdByName` in `Database.js` to use case-insensitive comparison when using the filter data cache:

```javascript
// Before (buggy):
return this.libraryFilterData[libraryId].series.find((se) => se.name === seriesName)?.id || null

// After (fixed):
const seriesNameLower = seriesName.toLowerCase()
return this.libraryFilterData[libraryId].series.find((se) => se.name.toLowerCase() === seriesNameLower)?.id || null
```

This affects both series and authors, preventing duplicates for both during import.

## How have you tested this?

1. All 315 existing unit tests pass
2. Manual testing steps:
   - Import a book with series "Harry Potter"
   - Import another book with series "harry potter" 
   - Both books now correctly group under the same series (using the first casing encountered)

🤖 Generated with [Claude Code](https://claude.ai/code)