### PR TITLE
Consider ISO-8859-1 encodings for text files

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "express-session": "^1.17.3",
     "graceful-fs": "^4.2.10",
     "htmlparser2": "^8.0.1",
+    "jschardet": "^3.1.4",
     "lru-cache": "^10.0.3",
     "node-unrar-js": "^2.0.2",
     "nodemailer": "^6.9.13",

--- a/server/utils/fileUtils.js
+++ b/server/utils/fileUtils.js
@@ -1,6 +1,8 @@
 const axios = require('axios')
 const Path = require('path')
 const ssrfFilter = require('ssrf-req-filter')
+const iconvlite = require('iconv-lite')
+const jschardet = require('jschardet')
 const exec = require('child_process').exec
 const fs = require('../libs/fsExtra')
 const rra = require('../libs/recursiveReaddirAsync')
@@ -122,7 +124,15 @@ module.exports.getIno = getIno
  */
 async function readTextFile(path) {
   try {
-    var data = await fs.readFile(path)
+    let data = await fs.readFile(path)
+    const det_enc = jschardet.detect(data)
+    if (det_enc)
+      try {
+        return iconvlite.decode(data, det_enc.encoding)
+      } catch (error) {
+        Logger.info(`[FileUtils] ReadTextFile detected encoding ${det_enc.encoding} for file ${path} failed to decode, defaulting to UTF-8. Internal error in iconv-lite: ${error}`)
+      }
+    // defaults to utf-8
     return String(data)
   } catch (error) {
     Logger.error(`[FileUtils] ReadTextFile error ${error}`)


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

Some metadata .nfo files are encoded in encodings other than UTF-8. However, the software does not take different encodings into account, generating invalid codepoints in titles and descriptions. I changed a utility function to fix this issue in multiple encodings.
<!-- Please provide a brief summary of what your PR attempts to achieve. -->

## Which issue is fixed?

<!-- Which issue number does this PR fix? Ex: "Fixes #1234" -->
Fixes #4731.

## In-depth Description

Two elements are required to solve this problem: (1) detecting the correct encoding and (2) decoding the buffer as the correct encoding.

For the first, I added the `jschardet` package, an encoding detection utility. I am not sure of whether this is the best library for this task, but it has no dependencies and it worked well in my testing of Latin1/Windows encoded files. The list of supported charsets is [here](https://www.npmjs.com/package/jschardet#supported-charsets).

For the latter, I used `iconv-lite`, which is already a dependency, to convert the buffer into the appropriate encoding. If the decoding fails, or no encoding is detected, the system falls back to UTF-8 (as it was already doing).

Elements related to this that I'm not sure are solved with this PR:
- [ ] Existing libraries: are .nfo and similar files re-read or are metadata stored in an internal database? I'd guess the second, so I don't know how existing libraries might benefit from this. Maybe writing a migration that loads existing metadata fields and tries to check the decoding? However, if a string is decoded (incorrectly) to utf-8, `jschardet` detects it as `ascii`. It only detects correctly when applied to a buffer, not a string. An alternative would be an option in the library settings to  re-scan existing metadata?
<!--
Describe your solution in more depth.
How does it work? Why is this the best solution?
Does it solve a problem that affects multiple users or is this an edge case for your setup?
-->

## How have you tested this?

I have built the client (`npm run client`), copied the dev-config (`cp .devcontainer/dev.js .`), run the dev server (`npm run dev`), created a library with a folder that contains a latin1-encoded .nfo file (for an audiobook) and scanned it. In the current release, the file is read as UTF-8, showing invalid chars. With this fix, the text is read correctly.
<!-- Please describe in detail with reproducible steps how you tested your changes. -->

## Screenshots

Before:
<img width="339" height="85" alt="image" src="https://github.com/user-attachments/assets/c3594d8c-e076-4538-988e-fe8e3dbb39ee" />

After:
<img width="331" height="83" alt="image" src="https://github.com/user-attachments/assets/5cb9b21d-f897-4f74-8747-d3bb724cb22e" />
<!-- If your PR includes any changes to the web client, please include screenshots or a short video from before and after your changes. -->
