### PR TITLE
Fix buffer-equal-constant-time for Node.js v25+ compatibility

### DIFF
--- a/server/libs/jwa/buffer-equal-constant-time/index.js
+++ b/server/libs/jwa/buffer-equal-constant-time/index.js
@@ -28,14 +28,19 @@ function bufferEq(a, b) {
 }
 
 bufferEq.install = function () {
-  Buffer.prototype.equal = SlowBuffer.prototype.equal = function equal(that) {
+  Buffer.prototype.equal = function equal(that) {
     return bufferEq(this, that);
   };
+  if (SlowBuffer && SlowBuffer.prototype) {
+    SlowBuffer.prototype.equal = Buffer.prototype.equal;
+  }
 };
 
 var origBufEqual = Buffer.prototype.equal;
-var origSlowBufEqual = SlowBuffer.prototype.equal;
+var origSlowBufEqual = SlowBuffer && SlowBuffer.prototype ? SlowBuffer.prototype.equal : undefined;
 bufferEq.restore = function () {
   Buffer.prototype.equal = origBufEqual;
-  SlowBuffer.prototype.equal = origSlowBufEqual;
+  if (SlowBuffer && SlowBuffer.prototype) {
+    SlowBuffer.prototype.equal = origSlowBufEqual;
+  }
 };


### PR DESCRIPTION
## Brief summary
Fixes the `buffer-equal-constant-time` dependency to handle the removal of `SlowBuffer` in Node.js v25+.

## Which issue is fixed?
No issue.

## In-depth Description
In Node.js v25+, the `SlowBuffer` class was entirely removed. The bundled `buffer-equal-constant-time` package (in `server/libs/jwa`) tries to unconditionally read `SlowBuffer.prototype.equal`, which causes an uncaught `ReferenceError` crashing the server on startup. This small guard prevents the crash without altering behavior on older Node.js versions.

## How have you tested this?
Ran `npm test` locally on Node.js v25+ and verified the server starts normally and all tests pass.

## Screenshots
N/A