### PR TITLE
Fix item_removed payload to include libraryId

### DIFF
--- a/server/controllers/LibraryController.js
+++ b/server/controllers/LibraryController.js
@@ -462,7 +462,7 @@ class LibraryController {
               }
             }
             Logger.info(`[LibraryController] Removing library item "${libraryItem.id}" from folder "${folder.path}"`)
-            await this.handleDeleteLibraryItem(libraryItem.id, mediaItemIds)
+            await this.handleDeleteLibraryItem(libraryItem.id, mediaItemIds, req.library.id)
           }
 
           if (authorIds.length) {
@@ -563,7 +563,7 @@ class LibraryController {
         mediaItemIds.push(libraryItem.mediaId)
       }
       Logger.info(`[LibraryController] Removing library item "${libraryItem.id}" from library "${req.library.name}"`)
-      await this.handleDeleteLibraryItem(libraryItem.id, mediaItemIds)
+      await this.handleDeleteLibraryItem(libraryItem.id, mediaItemIds, req.library.id)
     }
 
     // Set PlaybackSessions libraryId to null
@@ -714,7 +714,7 @@ class LibraryController {
         }
       }
       Logger.info(`[LibraryController] Removing library item "${libraryItem.id}" with issue`)
-      await this.handleDeleteLibraryItem(libraryItem.id, mediaItemIds)
+      await this.handleDeleteLibraryItem(libraryItem.id, mediaItemIds, req.library.id)
     }
 
     if (authorIds.length) {

--- a/server/controllers/LibraryItemController.js
+++ b/server/controllers/LibraryItemController.js
@@ -111,7 +111,7 @@ class LibraryItemController {
       }
     }
 
-    await this.handleDeleteLibraryItem(req.libraryItem.id, mediaItemIds)
+    await this.handleDeleteLibraryItem(req.libraryItem.id, mediaItemIds, req.libraryItem.libraryId)
     if (hardDelete) {
       Logger.info(`[LibraryItemController] Deleting library item from file system at "${libraryItemPath}"`)
       await fs.remove(libraryItemPath).catch((error) => {
@@ -565,7 +565,7 @@ class LibraryItemController {
           authorIds.push(...libraryItem.media.authors.map((au) => au.id))
         }
       }
-      await this.handleDeleteLibraryItem(libraryItem.id, mediaItemIds)
+      await this.handleDeleteLibraryItem(libraryItem.id, mediaItemIds, libraryItem.libraryId)
       if (hardDelete) {
         Logger.info(`[LibraryItemController] Deleting library item from file system at "${libraryItemPath}"`)
         await fs.remove(libraryItemPath).catch((error) => {

--- a/server/routers/ApiRouter.js
+++ b/server/routers/ApiRouter.js
@@ -363,8 +363,9 @@ class ApiRouter {
    * Remove library item and associated entities
    * @param {string} libraryItemId
    * @param {string[]} mediaItemIds array of bookId or podcastEpisodeId
+   * @param {string} libraryId
    */
-  async handleDeleteLibraryItem(libraryItemId, mediaItemIds) {
+  async handleDeleteLibraryItem(libraryItemId, mediaItemIds, libraryId) {
     const numProgressRemoved = await Database.mediaProgressModel.destroy({
       where: {
         mediaItemId: mediaItemIds
@@ -395,7 +396,8 @@ class ApiRouter {
     await Database.libraryItemModel.removeById(libraryItemId)
 
     SocketAuthority.emitter('item_removed', {
-      id: libraryItemId
+      id: libraryItemId,
+      libraryId
     })
   }
 


### PR DESCRIPTION
## Brief summary

Up until now, item_remolved was emitted with just the library item's id as payload. This makes it impossible to ignore the event if the client receiving the event is not displaying the same library as the item's.

## Which issue is fixed?

No issue.

## In-depth Description

To fix the issue, the libraryId is added to the item_removed payload. This has no effect on existing clients since it just adds to the payload, not changing existing fields.

## How have you tested this?

Removed library item on one window. Made sure that library item is still properly removed from the library page in a different window.