### PR TITLE
Fix podcast episode sort for pre-1970 broadcast dates (web client)

### DIFF
--- a/client/components/tables/podcast/LazyEpisodesTable.vue
+++ b/client/components/tables/podcast/LazyEpisodesTable.vue
@@ -194,14 +194,18 @@ export default {
             bValue = b[this.sortKey]
           }
 
-          // Sort episodes with no pub date as the oldest
+          // publishedAt is a numeric ms epoch (negative for pre-1970 broadcasts).
+          // Compare numerically so the leading "-" of negative epochs doesn't
+          // break Intl.Collator{numeric:true}, which only handles unsigned digit
+          // runs. Missing dates count as oldest.
           if (this.sortKey === 'publishedAt') {
-            if (!aValue) aValue = Number.MAX_VALUE
-            if (!bValue) bValue = Number.MAX_VALUE
+            const av = aValue == null ? Number.NEGATIVE_INFINITY : Number(aValue)
+            const bv = bValue == null ? Number.NEGATIVE_INFINITY : Number(bValue)
+            return av < bv ? -1 : av > bv ? 1 : 0
           }
 
           const primaryCompare = String(aValue).localeCompare(String(bValue), undefined, { numeric: true, sensitivity: 'base' })
-          if (primaryCompare !== 0 || this.sortKey === 'publishedAt') return primaryCompare
+          if (primaryCompare !== 0) return primaryCompare
 
           // When sorting by season, secondary sort is by episode number
           if (this.sortKey === 'season') {
@@ -212,11 +216,10 @@ export default {
             if (secondaryCompare !== 0) return secondaryCompare
           }
 
-          // Final sort by publishedAt
-          let aPubDate = a.publishedAt || Number.MAX_VALUE
-          let bPubDate = b.publishedAt || Number.MAX_VALUE
-
-          return String(aPubDate).localeCompare(String(bPubDate), undefined, { numeric: true, sensitivity: 'base' })
+          // Final tiebreaker: numeric publishedAt
+          const apa = a.publishedAt == null ? Number.NEGATIVE_INFINITY : Number(a.publishedAt)
+          const bpa = b.publishedAt == null ? Number.NEGATIVE_INFINITY : Number(b.publishedAt)
+          return apa < bpa ? -1 : apa > bpa ? 1 : 0
         })
     },
     episodesList() {


### PR DESCRIPTION
## Brief summary

Fix podcast episode sort in the web client for episodes whose `publishedAt` is a negative ms epoch (broadcasts before 1970-01-01). The current `String(value).localeCompare(..., { numeric: true })` comparator in `LazyEpisodesTable.vue` treats the leading `-` of a negative number as a non-numeric character, so pre-1970 episodes interleave incorrectly with later ones.

## Which issue is fixed?

No existing issue, though the bug is the same family as #3620 (years <1000 in the books library). Companion PR for the mobile app: advplyr/audiobookshelf-app#1866.

## In-depth Description

`Intl.Collator` with `numeric: true` only treats unsigned digit runs as numbers. The `-` sign of a negative ms epoch is plain ASCII, so for those values the comparator is purely lexical. On a long-running archive podcast (BBC *Just a Minute*, 1967 → present, 1015 episodes) pre-1970 episodes cluster together — a 1967 episode appears **before** 1968 episodes when "Pub Date — newest first" is selected.

Changes are confined to `client/components/tables/podcast/LazyEpisodesTable.vue`:

- The primary `publishedAt` branch switches to numeric subtraction.
- The same-named final tiebreaker (used after primary/season-secondary compares) does the same.
- Other sort keys (`title`, the `season+episode` secondary tiebreaker) keep `localeCompare(numeric: true)` so natural sort ("Episode 2" < "Episode 10") is preserved.

Bundled intent-fix: the long-standing *"sort episodes with no pub date as the oldest"* comment was implemented backwards (`Number.MAX_VALUE` makes them sort newest). Switched to `Number.NEGATIVE_INFINITY` to match the comment.

## How have you tested this?

1. **Paste-into-console reproducer** — confirms the bug and the fix at the comparator level:
   ```js
   const eps = [
     { id: 'bedrooms_1967',  publishedAt: -63417600000 },
     { id: 'brownies_1968',  publishedAt: -61603200000 },
     { id: 'honeymoon_1968', publishedAt: -60393600000 },
     { id: 'bacchus_1970',   publishedAt:    345600000 }
   ]
   // Buggy (current):
   [...eps].sort((a, b) =>
     String(b.publishedAt).localeCompare(String(a.publishedAt),
       undefined, { numeric: true, sensitivity: 'base' })
   ).map(e => e.id)
   // → ['bacchus_1970','bedrooms_1967','brownies_1968','honeymoon_1968']  ← 1967 ahead of 1968 in DESC

   // Fixed:
   [...eps].sort((a, b) => b.publishedAt - a.publishedAt).map(e => e.id)
   // → ['bacchus_1970','honeymoon_1968','brownies_1968','bedrooms_1967']  ← chronological
   ```
2. **Real data** — my own ABS server has a 1015-episode *Just a Minute* podcast spanning 1967–2026 that exhibits the bug. After the fix, episodes sort chronologically end-to-end.

The `client/` Vue components have no test coverage today; happy to add Vue Test Utils in a follow-up if interest.

## Screenshots

Before (web client, "Pub Date" descending) — same symptom as the mobile screenshot in advplyr/audiobookshelf-app#1866. 

---
*Developed with the help of [Claude](https://claude.ai/) (Anthropic). Bug, fix, and reproducer reviewed and verified by me.*
