### PR TITLE
Fix applying chapters not fully replacing existing chapter list

### DIFF
--- a/client/pages/audiobook/_id/chapters.vue
+++ b/client/pages/audiobook/_id/chapters.vue
@@ -753,8 +753,6 @@ export default {
         } else if (audibleChapters[audibleIdx]) {
           merged.push({ ...audibleChapters[audibleIdx], id: i })
           audibleIdx++
-        } else if (this.newChapters[i]) {
-          merged.push({ ...this.newChapters[i], id: i })
         }
       }
       this.newChapters = merged


### PR DESCRIPTION
## Brief summary

Fix bug where applying Audible chapters didn't fully replace the existing chapter list when the new list had fewer chapters.

## Which issue is fixed?

Fixes #4939

## In-depth Description

When applying chapters from Audible lookup, if the new chapter list had fewer chapters than the existing one, the old extra chapters were being retained. For example, going from 61 to 36 chapters would result in a hybrid list with 36 updated chapters plus 25 leftover old ones.

The bug was in the `applyChapterData()` function which incorrectly fell back to old chapters when the Audible chapter array was exhausted. This fallback should only happen for explicitly locked chapters, not for all remaining old chapters.

The fix removes the fallback to old non-locked chapters, ensuring the chapter list is fully replaced rather than merged with leftover old chapters.

This affects any user who:
- Has a book with more chapters than Audible returns
- Uses the chapter lookup feature

## How have you tested this?

1. Open a book with 61+ chapters in the chapter editor
2. Perform Audible chapter lookup (returns ~36 chapters)
3. Click "Apply Chapters"
4. Verify only 36 chapters remain (not 61)
5. Verify locked chapters are preserved if any were set

## Screenshots

N/A - No UI changes, logic fix only
