### PR TITLE
feat: add autocomplete attributes for password manager support

### DIFF
--- a/client/components/ui/TextInput.vue
+++ b/client/components/ui/TextInput.vue
@@ -1,6 +1,6 @@
 <template>
   <div ref="wrapper" class="relative">
-    <input :id="inputId" :name="inputName" ref="input" v-model="inputValue" :type="actualType" :step="step" :min="min" :readonly="readonly" :disabled="disabled" :placeholder="placeholder" dir="auto" class="rounded-sm bg-primary text-gray-200 focus:bg-bg focus:outline-hidden border h-full w-full" :class="classList" @keyup="keyup" @change="change" @focus="focused" @blur="blurred" />
+    <input :id="inputId" :name="inputName" ref="input" v-model="inputValue" :type="actualType" :step="step" :min="min" :readonly="readonly" :disabled="disabled" :placeholder="placeholder" :autocomplete="autocomplete" dir="auto" class="rounded-sm bg-primary text-gray-200 focus:bg-bg focus:outline-hidden border h-full w-full" :class="classList" @keyup="keyup" @change="change" @focus="focused" @blur="blurred" />
     <div v-if="clearable && inputValue" class="absolute top-0 right-0 h-full px-2 flex items-center justify-center">
       <span class="material-symbols text-gray-300 cursor-pointer" style="font-size: 1.1rem" @click.stop.prevent="clear">close</span>
     </div>
@@ -41,7 +41,8 @@ export default {
     step: [String, Number],
     min: [String, Number],
     customInputClass: String,
-    trimWhitespace: Boolean
+    trimWhitespace: Boolean,
+    autocomplete: String
   },
   data() {
     return {

--- a/client/components/ui/TextInputWithLabel.vue
+++ b/client/components/ui/TextInputWithLabel.vue
@@ -6,7 +6,7 @@
         <em v-if="note" class="font-normal text-xs pl-2">{{ note }}</em>
       </label>
     </slot>
-    <ui-text-input :placeholder="placeholder || label" :inputId="identifier" ref="input" v-model="inputValue" :disabled="disabled" :readonly="readonly" :type="type" :min="min" :show-copy="showCopy" class="w-full" :class="inputClass" :trim-whitespace="trimWhitespace" @blur="inputBlurred" />
+    <ui-text-input :placeholder="placeholder || label" :inputId="identifier" ref="input" v-model="inputValue" :disabled="disabled" :readonly="readonly" :type="type" :min="min" :show-copy="showCopy" :autocomplete="autocomplete" class="w-full" :class="inputClass" :trim-whitespace="trimWhitespace" @blur="inputBlurred" />
   </div>
 </template>
 
@@ -26,7 +26,8 @@ export default {
     disabled: Boolean,
     inputClass: String,
     showCopy: Boolean,
-    trimWhitespace: Boolean
+    trimWhitespace: Boolean,
+    autocomplete: String
   },
   data() {
     return {}

--- a/client/pages/login.vue
+++ b/client/pages/login.vue
@@ -17,9 +17,9 @@
 
         <form @submit.prevent="submitServerSetup">
           <p class="text-lg font-semibold mb-2 pl-1 text-center">Create Root User</p>
-          <ui-text-input-with-label v-model.trim="newRoot.username" label="Username" :disabled="processing" class="w-full mb-3 text-sm" />
-          <ui-text-input-with-label v-model="newRoot.password" label="Password" type="password" :disabled="processing" class="w-full mb-3 text-sm" />
-          <ui-text-input-with-label v-model="confirmPassword" label="Confirm Password" type="password" :disabled="processing" class="w-full mb-3 text-sm" />
+          <ui-text-input-with-label v-model.trim="newRoot.username" label="Username" autocomplete="username" :disabled="processing" class="w-full mb-3 text-sm" />
+          <ui-text-input-with-label v-model="newRoot.password" label="Password" type="password" autocomplete="new-password" :disabled="processing" class="w-full mb-3 text-sm" />
+          <ui-text-input-with-label v-model="confirmPassword" label="Confirm Password" type="password" autocomplete="new-password" :disabled="processing" class="w-full mb-3 text-sm" />
 
           <p class="text-lg font-semibold mt-6 mb-2 pl-1 text-center">Directory Paths</p>
           <ui-text-input-with-label v-model="ConfigPath" label="Config Path" disabled class="w-full mb-3 text-sm" />
@@ -51,10 +51,10 @@
 
           <form v-show="login_local" @submit.prevent="submitForm">
             <label class="text-xs text-gray-300 uppercase">{{ $strings.LabelUsername }}</label>
-            <ui-text-input v-model.trim="username" :disabled="processing" class="mb-3 w-full" inputName="username" />
+            <ui-text-input v-model.trim="username" autocomplete="username" :disabled="processing" class="mb-3 w-full" inputName="username" />
 
             <label class="text-xs text-gray-300 uppercase">{{ $strings.LabelPassword }}</label>
-            <ui-text-input v-model.trim="password" type="password" :disabled="processing" class="w-full mb-3" inputName="password" />
+            <ui-text-input v-model.trim="password" type="password" autocomplete="current-password" :disabled="processing" class="w-full mb-3" inputName="password" />
             <div class="w-full flex justify-end py-3">
               <ui-btn type="submit" :disabled="processing" color="bg-primary" class="leading-none">{{ processing ? 'Checking...' : $strings.ButtonSubmit }}</ui-btn>
             </div>


### PR DESCRIPTION
## PR Description

### Brief summary

Adds standard HTML `autocomplete` attributes to the login and initial server setup forms to improve support for browser-native and third-party password managers (e.g., Apple Keychain, 1Password, Bitwarden).

### Which issue is fixed?

Addresses the need for improved credential autofill support.

### In-depth Description

This PR updates the `ui-text-input` and `ui-text-input-with-label` components to accept an `autocomplete` prop, which is then bound to the underlying HTML `<input>` element.

The `login.vue` page has been updated to use these new props:

* **Initial Server Setup**: Sets `autocomplete="username"` and `autocomplete="new-password"` to help password managers suggest and save root credentials during setup.
* **Login**: Sets `autocomplete="username"` and `autocomplete="current-password"` to ensure saved credentials are correctly mapped and autofilled by the OS/browser.

This is a non-breaking change that follows standard Web accessibility and security practices for credential handling.

### How have you tested this?

1. **Manual Web Test**: Verified in a browser (Chrome/Firefox) that the "Save Password" prompt appears correctly after a successful login.
2. **Autofill Verification**: Confirmed that saved credentials appear as suggestions in the username field.
3. **Setup Test**: Verified that the password manager suggests a "Strong Password" for the `new-password` fields during the server initialization screen.