### PR TITLE
Add playbackRate to MediaProgress extraData

### DIFF
--- a/server/models/MediaProgress.js
+++ b/server/models/MediaProgress.js
@@ -169,6 +169,7 @@ class MediaProgress extends Model {
       hideFromContinueListening: !!this.hideFromContinueListening,
       ebookLocation: this.ebookLocation,
       ebookProgress: this.ebookProgress,
+      playbackRate: this.extraData?.playbackRate || null,
       lastUpdate: this.updatedAt.valueOf(),
       startedAt: this.createdAt.valueOf(),
       finishedAt: this.finishedAt?.valueOf() || null
@@ -207,6 +208,12 @@ class MediaProgress extends Model {
       // Old model stored progress on object
       this.extraData.progress = Math.min(1, Math.max(0, progressPayload.progress))
       this.changed('extraData', true)
+    }
+
+    if (progressPayload.playbackRate !== undefined) {
+      this.extraData.playbackRate = progressPayload.playbackRate
+      this.changed('extraData', true)
+      delete progressPayload.playbackRate
     }
 
     this.set(progressPayload)

--- a/test/server/models/MediaProgress.test.js
+++ b/test/server/models/MediaProgress.test.js
@@ -1,0 +1,102 @@
+const { expect } = require('chai')
+const sinon = require('sinon')
+
+const { Sequelize } = require('sequelize')
+const Database = require('../../../server/Database')
+const Logger = require('../../../server/Logger')
+
+describe('MediaProgress', () => {
+  let mediaProgress
+
+  beforeEach(async () => {
+    global.ServerSettings = {}
+    Database.sequelize = new Sequelize({ dialect: 'sqlite', storage: ':memory:', logging: false })
+    Database.sequelize.uppercaseFirst = (str) => (str ? `${str[0].toUpperCase()}${str.substr(1)}` : '')
+    await Database.buildModels()
+
+    const user = await Database.userModel.create({ username: 'testuser', type: 'root' })
+    const library = await Database.libraryModel.create({ name: 'Test Library', mediaType: 'book' })
+    const libraryFolder = await Database.libraryFolderModel.create({ path: '/test', libraryId: library.id })
+    const book = await Database.bookModel.create({ title: 'Test Book', audioFiles: [], tags: [], narrators: [], genres: [], chapters: [] })
+    const libraryItem = await Database.libraryItemModel.create({ libraryFiles: [], mediaId: book.id, mediaType: 'book', libraryId: library.id, libraryFolderId: libraryFolder.id })
+
+    mediaProgress = await Database.mediaProgressModel.create({
+      mediaItemId: book.id,
+      mediaItemType: 'book',
+      userId: user.id,
+      duration: 36000,
+      currentTime: 1234.5,
+      extraData: { libraryItemId: libraryItem.id, progress: 0.034 }
+    })
+
+    sinon.stub(Logger, 'info')
+    sinon.stub(Logger, 'error')
+  })
+
+  afterEach(async () => {
+    sinon.restore()
+    await Database.sequelize.sync({ force: true })
+  })
+
+  describe('getOldMediaProgress', () => {
+    it('includes playbackRate from extraData when set', () => {
+      mediaProgress.extraData = { ...mediaProgress.extraData, playbackRate: 1.5 }
+      const result = mediaProgress.getOldMediaProgress()
+      expect(result.playbackRate).to.equal(1.5)
+    })
+
+    it('returns null when playbackRate not in extraData', () => {
+      const result = mediaProgress.getOldMediaProgress()
+      expect(result.playbackRate).to.be.null
+    })
+
+    it('returns null when extraData is null', () => {
+      mediaProgress.extraData = null
+      const result = mediaProgress.getOldMediaProgress()
+      expect(result.playbackRate).to.be.null
+    })
+
+    it('preserves existing extraData fields', () => {
+      mediaProgress.extraData = { libraryItemId: 'li_test', progress: 0.5, playbackRate: 2.0 }
+      const result = mediaProgress.getOldMediaProgress()
+      expect(result.playbackRate).to.equal(2.0)
+      expect(result.progress).to.equal(0.5)
+      expect(result.libraryItemId).to.equal('li_test')
+    })
+  })
+
+  describe('applyProgressUpdate', () => {
+    it('stores playbackRate in extraData', async () => {
+      await mediaProgress.applyProgressUpdate({ playbackRate: 1.5 })
+      expect(mediaProgress.extraData.playbackRate).to.equal(1.5)
+    })
+
+    it('updates existing playbackRate', async () => {
+      mediaProgress.extraData = { ...mediaProgress.extraData, playbackRate: 1.5 }
+      await mediaProgress.applyProgressUpdate({ playbackRate: 2.0 })
+      expect(mediaProgress.extraData.playbackRate).to.equal(2.0)
+    })
+
+    it('does not touch playbackRate when not in payload', async () => {
+      mediaProgress.extraData = { ...mediaProgress.extraData, playbackRate: 1.5 }
+      await mediaProgress.applyProgressUpdate({ currentTime: 5000 })
+      expect(mediaProgress.extraData.playbackRate).to.equal(1.5)
+    })
+
+    it('preserves other extraData fields when setting playbackRate', async () => {
+      const originalLibraryItemId = mediaProgress.extraData.libraryItemId
+      const originalProgress = mediaProgress.extraData.progress
+      await mediaProgress.applyProgressUpdate({ playbackRate: 1.75 })
+      expect(mediaProgress.extraData.libraryItemId).to.equal(originalLibraryItemId)
+      expect(mediaProgress.extraData.progress).to.equal(originalProgress)
+      expect(mediaProgress.extraData.playbackRate).to.equal(1.75)
+    })
+
+    it('initializes extraData if null', async () => {
+      mediaProgress.extraData = null
+      await mediaProgress.applyProgressUpdate({ playbackRate: 1.25 })
+      expect(mediaProgress.extraData).to.be.an('object')
+      expect(mediaProgress.extraData.playbackRate).to.equal(1.25)
+    })
+  })
+})


### PR DESCRIPTION
## Brief summary

I added `playbackRate` to `mediaProgress.extraData` so each book/episode can store its own playback speed server-side. Any client (web, mobile, third-party) can use it.

## Which issue is fixed?

- Partially fixes #1173. Just the server changes here, the web client will need to wait until the React migration is done (see #5104)

## In-depth Description

I'm storing playback rate per item in `mediaProgress.extraData.playbackRate`. The existing `PATCH /api/me/progress/:libraryItemId/:episodeId?` endpoint accepts `playbackRate` in the payload, and `GET /api/me/progress` returns it in the response.

I'm already using this on the iOS side in [AudioBooth](https://github.com/AudioBooth/AudioBooth/pull/167) for per-book narration speed. The web client implementation is in #5104, kept separate since the frontend is being rewritten to React.

## How have you tested this?

- Verified `playbackRate` persists in the database via `PATCH /api/me/progress/:id`
- Verified it's returned in `getOldMediaProgress()` serialization
- unit tests

## Screenshots

```bash
# 1. Check current playbackRate (null, no per-book rate set)
$ curl -s "/api/me/progress/$ITEM" | jq .playbackRate
null

# 2. Set playbackRate to 1.5x
$ curl -X PATCH "/api/me/progress/$ITEM" -d '{"playbackRate": 1.5}'
HTTP 200

# 3. Read it back
$ curl -s "/api/me/progress/$ITEM" | jq .playbackRate
1.5

# 4. Update to 2.0x
$ curl -X PATCH "/api/me/progress/$ITEM" -d '{"playbackRate": 2.0}'
HTTP 200

# 5. Confirm update
$ curl -s "/api/me/progress/$ITEM" | jq .playbackRate
2

# 6. Verify other progress fields are unaffected
$ curl -s "/api/me/progress/$ITEM" | jq "{playbackRate, currentTime, progress, isFinished}"
{
  "playbackRate": 2,
  "currentTime": 107.001282,
  "progress": 0.015263561750603215,
  "isFinished": false
}
```
