### PR TITLE
feat: Add adjustable sizing to Cover search results

### DIFF
--- a/client/components/modals/item/tabs/Cover.vue
+++ b/client/components/modals/item/tabs/Cover.vue
@@ -68,9 +68,21 @@
       <p v-else-if="!searchInProgress && !coversFound.length" class="text-gray-300 py-4">{{ $strings.MessageNoCoversFound }}</p>
       <template v-for="cover in coversFound">
         <div :key="cover" class="m-0.5 mb-5 border-2 border-transparent hover:border-yellow-300 cursor-pointer" :class="cover === coverPath ? 'border-yellow-300' : ''" @click="updateCover(cover)">
-          <covers-preview-cover :src="cover" :width="80" show-open-new-tab :book-cover-aspect-ratio="bookCoverAspectRatio" />
+          <covers-preview-cover :src="cover" :width="coverWidth" show-open-new-tab :book-cover-aspect-ratio="bookCoverAspectRatio" />
         </div>
       </template>
+    </div>
+
+    <div v-if="hasSearched && coversFound.length" class="absolute bottom-4 right-4 z-50">
+      <div aria-hidden="true" class="rounded-full py-1 bg-primary px-3 border border-black-100 text-center flex items-center shadow-lg backdrop-blur-sm bg-opacity-90">
+        <span role="button" class="material-symbols hover:text-yellow-300 cursor-pointer select-none" style="font-size: 1.1rem" aria-label="Decrease Cover Size" @click="coverWidth = Math.max(60, coverWidth - 20)"> remove </span>
+
+        <p class="px-4 font-mono select-none" style="font-size: 1rem">
+          {{ coverWidth }}
+        </p>
+
+        <span role="button" class="material-symbols hover:text-yellow-300 cursor-pointer select-none" style="font-size: 1.1rem" aria-label="Increase Cover Size" @click="coverWidth = Math.min(300, coverWidth + 20)"> add </span>
+      </div>
     </div>
 
     <div v-if="previewUpload" class="absolute top-0 left-0 w-full h-full z-10 bg-bg p-8">
@@ -110,7 +122,8 @@ export default {
       provider: 'google',
       currentSearchRequestId: null,
       searchInProgress: false,
-      socketListenersActive: false
+      socketListenersActive: false,
+      coverWidth: 80
     }
   },
   watch: {


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

This adds functionality to adjust the size of the cover thumbnails returned by the library item -> edit -> cover search.

## Which issue is fixed?

Fixes #5044 

## In-depth Description

<!--
Describe your solution in more depth.
How does it work? Why is this the best solution?
Does it solve a problem that affects multiple users or is this an edge case for your setup?
-->

All this does is replace the default width attribute of the search results (80) with a variable `coverWidth` which is set by the buttons, just like the cover thumbnails shown in the regular library browsing screen.  It limits the sizes to a minimum of 60, and maximum of 300 (which fits 2 covers side by side in the window and leaves the text showing the size in pixels just variable, see screenshots).  The sizing buttons are only shown if the search is performed and has a nonzero number of results.

It works by just 

It also adds another entry to the data() object for Cover.vue (which is just the coverWdith).  

## How have you tested this?

<!-- Please describe in detail with reproducible steps how you tested your changes. -->

I built the web client and server applications, and tested this in that web client.  

## Screenshots

<!-- If your PR includes any changes to the web client, please include screenshots or a short video from before and after your changes. -->

Before (no buttons, icons small and hard to read)
<img width="812" height="700" alt="image" src="https://github.com/user-attachments/assets/b6f072b2-7d05-4310-a124-577c21703e77" />

After (icons still at default size of 80, buttons in lower right)
<img width="824" height="711" alt="image" src="https://github.com/user-attachments/assets/d31476d3-83f9-49d3-9d66-c20d34993283" />

After (icons at maximum size)
<img width="811" height="696" alt="image" src="https://github.com/user-attachments/assets/882488b7-45b0-4c3d-866d-027be7344870" />


