### PR TITLE
Update log filename format to include timestamp

### DIFF
--- a/server/scanner/LibraryScan.js
+++ b/server/scanner/LibraryScan.js
@@ -54,7 +54,7 @@ class LibraryScan {
     return secondsToTimestamp(this.elapsed / 1000)
   }
   get logFilename() {
-    return date.format(new Date(), 'YYYY-MM-DD') + '_' + this.id + '.txt'
+    return date.format(new Date(), 'YYYY-MM-DD HH:mm:ss.SSS') + '_' + this.id + '.txt'
   }
   get scanResultsString() {
     const strs = []


### PR DESCRIPTION
## Brief summary

The PR extends the timestamp in the filename, to make it easier to differentiate the logs if you are debugging.

## Which issue is fixed?

I had to debug the library scan due to some books not showing up. During that it was very annoying to differentiate log files, due to them only showing the date, not the time.

## In-depth Description

I just added minutes, seconds and miliseconds to the timestamp.


## How have you tested this?

-

## Screenshots

-
