### PR TITLE
Podcast episode description search, deep linking, and in-modal playback

### DIFF
--- a/client/components/cards/LazyBookCard.vue
+++ b/client/components/cards/LazyBookCard.vue
@@ -711,6 +711,7 @@ export default {
         var router = this.$router || this.$nuxt.$router
         if (router) {
           if (this.collapsedSeries) router.push(`/library/${this.libraryId}/series/${this.collapsedSeries.id}`)
+          else if (this.recentEpisode) router.push(`/item/${this.libraryItemId}?episodeId=${this.recentEpisode.id}`)
           else router.push(`/item/${this.libraryItemId}`)
         }
       }

--- a/client/components/controls/GlobalSearch.vue
+++ b/client/components/controls/GlobalSearch.vue
@@ -92,6 +92,12 @@
               </nuxt-link>
             </li>
           </template>
+          <li class="border-t border-white/10 mt-2 pt-1">
+            <button class="w-full text-left px-2 py-2 text-xs text-gray-300 hover:text-white hover:bg-black-400 rounded flex items-center gap-1" @click="submitSearch">
+              <span class="material-symbols" style="font-size: 1rem">search</span>
+              {{ $strings.ButtonSeeAllResultsFor || 'See all results for' }} "{{ lastSearch }}"
+            </button>
+          </li>
         </template>
       </ul>
     </div>

--- a/client/components/controls/GlobalSearch.vue
+++ b/client/components/controls/GlobalSearch.vue
@@ -42,7 +42,7 @@
           <p v-if="episodeResults.length" class="uppercase text-xs text-gray-400 my-1 px-1 font-semibold">{{ $strings.LabelEpisodes }}</p>
           <template v-for="item in episodeResults">
             <li :key="item.libraryItem.recentEpisode.id" class="text-gray-50 select-none relative cursor-pointer hover:bg-black-400 py-1" role="option" @click="clickOption">
-              <nuxt-link :to="`/item/${item.libraryItem.id}`">
+              <nuxt-link :to="`/item/${item.libraryItem.id}?episodeId=${item.libraryItem.recentEpisode.id}`">
                 <cards-episode-search-card :episode="item.libraryItem.recentEpisode" :library-item="item.libraryItem" />
               </nuxt-link>
             </li>

--- a/client/components/modals/podcast/ViewEpisode.vue
+++ b/client/components/modals/podcast/ViewEpisode.vue
@@ -14,6 +14,9 @@
           <p class="text-base mb-1">{{ podcastTitle }}</p>
           <p class="text-xs text-gray-300">{{ podcastAuthor }}</p>
         </div>
+        <button class="flex items-center justify-center w-10 h-10 rounded-full bg-white/10 hover:bg-white/20 text-white" @click="play">
+          <span class="material-symbols text-2xl">play_arrow</span>
+        </button>
       </div>
       <p dir="auto" class="text-lg font-semibold mb-6">{{ title }}</p>
       <div v-if="description" dir="auto" class="default-style less-spacing" @click="handleDescriptionClick" v-html="description" />
@@ -105,6 +108,13 @@ export default {
     }
   },
   methods: {
+    play() {
+      this.$eventBus.$emit('play-item', {
+        libraryItemId: this.libraryItem.id,
+        episodeId: this.episodeId
+      })
+      this.show = false
+    },
     handleDescriptionClick(e) {
       if (e.target.matches('span.time-marker')) {
         const time = parseInt(e.target.dataset.time)

--- a/client/pages/item/_id/index.vue
+++ b/client/pages/item/_id/index.vue
@@ -785,6 +785,16 @@ export default {
     this.episodeDownloadsQueued = this.libraryItem.episodeDownloadsQueued || []
     this.episodesDownloading = this.libraryItem.episodesDownloading || []
 
+    const episodeId = this.$route.query.episodeId
+    if (episodeId) {
+      const episode = this.podcastEpisodes.find((ep) => ep.id === episodeId)
+      if (episode) {
+        this.$store.commit('setSelectedLibraryItem', this.libraryItem)
+        this.$store.commit('globals/setSelectedEpisode', episode)
+        this.$store.commit('globals/setShowViewPodcastEpisodeModal', true)
+      }
+    }
+
     this.$eventBus.$on(`${this.libraryItem.id}_updated`, this.libraryItemUpdated)
     this.$root.socket.on('item_updated', this.libraryItemUpdated)
     this.$root.socket.on('rss_feed_open', this.rssFeedOpen)

--- a/server/utils/queries/libraryItemsPodcastFilters.js
+++ b/server/utils/queries/libraryItemsPodcastFilters.js
@@ -414,10 +414,10 @@ module.exports = {
       })
     }
 
-    // Search podcast episode title
+    // Search podcast episode title and description
     const podcastEpisodes = await Database.podcastEpisodeModel.findAll({
       where: [
-        Sequelize.literal(textSearchQuery.matchExpression('podcastEpisode.title')),
+        Sequelize.literal(`(${textSearchQuery.matchExpression('podcastEpisode.title')} OR ${textSearchQuery.matchExpression('podcastEpisode.description')})`),
         {
           '$podcast.libraryItem.libraryId$': library.id
         }


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

Make search also match episode descriptions, and route search result directly to matched episode modal. Also added a play button to the modal to be able to play directly.

## Which issue is fixed?

Not sure

## In-depth Description

  1. Extends the Sequalize episode search query to OR against podcastEpisode.description in addition to podcastEpisode.title.
  2. Adds ?episodeId=<id> to episode links in LazyBookCard and GlobalSearch. On the item page's mounted hook, reads that param and auto-opens the ViewEpisode modal 
  3. Adds a "See all results for" footer button in the search dropdown that calls submitSearch() to navigate to the full search page for a better UX
  4.  Adds a play button to the ViewEpisode modal header that emits play-item on $eventBus with { libraryItemId, episodeId } and closes the modal.

## How have you tested this?

Tested locally running in docker.

## Screenshots

<img width="708" height="504" alt="image" src="https://github.com/user-attachments/assets/d9e1eedf-40e8-4834-a62c-7c1be1b538fa" />

<img width="847" height="453" alt="image" src="https://github.com/user-attachments/assets/b697ffbc-db0b-4e19-8945-cafb0c033439" />
