### PR TITLE
Fix OpenID logout redirect URI for subfolder deployments

### DIFF
--- a/server/auth/OidcAuthStrategy.js
+++ b/server/auth/OidcAuthStrategy.js
@@ -396,9 +396,9 @@ class OidcAuthStrategy {
       if (authMethod === 'openid') {
         const protocol = req.secure || req.get('x-forwarded-proto') === 'https' ? 'https' : 'http'
         const host = req.get('host')
-        // TODO: ABS does currently not support subfolders for installation
-        // If we want to support it we need to include a config for the serverurl
-        postLogoutRedirectUri = `${protocol}://${host}${global.RouterBasePath}/login`
+        const hostUrl = new URL(`${protocol}://${host}`)
+        const subfolder = global.ServerSettings.authOpenIDSubfolderForRedirectURLs || ''
+        postLogoutRedirectUri = new URL(`${subfolder}/login`, hostUrl).toString()
       }
       // else for openid-mobile we keep postLogoutRedirectUri on null
       //  nice would be to redirect to the app here, but for example Authentik does not implement


### PR DESCRIPTION
## Brief summary
Fixes the OpenID logout redirect URI to respect subfolder deployments.

## Which issue is fixed?
No issue.

## In-depth Description
Currently, when Audiobookshelf is deployed behind a reverse proxy in a subfolder with OpenID enabled, the `post_logout_redirect_uri` falls back to the hardcoded `RouterBasePath` `/login`. This causes the user to be redirected to the root domain's `/login` path instead of the correct subfolder path upon logout.

This PR uses the `authOpenIDSubfolderForRedirectURLs` server setting (if present) to correctly construct the logout redirect URI relative to the subfolder.

## How have you tested this?
Locally verified the logout flow redirects to the correct subfolder path when `authOpenIDSubfolderForRedirectURLs` is configured.

## Screenshots
N/A