### PR TITLE
feat: Add 'Add to Playlist' option when selecting multiple items

### DIFF
--- a/client/components/app/Appbar.vue
+++ b/client/components/app/Appbar.vue
@@ -64,6 +64,9 @@
         <ui-tooltip v-if="userCanUpdate && isBookLibrary" :text="$strings.LabelAddToCollection" direction="bottom">
           <ui-icon-btn :disabled="processingBatch" icon="collections_bookmark" @click="batchAddToCollectionClick" class="mx-1.5" />
         </ui-tooltip>
+        <ui-tooltip v-if="isBookLibrary" :text="$strings.LabelAddToPlaylist" direction="bottom">
+          <ui-icon-btn :disabled="processingBatch" icon="playlist_add" @click="batchAddToPlaylistClick" class="mx-1.5" />
+        </ui-tooltip>
         <template v-if="userCanUpdate">
           <ui-tooltip :text="$strings.LabelEdit" direction="bottom">
             <ui-icon-btn :disabled="processingBatch" icon="edit" bg-color="bg-warning" class="mx-1.5" @click="batchEditClick" />
@@ -370,6 +373,14 @@ export default {
     },
     batchAddToCollectionClick() {
       this.$store.commit('globals/setShowBatchCollectionsModal', true)
+    },
+    batchAddToPlaylistClick() {
+      const playlistItems = this.selectedMediaItems.map((i) => ({
+        libraryItem: { id: i.id },
+        episode: null
+      }))
+      this.$store.commit('globals/setSelectedPlaylistItems', playlistItems)
+      this.$store.commit('globals/setShowPlaylistsModal', true)
     },
     setBookshelfTotalEntities(totalEntities) {
       this.totalEntities = totalEntities


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

Adds new button when selecting multiple items to add them to a playlist

## Which issue is fixed?

Fixes https://github.com/advplyr/audiobookshelf/issues/5178

## In-depth Description
Changes are very simple and does nothing new compared to what's already there. Simply, adds a new button and calls on the existing playlist module to allow adding multiple items to a playlist.

## How have you tested this?

Made the change, spun up locally, downloaded some free audiobook and added multiple of them to a playlist 😄 

## Screenshots
<img width="1438" height="417" alt="image" src="https://github.com/user-attachments/assets/9bd7da73-6d00-49b4-a3a4-54c1cb992d06" />

<img width="974" height="665" alt="image" src="https://github.com/user-attachments/assets/fd5bfe89-5ae0-41f6-a929-e884a3d5234f" />
<img width="1195" height="420" alt="image" src="https://github.com/user-attachments/assets/c348fa24-752a-4855-949e-33829136e332" />

