### PR TITLE
Draft: Added initial usage of `parserDate`

### DIFF
--- a/server/scanner/AudioFileScanner.js
+++ b/server/scanner/AudioFileScanner.js
@@ -5,6 +5,7 @@ const { LogLevel } = require('../utils/constants')
 const { parseOverdriveMediaMarkersAsChapters } = require('../utils/parsers/parseOverdriveMediaMarkers')
 const parseNameString = require('../utils/parsers/parseNameString')
 const parseSeriesString = require('../utils/parsers/parseSeriesString')
+const parseDate = require('../utils/parsers/parseDate')
 const LibraryItem = require('../models/LibraryItem')
 const AudioFile = require('../objects/files/AudioFile')
 
@@ -463,8 +464,8 @@ class AudioFileScanner {
         value = value.trim() // Trim whitespace
 
         if (mapping.key === 'pubDate') {
-          const pubJsDate = new Date(value)
-          if (pubJsDate && !isNaN(pubJsDate)) {
+          const pubJsDate = parseDate.parse(value)
+          if (pubJsDate) {
             podcastEpisode.publishedAt = pubJsDate.valueOf()
             podcastEpisode.pubDate = value
             scanLogger.addLog(LogLevel.DEBUG, `Mapping metadata to key ${tagToUse} => ${mapping.key}: ${podcastEpisode[mapping.key]}`)

--- a/server/scanner/AudioFileScanner.js
+++ b/server/scanner/AudioFileScanner.js
@@ -433,6 +433,10 @@ class AudioFileScanner {
         key: 'pubDate'
       },
       {
+        tag: 'tagDate',
+        key: 'date'
+      },
+      {
         tag: 'tagDisc',
         key: 'season'
       },
@@ -463,7 +467,7 @@ class AudioFileScanner {
       if (value && typeof value === 'string') {
         value = value.trim() // Trim whitespace
 
-        if (mapping.key === 'pubDate') {
+        if ((mapping.key === 'pubDate' || mapping.key === 'date') && !podcastEpisode.pubDate) {
           const pubJsDate = parseDate.parse(value)
           if (pubJsDate) {
             podcastEpisode.publishedAt = pubJsDate.valueOf()

--- a/server/utils/parsers/parseDate.js
+++ b/server/utils/parsers/parseDate.js
@@ -1,0 +1,54 @@
+/**
+ * Parse a date string with multiple fallback formats
+ *
+ * @example
+ * parse('2024-01-15') => Date object for Jan 15, 2024
+ * parse('20240325')   => Date object for Mar 25, 2024
+ * parse('250312')     => Date object for Mar 12, 2025 (year <= 50 as 20xx)
+ * parse('750312')     => Date object for Mar 12, 1975 (year > 50 as 19xx)
+ *
+ * @param {string} dateString The date string to parse
+ * @returns {Date|null} Date object or null if unparseable
+ */
+function parseDate(dateString) {
+  if (!dateString || typeof dateString !== 'string') return null
+
+  const date = new Date(dateString)
+  if (!isNaN(date.getTime())) {
+    const year = date.getFullYear()
+    if (year >= 0 && year <= 9999) {
+      return date
+    }
+  }
+
+  const yyyymmddMatch = dateString.match(/^(\d{4})(\d{2})(\d{2})$/)
+  if (yyyymmddMatch) {
+    const [, year, month, day] = yyyymmddMatch
+    const monthNum = parseInt(month)
+    const dayNum = parseInt(day)
+    if (monthNum >= 1 && monthNum <= 12 && dayNum >= 1 && dayNum <= 31) {
+      const parsedDate = new Date(parseInt(year), monthNum - 1, dayNum)
+      if (!isNaN(parsedDate.getTime())) {
+        return parsedDate
+      }
+    }
+  }
+
+  const yymmddMatch = dateString.match(/^(\d{2})(\d{2})(\d{2})$/)
+  if (yymmddMatch) {
+    const [, year, month, day] = yymmddMatch
+    const monthNum = parseInt(month)
+    const dayNum = parseInt(day)
+    if (monthNum >= 1 && monthNum <= 12 && dayNum >= 1 && dayNum <= 31) {
+      const fullYear = parseInt(year) > 50 ? 1900 + parseInt(year) : 2000 + parseInt(year)
+      const parsedDate = new Date(fullYear, monthNum - 1, dayNum)
+      if (!isNaN(parsedDate.getTime())) {
+        return parsedDate
+      }
+    }
+  }
+
+  return null
+}
+
+module.exports.parse = parseDate

--- a/server/utils/podcastUtils.js
+++ b/server/utils/podcastUtils.js
@@ -4,6 +4,7 @@ const Logger = require('../Logger')
 const { xmlToJSON, timestampToSeconds } = require('./index')
 const htmlSanitizer = require('../utils/htmlSanitizer')
 const Fuse = require('../libs/fusejs')
+const parseDate = require('../utils/parsers/parseDate')
 
 /**
  * @typedef RssPodcastChapter
@@ -147,6 +148,12 @@ function extractPodcastMetadata(channel) {
     if (value?.['_']) value = value['_']
     metadata[cleanKey] = value
   })
+
+  if (!metadata['pubDate']) {
+    const dateVal = extractFirstArrayItem(channel, 'date')
+    if (dateVal) metadata['pubDate'] = dateVal
+  }
+
   return metadata
 }
 
@@ -197,6 +204,15 @@ function extractEpisodeData(item) {
       episode.pubDate = pubDate._
     } else {
       Logger.error(`[podcastUtils] Invalid pubDate ${item['pubDate']} for ${episode.enclosure.url}`)
+    }
+  } else if (item['date']) {
+    const date = extractFirstArrayItem(item, 'date')
+    if (typeof date === 'string') {
+      episode.pubDate = date
+    } else if (typeof date?._ === 'string') {
+      episode.pubDate = date._
+    } else {
+      Logger.error(`[podcastUtils] Invalid date ${item['date']} for ${episode.enclosure.url}`)
     }
   }
 
@@ -261,7 +277,7 @@ function extractEpisodeData(item) {
 }
 
 function cleanEpisodeData(data) {
-  const pubJsDate = data.pubDate ? new Date(data.pubDate) : null
+  const pubJsDate = data.pubDate ? parseDate.parse(data.pubDate) : null
   const publishedAt = pubJsDate && !isNaN(pubJsDate) ? pubJsDate.valueOf() : null
 
   return {

--- a/test/server/utils/parsers/parseDate.test.js
+++ b/test/server/utils/parsers/parseDate.test.js
@@ -1,0 +1,109 @@
+const chai = require('chai')
+const expect = chai.expect
+const { parse } = require('../../../../server/utils/parsers/parseDate')
+
+describe('parseDate', () => {
+  describe('parse', () => {
+    it('returns null for empty input', () => {
+      expect(parse('')).to.be.null
+      expect(parse(null)).to.be.null
+      expect(parse(undefined)).to.be.null
+    })
+
+    it('returns null for non-string input', () => {
+      expect(parse(20250101)).to.be.null
+      expect(parse({})).to.be.null
+      expect(parse([])).to.be.null
+    })
+
+    it('parses ISO 8601 date string with new Date()', () => {
+      const result = parse('2024-01-15')
+      expect(result).to.be.instanceOf(Date)
+      expect(result.getFullYear()).to.equal(2024)
+      expect(result.getMonth()).to.equal(0)
+      expect(result.getDate()).to.equal(15)
+    })
+
+    it('parses date string with time using new Date()', () => {
+      const result = parse('2024-06-20T14:30:00Z')
+      expect(result).to.be.instanceOf(Date)
+      expect(result.getFullYear()).to.equal(2024)
+      expect(result.getMonth()).to.equal(5)
+      expect(result.getDate()).to.equal(20)
+    })
+
+    it('parses YYYYMMDD format when new Date() fails', () => {
+      const result = parse('20240325')
+      expect(result).to.be.instanceOf(Date)
+      expect(result.getFullYear()).to.equal(2024)
+      expect(result.getMonth()).to.equal(2)
+      expect(result.getDate()).to.equal(25)
+    })
+
+    it('parses YYYYMMDD format with leading zeros', () => {
+      const result = parse('20240105')
+      expect(result).to.be.instanceOf(Date)
+      expect(result.getFullYear()).to.equal(2024)
+      expect(result.getMonth()).to.equal(0)
+      expect(result.getDate()).to.equal(5)
+    })
+
+    it('parses YYMMDD format (2-digit year > 50 as 19xx)', () => {
+      const result = parse('750312')
+      expect(result).to.be.instanceOf(Date)
+      expect(result.getFullYear()).to.equal(1975)
+      expect(result.getMonth()).to.equal(2)
+      expect(result.getDate()).to.equal(12)
+    })
+
+    it('parses YYMMDD format (2-digit year <= 50 as 20xx)', () => {
+      const result = parse('250312')
+      expect(result).to.be.instanceOf(Date)
+      expect(result.getFullYear()).to.equal(2025)
+      expect(result.getMonth()).to.equal(2)
+      expect(result.getDate()).to.equal(12)
+    })
+
+    it('parses YYMMDD format with leading zeros', () => {
+      const result = parse('990105')
+      expect(result).to.be.instanceOf(Date)
+      expect(result.getFullYear()).to.equal(1999)
+      expect(result.getMonth()).to.equal(0)
+      expect(result.getDate()).to.equal(5)
+    })
+
+    it('prefers new Date() parsing over YYYYMMDD when both could work', () => {
+      const result = parse('2024-01-15')
+      expect(result).to.be.instanceOf(Date)
+      expect(result.getFullYear()).to.equal(2024)
+    })
+
+    it('rejects month overflow in YYYYMMDD', () => {
+      expect(parse('20241301')).to.be.null
+    })
+
+    it('rejects day overflow in YYYYMMDD', () => {
+      expect(parse('20240235')).to.be.null
+    })
+
+    it('returns null for invalid strings', () => {
+      expect(parse('not a date')).to.be.null
+      expect(parse('hello world')).to.be.null
+      expect(parse('202401')).to.be.null
+    })
+
+    it('returns null for YYYYMMDD with non-digits', () => {
+      expect(parse('2024-01-15')).to.be.instanceOf(Date)
+      expect(parse('2024/01/15')).to.be.instanceOf(Date)
+      expect(parse('2024.01.15')).to.be.instanceOf(Date)
+    })
+
+    it('parses 4-digit year string as year', () => {
+      const result = parse('2024')
+      expect(result).to.be.instanceOf(Date)
+      expect(result.getFullYear()).to.equal(2024)
+      expect(result.getMonth()).to.equal(0)
+      expect(result.getDate()).to.equal(1)
+    })
+  })
+})


### PR DESCRIPTION
## Brief summary

For my use case, AudiobookShelf is my podcast central, and the Podcast entry is a mp3 file downloaded from other sources (Youtube, SoundCloud...) these files receive the date in the `date` metadata, with the format of `YYYYMMDD`. Right now the parser uses a plain `new Date()` which fails since this isn't a ISO standard.

This should use a `parserDate` to also attempt to parse these dates.

## Which issue is fixed?

Fixes #5192 

## In-depth Description

On the `AudioFileScanner` I'm using the newly created `parseDate` to parse the date from these edge cases.

## How have you tested this?

Unit tested and manual tested.

## Test Images

<img width="342" height="153" alt="Screenshot 2026-04-15 at 08 59 29" src="https://github.com/user-attachments/assets/ddcb52af-3c1e-40fe-b245-6e3442db4698" />

<img width="320" height="306" alt="Screenshot 2026-04-15 at 09 30 27" src="https://github.com/user-attachments/assets/f1eca91c-3f61-4119-8972-ee656d71fbfd" />

