### PR TITLE
AuthorController: Update author name in match if changed

### DIFF
--- a/server/controllers/AuthorController.js
+++ b/server/controllers/AuthorController.js
@@ -368,6 +368,11 @@ class AuthorController {
       hasUpdates = true
     }
 
+    if (authorData.name && req.author.name !== authorData.name) {
+      req.author.name = authorData.name
+      hasUpdates = true
+    }
+
     if (hasUpdates) {
       await req.author.save()
 


### PR DESCRIPTION
## Brief summary

When quick matching an author, a check is added if the matched author name is different from the saved author.

## Which issue is fixed?

<!-- Which issue number does this PR fix? Ex: "Fixes #1234" -->

Fixes #5075

The author name check was missing and therefore the author name was not updated as expected.
I added a diff check similar to other fields, and if there's a diff, it updates the author name and sets `hasUpdates` appropriately.

## How have you tested this?

Ran the repro steps in the bug. Now the expected update happens.