### PR TITLE
Add config for bcrypt cost, default to 12 instead of 8.

### DIFF
--- a/server/auth/LocalAuthStrategy.js
+++ b/server/auth/LocalAuthStrategy.js
@@ -2,6 +2,7 @@ const passport = require('passport')
 const LocalStrategy = require('../libs/passportLocal')
 const Database = require('../Database')
 const Logger = require('../Logger')
+const { toNumber } = require('../utils/index')
 
 const bcrypt = require('../libs/bcryptjs')
 const requestIp = require('../libs/requestIp')
@@ -87,6 +88,20 @@ class LocalAuthStrategy {
       // approve login
       Logger.info(`[LocalAuth] User "${user.username}" logged in from ip ${requestIp.getClientIp(req)}`)
 
+      const BCRYPT_COST = Math.max(Math.trunc(toNumber(process.env.BCRYPT_COST, 12)), 8);
+      const oldRounds = bcrypt.getRounds(user.pash);
+      // Update even if current hash is stronger, otherwise users with extra-light hardware (raspberry-pi or similar)
+      // will have unexpectedly slow logins even after lowering the BCRYPT_COST env var.
+      if (oldRounds != BCRYPT_COST) {
+        Logger.info(`[LocalAuth] Updating bcrypt cost for user "${user.username}" from ${oldRounds} to ${BCRYPT_COST}`)
+        const pash = await this.hashPassword(password)
+        if (!pash) {
+          Logger.error(`[LocalAuth] Failed to update bcrypt cost for user "${user.username}"`)
+          done(null, null)
+        }
+        await user.update({ pash })
+      }
+
       done(null, user)
       return
     }
@@ -114,7 +129,8 @@ class LocalAuthStrategy {
    */
   hashPassword(password) {
     return new Promise((resolve) => {
-      bcrypt.hash(password, 8, (err, hash) => {
+      const BCRYPT_COST = Math.max(Math.trunc(toNumber(process.env.BCRYPT_COST, 12)), 8);
+      bcrypt.hash(password, BCRYPT_COST, (err, hash) => {
         if (err) {
           resolve(null)
         } else {


### PR DESCRIPTION
## Brief summary

Allow configuring bcrypt cost, default to 12 instead of 8.

## In-depth Description

The recommended cost for bcrypt these days is usually 12, with 10 being the recommendation from over a decade ago. This PR adds an environment variable `BCRYPT_COST` to configure the bcrypt cost, with a minimum of 8.

I was unable to find any source for the documentation [here](https://www.audiobookshelf.org/docs/#security), so that will need to be updated separately. I recommend updating it with:

 - `BCRYPT_COST` (default: `12`)
   - This influences the time it takes to hash passwords when logging in; increasing by 1 doubles how long it takes.
   - It is recommended to leave it at the default, or, if it takes too long to log in, decrease it by 1 until logging in takes less than half a second (note that each user's first login after changing will take extra long to re-hash using the new cost).

## How have you tested this?

Created several users, logged in after changing bcrypt cost, changed passwords after changing bcrypt cost again.