### PR TITLE
fix: Retry socket authentication on auth failure

### DIFF
--- a/client/layouts/default.vue
+++ b/client/layouts/default.vue
@@ -143,6 +143,18 @@ export default {
     authFailed(payload) {
       console.error('[SOCKET] auth failed', payload.message)
       this.isSocketAuthenticated = false
+
+      // Retry authentication after a short delay (e.g., token might not be loaded yet)
+      // This handles race conditions where socket connects before token is available
+      setTimeout(() => {
+        if (!this.isSocketAuthenticated && this.socket?.connected) {
+          const token = this.$store.getters['user/getToken']
+          if (token) {
+            console.log('[SOCKET] Retrying authentication after auth failure')
+            this.socket.emit('auth', token)
+          }
+        }
+      }, 500)
     },
     init(payload) {
       console.log('Init Payload', payload)


### PR DESCRIPTION
When socket authentication fails (e.g., race condition when token is not yet loaded from storage), the client now retries authentication after a short delay. This fixes the issue where:

- Login page shows spinning icon forever
- Playback fails with 'invalid token' errors  
- Socket stays unauthenticated after transient failures

The fix adds a 500ms retry delay that allows time for the token to become available (e.g., after hydration from localStorage).

Fixes #5101

---
*Contributed by [theluckystrike](https://github.com/theluckystrike) | [Zovo](https://zovo.one)*