### PR TITLE
Add Continue Series shelf for podcasts

### DIFF
--- a/server/models/LibraryItem.js
+++ b/server/models/LibraryItem.js
@@ -388,6 +388,22 @@ class LibraryItem extends Model {
       }
       Logger.debug(`Loaded ${continueSeriesPayload.libraryItems.length} of ${continueSeriesPayload.count} items for "Continue Series" in ${((Date.now() - start) / 1000).toFixed(2)}s`)
     } else if (library.isPodcast) {
+      start = Date.now()
+      // "Continue Series" shelf for serial podcasts
+      const continueSeriesPayload = await libraryFilters.getPodcastEpisodesContinueSeries(library, user, limit)
+      if (continueSeriesPayload.libraryItems.length) {
+        shelves.push({
+          id: 'continue-series',
+          label: 'Continue Series',
+          labelStringKey: 'LabelContinueSeries',
+          type: 'episode',
+          entities: continueSeriesPayload.libraryItems,
+          total: continueSeriesPayload.count
+        })
+      }
+      Logger.debug(`Loaded ${continueSeriesPayload.libraryItems.length} of ${continueSeriesPayload.count} episodes for "Continue Series" in ${((Date.now() - start) / 1000).toFixed(2)}s`)
+
+      start = Date.now()
       // "Newest Episodes" shelf
       const newestEpisodesPayload = await libraryFilters.getNewestPodcastEpisodes(library, user, limit)
       if (newestEpisodesPayload.libraryItems.length) {

--- a/server/utils/queries/libraryFilters.js
+++ b/server/utils/queries/libraryFilters.js
@@ -411,6 +411,31 @@ module.exports = {
   },
 
   /**
+   * Get podcast episodes for continue series shelf
+   * Returns the next episode for podcasts that have at least 1 finished episode and at least 1 unfinished episode
+   * - Serial podcasts: oldest unfinished episode (oldest to newest)
+   * - Episodic podcasts: newest unfinished episode (latest to oldest)
+   * An episode is unfinished if: has progress with isFinished = false OR no progress entry
+   * @param {import('../../models/Library')} library
+   * @param {import('../../models/User')} user
+   * @param {number} limit
+   * @returns {Promise<{libraryItems:oldLibraryItem[], count:number}>}
+   */
+  async getPodcastEpisodesContinueSeries(library, user, limit) {
+    if (library.mediaType !== 'podcast') return { libraryItems: [], count: 0 }
+
+    const { libraryItems, count } = await libraryItemsPodcastFilters.getContinueSeriesPodcastEpisodes(user, library, limit, 0)
+    return {
+      count,
+      libraryItems: libraryItems.map((li) => {
+        const oldLibraryItem = li.toOldJSONMinified()
+        oldLibraryItem.recentEpisode = li.recentEpisode
+        return oldLibraryItem
+      })
+    }
+  },
+
+  /**
    * Get library items for an author, optional use user permissions
    * @param {import('../../models/Author')} author
    * @param {import('../../models/User')} user


### PR DESCRIPTION
## Brief summary

Adds a Continue Series shelf for serial podcasts

## Which issue is fixed?

Fixes #861

## In-depth Description

As described in the linked issue, it would be very nice to have a "Continue Series" shelf, specifically for serial podcast (for episodic podcasts, the correct "Up next" episode will already likely be available under "Newest Episodes").

* This specifically adds a "Continue Series" shelf for podcast libraries. I'm using the same language from the books because it applies in English but I assume I should switch this to a new string? I'm sure it doesn't apply to both podcasts and books in all languages
* Adds the logic to pull and sort podcasts and episodes for this shelf
  * Podcasts must be started to appear (have at least one podcast that is finished or has progress)
  * Podcasts must be unfinished to appear (have a least one episode that is not finished or has no progress)
  * Serial podcasts serve the next episode as the oldest unfinished episode
  * Episodic podcasts serve the next episode as the newest unfinished episode

## How have you tested this?

**Serial**
1. Add a serial podcast (e.g. History of Rome)
2. Download multiple episodes
3. Note: does NOT show up in Continue Series
4. Mark one of the episodes as finished
5. Note: podcast DOES show up in Continue Series
6. Note: next episode is the oldest unfinished 
7. Mark ALL the episodes as finished
8. Note: podcast does NOT show up in Continue Series

**Episodic**
1. Add a episode podcast (e.g. The Daily)
2. Download multiple episodes
3. Note: does NOT show up in Continue Series
4. Mark one of the episodes as finished
5. Note: podcast DOES show up in Continue Series
6. Note: next episode is the newest unfinished 
7. Mark ALL the episodes as finished
8. Note: podcast does NOT show up in Continue Series

## Screenshots

<img width="918" height="743" alt="image" src="https://github.com/user-attachments/assets/4909734d-5d27-42eb-aaa8-1624a09b84e0" />
