### PR TITLE
feat: Add Series and Sequence number to the playlist view for items when applicable

### DIFF
--- a/client/components/tables/playlist/ItemTableRow.vue
+++ b/client/components/tables/playlist/ItemTableRow.vue
@@ -19,6 +19,9 @@
           <div class="truncate max-w-48 md:max-w-md">
             <nuxt-link :to="`/item/${libraryItem.id}`" class="truncate hover:underline text-sm md:text-base">{{ itemTitle }}</nuxt-link>
           </div>
+          <div v-if="seriesList.length" class="truncate max-w-48 md:max-w-md text-xs md:text-sm text-gray-300">
+            <nuxt-link v-for="_series in seriesList" :key="_series.id" :to="`/library/${libraryItem.libraryId}/series/${_series.id}`" class="hover:underline font-sans text-gray-300"> {{ _series.text }}</nuxt-link>
+          </div>
           <div class="truncate max-w-48 md:max-w-md text-xs md:text-sm text-gray-300">
             <template v-for="(author, index) in bookAuthors">
               <nuxt-link :key="author.id" :to="`/author/${author.id}`" class="truncate hover:underline">{{ author.name }}</nuxt-link
@@ -104,6 +107,17 @@ export default {
     bookAuthors() {
       if (this.episode) return []
       return this.mediaMetadata.authors || []
+    },
+    series() {
+      if (this.episode) return []
+      return this.mediaMetadata.series || []
+    },
+    seriesList() {
+      return this.series.map((se) => {
+        let text = se.name
+        if (se.sequence) text += ` #${se.sequence}`
+        return { ...se, text }
+      })
     },
     itemDuration() {
       if (this.episode) return this.$elapsedPretty(this.episode.duration)


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

Simply adds a series and sequence number to items a in playlist if they exist

## Which issue is fixed?

Fixes https://github.com/advplyr/audiobookshelf/issues/5179

## In-depth Description
Nothing new, adds a third line of content for items in a playlist, this line contains the Series and Sequence number if they exist


## How have you tested this?

Yes, added two audiobooks and set their series to `Test` with sequence numbers 1 and 2, started dev server

## Screenshots
<img width="925" height="333" alt="image" src="https://github.com/user-attachments/assets/95319095-8b0d-42cf-b73b-f76821bfb034" />

