### PR TITLE
feat: MediaSession respects "Use chapter track" setting

### DIFF
--- a/client/components/app/MediaPlayerContainer.vue
+++ b/client/components/app/MediaPlayerContainer.vue
@@ -148,6 +148,10 @@ export default {
     currentChapter() {
       return this.chapters.find((chapter) => chapter.start <= this.currentTime && this.currentTime < chapter.end)
     },
+    useChapterTrack() {
+      const _useChapterTrack = this.$store.getters['user/getUserSetting']('useChapterTrack') || false
+      return this.chapters.length ? _useChapterTrack : false
+    },
     title() {
       if (this.playerHandler.displayTitle) return this.playerHandler.displayTitle
       return this.mediaMetadata.title || 'No Title'
@@ -291,6 +295,8 @@ export default {
     setPlaybackRate(playbackRate) {
       this.currentPlaybackRate = playbackRate
       this.playerHandler.setPlaybackRate(playbackRate)
+      // Update position state with new playback rate
+      this.updateMediaSessionPositionState()
     },
     seek(time) {
       this.playerHandler.seek(time)
@@ -300,6 +306,7 @@ export default {
       this.playerHandler.seek(time, false)
     },
     setCurrentTime(time) {
+      const previousChapterId = this.currentChapter?.id
       this.currentTime = time
       if (this.$refs.audioPlayer) {
         this.$refs.audioPlayer.setCurrentTime(time)
@@ -307,6 +314,14 @@ export default {
 
       if (this.sleepTimerType === this.$constants.SleepTimerTypes.CHAPTER && this.sleepTimerSet) {
         this.checkChapterEnd()
+      }
+
+      // Update MediaSession position state (chapter-relative when useChapterTrack enabled)
+      this.updateMediaSessionPositionState()
+
+      // If chapter changed and useChapterTrack enabled, update MediaSession metadata
+      if (this.useChapterTrack && this.currentChapter?.id !== previousChapterId && this.currentChapter) {
+        this.updateMediaSessionForChapter()
       }
     },
     setDuration(duration) {
@@ -355,7 +370,20 @@ export default {
     mediaSessionSeekTo(e) {
       console.log('Media session seek to', e)
       if (e.seekTime !== null && !isNaN(e.seekTime)) {
-        this.playerHandler.seek(e.seekTime)
+        // When "Use chapter track" is enabled and chapters exist, seekTime is
+        // relative to current chapter start. Map it back to absolute position.
+        if (this.useChapterTrack && this.currentChapter) {
+          const chapterStart = this.currentChapter.start
+          const chapterEnd = this.currentChapter.end
+          const chapterDuration = chapterEnd - chapterStart
+          // Clamp seekTime to chapter bounds to prevent seeking outside chapter
+          const clampedSeekTime = Math.max(0, Math.min(e.seekTime, chapterDuration))
+          const absoluteTime = chapterStart + clampedSeekTime
+          this.playerHandler.seek(absoluteTime)
+        } else {
+          // "Use chapter track" disabled or no chapters - use full-file seek
+          this.playerHandler.seek(e.seekTime)
+        }
       }
     },
     mediaSessionPreviousTrack() {
@@ -371,6 +399,91 @@ export default {
     updateMediaSessionPlaybackState() {
       if ('mediaSession' in navigator) {
         navigator.mediaSession.playbackState = this.isPlaying ? 'playing' : 'paused'
+      }
+    },
+    /**
+     * Update MediaSession metadata when chapter changes (only if useChapterTrack is enabled).
+     * Updates the title to show chapter info and resets position state.
+     */
+    updateMediaSessionForChapter() {
+      if (!('mediaSession' in navigator) || !this.useChapterTrack || !this.currentChapter) {
+        return
+      }
+
+      // Update metadata with chapter title
+      const baseTitle = this.title
+      const chapterTitle = this.currentChapter.title
+
+      navigator.mediaSession.metadata = new MediaMetadata({
+        title: chapterTitle || baseTitle,
+        artist: this.playerHandler.displayAuthor || this.mediaMetadata.authorName || 'Unknown',
+        album: baseTitle,
+        artwork: [
+          {
+            src: this.$store.getters['globals/getLibraryItemCoverSrc'](this.streamLibraryItem, '/Logo.png', true)
+          }
+        ]
+      })
+
+      // Immediately update position state for new chapter
+      this.updateMediaSessionPositionState()
+    },
+    /**
+     * Update MediaSession position state.
+     * When "Use chapter track" is enabled and a chapter is active, reports
+     * duration/position relative to chapter bounds so the OS scrubber spans
+     * only the current chapter. Otherwise uses full-file duration/position.
+     */
+    updateMediaSessionPositionState() {
+      if (!('mediaSession' in navigator) || !navigator.mediaSession.setPositionState) {
+        return
+      }
+
+      const playbackRate = this.currentPlaybackRate || 1
+
+      if (this.useChapterTrack && this.currentChapter) {
+        // "Use chapter track" enabled - report chapter-relative values
+        const chapterStart = this.currentChapter.start
+        const chapterEnd = this.currentChapter.end
+        const chapterDuration = chapterEnd - chapterStart
+
+        // Calculate position relative to chapter start
+        // Clamp to valid range to handle slight timing drift
+        let chapterPosition = this.currentTime - chapterStart
+        chapterPosition = Math.max(0, Math.min(chapterPosition, chapterDuration))
+
+        // Validate values to prevent NaN or invalid states
+        if (isNaN(chapterDuration) || chapterDuration <= 0 || isNaN(chapterPosition)) {
+          console.warn('Invalid chapter position state values, skipping update')
+          return
+        }
+
+        try {
+          navigator.mediaSession.setPositionState({
+            duration: chapterDuration,
+            position: chapterPosition,
+            playbackRate: playbackRate
+          })
+        } catch (e) {
+          console.error('Error setting media session position state:', e)
+        }
+      } else if (this.totalDuration > 0) {
+        // "Use chapter track" disabled or no chapters - use full-file values
+        const position = Math.max(0, Math.min(this.currentTime, this.totalDuration))
+
+        if (isNaN(this.totalDuration) || isNaN(position)) {
+          return
+        }
+
+        try {
+          navigator.mediaSession.setPositionState({
+            duration: this.totalDuration,
+            position: position,
+            playbackRate: playbackRate
+          })
+        } catch (e) {
+          console.error('Error setting media session position state:', e)
+        }
       }
     },
     setMediaSession() {

--- a/client/pages/share/_slug.vue
+++ b/client/pages/share/_slug.vue
@@ -56,7 +56,8 @@ export default {
       listeningTimeSinceSync: 0,
       coverRgb: null,
       coverBgIsLight: false,
-      currentTime: 0
+      currentTime: 0,
+      currentPlaybackRate: 1
     }
   },
   computed: {
@@ -87,6 +88,10 @@ export default {
     },
     currentChapter() {
       return this.chapters.find((chapter) => chapter.start <= this.currentTime && this.currentTime < chapter.end)
+    },
+    useChapterTrack() {
+      const _useChapterTrack = this.$store.getters['user/getUserSetting']('useChapterTrack') || false
+      return this.chapters.length ? _useChapterTrack : false
     },
     coverAspectRatio() {
       const coverAspectRatio = this.playbackSession.coverAspectRatio
@@ -133,7 +138,20 @@ export default {
     mediaSessionSeekTo(e) {
       console.log('Media session seek to', e)
       if (e.seekTime !== null && !isNaN(e.seekTime)) {
-        this.seek(e.seekTime)
+        // When "Use chapter track" is enabled and chapters exist, seekTime is
+        // relative to current chapter start. Map it back to absolute position.
+        if (this.useChapterTrack && this.currentChapter) {
+          const chapterStart = this.currentChapter.start
+          const chapterEnd = this.currentChapter.end
+          const chapterDuration = chapterEnd - chapterStart
+          // Clamp seekTime to chapter bounds to prevent seeking outside chapter
+          const clampedSeekTime = Math.max(0, Math.min(e.seekTime, chapterDuration))
+          const absoluteTime = chapterStart + clampedSeekTime
+          this.seek(absoluteTime)
+        } else {
+          // "Use chapter track" disabled or no chapters - use full-file seek
+          this.seek(e.seekTime)
+        }
       }
     },
     mediaSessionPreviousTrack() {
@@ -149,6 +167,86 @@ export default {
     updateMediaSessionPlaybackState() {
       if ('mediaSession' in navigator) {
         navigator.mediaSession.playbackState = this.isPlaying ? 'playing' : 'paused'
+      }
+    },
+    /**
+     * Update MediaSession metadata when chapter changes (only if useChapterTrack is enabled).
+     * Updates the title to show chapter info and resets position state.
+     */
+    updateMediaSessionForChapter() {
+      if (!('mediaSession' in navigator) || !this.useChapterTrack || !this.currentChapter) {
+        return
+      }
+
+      const baseTitle = this.mediaItemShare.playbackSession.displayTitle || 'No title'
+      const chapterTitle = this.currentChapter.title
+
+      navigator.mediaSession.metadata = new MediaMetadata({
+        title: chapterTitle || baseTitle,
+        artist: this.mediaItemShare.playbackSession.displayAuthor || 'Unknown',
+        album: baseTitle,
+        artwork: [
+          {
+            src: this.coverUrl
+          }
+        ]
+      })
+
+      this.updateMediaSessionPositionState()
+    },
+    /**
+     * Update MediaSession position state.
+     * When "Use chapter track" is enabled and a chapter is active, reports
+     * duration/position relative to chapter bounds so the OS scrubber spans
+     * only the current chapter. Otherwise uses full-file duration/position.
+     */
+    updateMediaSessionPositionState() {
+      if (!('mediaSession' in navigator) || !navigator.mediaSession.setPositionState) {
+        return
+      }
+
+      const playbackRate = this.currentPlaybackRate || 1
+
+      if (this.useChapterTrack && this.currentChapter) {
+        // "Use chapter track" enabled - report chapter-relative values
+        const chapterStart = this.currentChapter.start
+        const chapterEnd = this.currentChapter.end
+        const chapterDuration = chapterEnd - chapterStart
+
+        let chapterPosition = this.currentTime - chapterStart
+        chapterPosition = Math.max(0, Math.min(chapterPosition, chapterDuration))
+
+        if (isNaN(chapterDuration) || chapterDuration <= 0 || isNaN(chapterPosition)) {
+          console.warn('Invalid chapter position state values, skipping update')
+          return
+        }
+
+        try {
+          navigator.mediaSession.setPositionState({
+            duration: chapterDuration,
+            position: chapterPosition,
+            playbackRate: playbackRate
+          })
+        } catch (e) {
+          console.error('Error setting media session position state:', e)
+        }
+      } else if (this.totalDuration > 0) {
+        // "Use chapter track" disabled or no chapters - use full-file values
+        const position = Math.max(0, Math.min(this.currentTime, this.totalDuration))
+
+        if (isNaN(this.totalDuration) || isNaN(position)) {
+          return
+        }
+
+        try {
+          navigator.mediaSession.setPositionState({
+            duration: this.totalDuration,
+            position: position,
+            playbackRate: playbackRate
+          })
+        } catch (e) {
+          console.error('Error setting media session position state:', e)
+        }
       }
     },
     setMediaSession() {
@@ -237,7 +335,10 @@ export default {
     },
     setPlaybackRate(playbackRate) {
       if (!this.localAudioPlayer || !this.hasLoaded) return
+      this.currentPlaybackRate = playbackRate
       this.localAudioPlayer.setPlaybackRate(playbackRate)
+      // Update position state with new playback rate
+      this.updateMediaSessionPositionState()
     },
     seek(time) {
       if (!this.localAudioPlayer || !this.hasLoaded) return
@@ -248,9 +349,19 @@ export default {
     setCurrentTime(time) {
       if (!this.$refs.audioPlayer) return
 
+      const previousChapterId = this.currentChapter?.id
+
       // Update UI
       this.$refs.audioPlayer.setCurrentTime(time)
       this.currentTime = time
+
+      // Update MediaSession position state (chapter-relative when useChapterTrack enabled)
+      this.updateMediaSessionPositionState()
+
+      // If chapter changed and useChapterTrack enabled, update MediaSession metadata
+      if (this.useChapterTrack && this.currentChapter?.id !== previousChapterId && this.currentChapter) {
+        this.updateMediaSessionForChapter()
+      }
     },
     setDuration() {
       if (!this.localAudioPlayer) return


### PR DESCRIPTION
## Brief summary

- When "Use chapter track" is enabled in player settings, the Media Session API now reports the current chapter's duration/position instead of the full audiobook
- OS lock screen and notification center scrubbers now span only the current chapter
- Seek requests from OS controls are mapped back to the correct absolute position

## Which issue is fixed?

Implements https://github.com/advplyr/audiobookshelf/issues/5079

## In-depth Description

### The Problem

When playing an M4B audiobook with embedded chapters (e.g., a 12-hour book with 30 chapters), the OS media controls (lock screen, notification center, Control Center) show a scrubber spanning the entire 12 hours! This makes precise navigation nearly impossible - a tiny thumb movement might skip 30 minutes.

### The Solution

When the user enables `Use chapter track` in player settings, we intercept the Media Session API to report values relative to the chapter instead of to the full audio file.

### Technical Implementation

1. Position State Reporting (`updateMediaSessionPositionState`)

Instead of:
```javascript
setPositionState({ duration: 43200, position: 7200 })  // 12hr book, 2hr in
```

We calculate:
```javascript
chapterStart = 7000      // Chapter 5 starts at 1:56:40
chapterEnd = 8440        // Chapter 5 ends at 2:20:40
chapterDuration = 1440   // 24 minutes
chapterPosition = 200    // 3:20 into chapter

setPositionState({ duration: 1440, position: 200 })
```

2. Seek Mapping (`mediaSessionSeekTo`)

When the user drags the OS scrubber, the OS sends a seek request relative to what we reported. We map it back:

```javascript
// OS requests: "seek to 600 seconds" (10 min into the 24-min chapter)
// We translate: chapterStart + 600 = 7000 + 600 = 7600
audio.currentTime = 7600  // Correct absolute position
```

3. Metadata Updates (`updateMediaSessionForChapter`)

When chapters change, we update the displayed title to show the chapter name instead of the book title.

### Why This Approach?

This was the minimum code change necessary to get the consistent UX between the web app interface and the OS media controls. This also gets the UI/UX in consistency with other apps, such as Audible.

## How have you tested this?

1. Tested on an iPad using the iOS Safari.
2. Tested for regressions. During playback and in the lock screen, the full audio progress shows if the "Use chapter track" is disabled, or if the audio file doesn't have tracker markers.
3. Tested new functionality, enabled "Use chapter track", locked the screen, now only the current chapter appears. Scrubbing and skipping ahead/behind 10s works as expected. Chapters transition at the right time.

## Screenshots

Before while listening to chapter 1 of Fourth Wing:
![audiobookshelf-screen-2](https://github.com/user-attachments/assets/cc936fef-c2e7-43e1-b9cd-5ede4783560a)

After listening to chapter 1 of Fourth Wing:
![audiobookshelf-screen-3](https://github.com/user-attachments/assets/e792ddc4-8f8a-45ae-9416-bab7099bb031)

