### PR TITLE
finetune opus encoding

### DIFF
--- a/server/utils/ffmpegHelpers.js
+++ b/server/utils/ffmpegHelpers.js
@@ -471,7 +471,11 @@ async function mergeAudioFiles(audioTracks, duration, itemCachePath, outputFileP
   ffmpeg.outputOptions(['-f mp4'])
 
   if (audioRequiresEncode) {
-    ffmpeg.outputOptions(['-map 0:a', `-acodec ${audioCodec}`, `-ac ${audioChannels}`, `-b:a ${audioBitrate}`])
+    if (audioCodec === 'opus') {
+      ffmpeg.outputOptions(['-map 0:a', '-c:a libopus', `-b:a ${audioBitrate}`, '-vbr on', '-compression_level 10', '-application voip', `-ac ${audioChannels}`])
+    } else {
+      ffmpeg.outputOptions(['-map 0:a', `-acodec ${audioCodec}`, `-ac ${audioChannels}`, `-b:a ${audioBitrate}`])
+    }
   } else {
     ffmpeg.outputOptions(['-max_muxing_queue_size 1000'])
 


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

Just minor improvement to the opus encoding adding `vbr on` `compression-level 10` and `application voip`
to the ffmpeg command

## Which issue is fixed?

Before opus converted audiobooks quality was questionable with the default settings

## How have you tested this?

I have converted multiple audiobooks with different original codecs (multiple mp3, flac, aac) to 
`m4b format with opus audio channel`
