### PR TITLE
The timestamp in the share URL should override the saved position for the user.

### DIFF
--- a/client/pages/share/_slug.vue
+++ b/client/pages/share/_slug.vue
@@ -363,7 +363,9 @@ export default {
       console.log('Loaded media item share', this.mediaItemShare)
     }
 
-    const startTime = this.playbackSession.currentTime || 0
+    const startTime = this.$route.query.t && !isNaN(this.$route.query.t)
+      ? parseFloat(this.$route.query.t)
+      : (this.playbackSession.currentTime || 0)
     this.localAudioPlayer.set(null, this.audioTracks, false, startTime, false)
     this.localAudioPlayer.on('stateChange', this.playerStateChange.bind(this))
     this.localAudioPlayer.on('timeupdate', this.playerTimeUpdate.bind(this))

--- a/client/pages/share/_slug.vue
+++ b/client/pages/share/_slug.vue
@@ -363,9 +363,8 @@ export default {
       console.log('Loaded media item share', this.mediaItemShare)
     }
 
-    const startTime = this.$route.query.t && !isNaN(this.$route.query.t)
-      ? parseFloat(this.$route.query.t)
-      : (this.playbackSession.currentTime || 0)
+    const startTime = this.playbackSession.currentTime || 0
+
     this.localAudioPlayer.set(null, this.audioTracks, false, startTime, false)
     this.localAudioPlayer.on('stateChange', this.playerStateChange.bind(this))
     this.localAudioPlayer.on('timeupdate', this.playerTimeUpdate.bind(this))

--- a/server/controllers/ShareController.js
+++ b/server/controllers/ShareController.js
@@ -20,7 +20,7 @@ const ShareManager = require('../managers/ShareManager')
  */
 
 class ShareController {
-  constructor() {}
+  constructor() { }
 
   /**
    * Public route
@@ -53,6 +53,10 @@ class ShareController {
       if (playbackSession) {
         if (mediaItemShare.id === playbackSession.mediaItemShareId) {
           Logger.debug(`[ShareController] Found share playback session ${req.cookies.share_session_id}`)
+          // If ?t was provided, override the cached currentTime
+          if (startTime > 0) {
+            playbackSession.currentTime = startTime
+          }
           mediaItemShare.playbackSession = playbackSession.toJSONForClient()
           return res.json(mediaItemShare)
         } else {

--- a/server/controllers/ShareController.js
+++ b/server/controllers/ShareController.js
@@ -20,7 +20,7 @@ const ShareManager = require('../managers/ShareManager')
  */
 
 class ShareController {
-  constructor() { }
+  constructor() {}
 
   /**
    * Public route
@@ -54,7 +54,7 @@ class ShareController {
         if (mediaItemShare.id === playbackSession.mediaItemShareId) {
           Logger.debug(`[ShareController] Found share playback session ${req.cookies.share_session_id}`)
           // If ?t was provided, override the cached currentTime
-          if (startTime > 0) {
+          if (startTime > 0 && startTime < playbackSession.duration) {
             playbackSession.currentTime = startTime
           }
           mediaItemShare.playbackSession = playbackSession.toJSONForClient()


### PR DESCRIPTION
## Brief summary
When a share link includes a ?t= query parameter specifying a start time, it should seek to that position rather than resuming from the listener's previously cached position.
## Which issue is fixed?
No existing issue, this is a new bug fix.
## In-depth Description
Share links support a ?t= query parameter for specifying a start time. However, when a returning visitor has an active share session (via share_session_id cookie), the server returns the cached currentTime from that session and ignores the ?t parameter entirely.
The fix is in ShareController.getMediaItemShareBySlug: when an existing session is found and returned early, ?t is now checked and applied to playbackSession.currentTime before the response is sent. The client (_slug.vue) is also updated to prefer ?t over playbackSession.currentTime as a belt-and-suspenders guard.
This is useful any time someone wants to share a link to a specific moment (a particular chapter or scene) with someone who has already listened to part of the same share.
## How have you tested this?
`npm test`

Created a share link for an audiobook
Opened the link and listened for ~30 seconds (establishing a cached session)
Reloaded the page - confirmed it resumed from the cached position (expected baseline behavior)
Appended ?t=120 to the URL and reloaded - confirmed playback started at 2:00 rather than the cached position
Removed ?t and reloaded - confirmed it returned to resuming from cached position