### PR TITLE
Add `audible.br` (Audible Brasil) as a book metadata provider

### DIFF
--- a/client/pages/audiobook/_id/chapters.vue
+++ b/client/pages/audiobook/_id/chapters.vue
@@ -347,7 +347,7 @@ export default {
       asinError: null,
       removeBranding: false,
       showSecondInputs: false,
-      audibleRegions: ['US', 'CA', 'UK', 'AU', 'FR', 'DE', 'JP', 'IT', 'IN', 'ES'],
+      audibleRegions: ['US', 'CA', 'UK', 'AU', 'FR', 'DE', 'JP', 'IT', 'IN', 'ES', 'BR'],
       hasChanges: false,
       timeIncrementAmount: 1,
       elapsedTime: 0,

--- a/server/controllers/SearchController.js
+++ b/server/controllers/SearchController.js
@@ -25,6 +25,7 @@ const providerMap = {
   'audible.it': 'Audible.it',
   'audible.in': 'Audible.in',
   'audible.es': 'Audible.es',
+  'audible.br': 'Audible.com.br',
   audnexus: 'Audnexus'
 }
 

--- a/server/finders/BookFinder.js
+++ b/server/finders/BookFinder.js
@@ -23,7 +23,7 @@ class BookFinder {
     this.audiobookCovers = new AudiobookCovers()
     this.customProviderAdapter = new CustomProviderAdapter()
 
-    this.providers = ['google', 'itunes', 'openlibrary', 'fantlab', 'audiobookcovers', 'audible', 'audible.ca', 'audible.uk', 'audible.au', 'audible.fr', 'audible.de', 'audible.jp', 'audible.it', 'audible.in', 'audible.es']
+    this.providers = ['google', 'itunes', 'openlibrary', 'fantlab', 'audiobookcovers', 'audible', 'audible.ca', 'audible.uk', 'audible.au', 'audible.fr', 'audible.de', 'audible.jp', 'audible.it', 'audible.in', 'audible.es', 'audible.br']
 
     this.verbose = false
   }

--- a/server/providers/Audible.js
+++ b/server/providers/Audible.js
@@ -16,7 +16,8 @@ class Audible {
       jp: '.co.jp',
       it: '.it',
       in: '.in',
-      es: '.es'
+      es: '.es',
+      br: '.com.br'
     }
   }
 


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

 Adds `audible.br` to the list of available book metadata providers, enabling users to search and match books using Audible's Brazilian catalogue (`audible.com.br`).

## Which issue is fixed?

 N/A

## In-depth Description

 The `Audible.js` provider already had the `br` region mapped to  `.com.br` in its `regionMap`, but `BookFinder.js` was not exposing `audible.br` in its providers array — so the option never appeared in the UI dropdown.

> Note: This PR depends on laxamentumtech/audnexus#861, which adds Brazil region support to the Audnexus API used for ASIN lookups.

## How have you tested this?

<!-- Please describe in detail with reproducible steps how you tested your changes. -->

On my mahchine, see the screenshots bellow.

## Screenshots


<img width="1122" height="515" alt="Screenshot 2026-05-01 at 21 07 47" src="https://github.com/user-attachments/assets/dbd37281-cc38-4cc4-87bf-e461a64fb0fc" />
<img width="1213" height="607" alt="Screenshot 2026-05-01 at 21 08 05" src="https://github.com/user-attachments/assets/e2c195bb-77d5-4f7a-8aa8-99022a00c2cb" />
<img width="759" height="265" alt="Screenshot 2026-05-01 at 21 09 50" src="https://github.com/user-attachments/assets/bf1dbf2b-8c1e-4ce7-b911-183a0dabb619" />
<img width="676" height="229" alt="Screenshot 2026-05-01 at 21 10 07" src="https://github.com/user-attachments/assets/ce514c60-bb6f-43d5-8815-833e41c491ae" />
<img width="1123" height="445" alt="Screenshot 2026-05-01 at 21 10 12" src="https://github.com/user-attachments/assets/cfecf077-ace6-4641-87d6-73db5d100f00" />
