### PR TITLE
fix: support uploading files to existing library item folders

### DIFF
--- a/server/controllers/FileSystemController.js
+++ b/server/controllers/FileSystemController.js
@@ -88,7 +88,7 @@ class FileSystemController {
       return res.sendStatus(403)
     }
 
-    const { directory, folderPath } = req.body
+    const { folderPath, directory, fileName } = req.body
     if (!directory?.length || typeof directory !== 'string' || !folderPath?.length || typeof folderPath !== 'string') {
       Logger.error(`[FileSystemController] Invalid request body: ${JSON.stringify(req.body)}`)
       return res.status(400).json({
@@ -113,7 +113,7 @@ class FileSystemController {
       return res.sendStatus(403)
     }
 
-    let filepath = Path.join(libraryFolder.path, directory)
+    let filepath = Path.join(libraryFolder.path, directory, fileName)
     filepath = fileUtils.filePathToPOSIX(filepath)
 
     // Ensure filepath is inside library folder (prevents directory traversal)


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

This PR attempts to address enhancement #1894, Attempting to upload a file/book to existing library items. I simply changed the `pathexists` api call to accept the filepath of a file within an item. The UI was also updated to call the `pathexists` endpoint per file within an item, as a result.

<!-- Please provide a brief summary of what your PR attempts to achieve. -->

## Which issue is fixed?

Closes #1894 

<!-- Which issue number does this PR fix? Ex: "Fixes #1234" -->

## In-depth Description

Someone tried to compliment my audiobook with an ebook supplimant, and ran into this issue. I thought it would be a good into the project.

The update is rather straightforward, but I decided to allow partial uploads. this means if at least 1 file _doesnt_ exist (meaning the rest are dupes), the upload will proceed with the new file. I could change it though that all the files must not exist before uploading.

I understand there is a UI update in the works, but considering its months away, and this update is very tiny, I was hoping it would be acceptable.
<!--
Describe your solution in more depth.
How does it work? Why is this the best solution?
Does it solve a problem that affects multiple users or is this an edge case for your setup?
-->

## How have you tested this?
I ran the `npm run test` command, but found the controller I updated had no unit tests. If desired, i could start some, though itd certainly take me a little longer.

1. create library
2. upload file 'foo.m4b' with author 'anyguy'
3. attempt to upload file 'foo.m4b' with author 'anyguy' again
  - it should fail, as it used to
4. upload file 'foo.pdf' with author 'anyguy'
5. Notice Library has book 'Foo' from 'anyguy' with both uploads being successful.


<!-- Please describe in detail with reproducible steps how you tested your changes. -->

## Screenshots

Attached a video of the change working, and also blocking a re-upload (im used to work where the video would embed, I could post it privately to youtube if we still want it embedded lol).
https://github.com/user-attachments/assets/54e35a66-681e-484c-87df-84bf40de9fa8

Without my changes, the red error happens each time.
<!-- If your PR includes any changes to the web client, please include screenshots or a short video from before and after your changes. -->
