### PR TITLE
Fix SSRF agents for cross-protocol podcast redirects

### DIFF
--- a/server/utils/ffmpegHelpers.js
+++ b/server/utils/ffmpegHelpers.js
@@ -1,11 +1,11 @@
 const axios = require('axios')
-const ssrfFilter = require('ssrf-req-filter')
 const Ffmpeg = require('../libs/fluentFfmpeg')
 const ffmpgegUtils = require('../libs/fluentFfmpeg/utils')
 const fs = require('../libs/fsExtra')
 const Path = require('path')
 const Logger = require('../Logger')
 const { filePathToPOSIX, copyToExisting } = require('./fileUtils')
+const { getSsrfRequestFilterAgents } = require('./ssrfUtils')
 
 function escapeSingleQuotes(path) {
   // A ' within a quoted string is escaped with '\'' in ffmpeg (see https://www.ffmpeg.org/ffmpeg-utils.html#Quoting-and-escaping)
@@ -116,6 +116,7 @@ module.exports.downloadPodcastEpisode = (podcastEpisodeDownload) => {
 
     for (const userAgent of userAgents) {
       try {
+        const ssrfRequestFilterAgents = getSsrfRequestFilterAgents(podcastEpisodeDownload.url)
         response = await axios({
           url: podcastEpisodeDownload.url,
           method: 'GET',
@@ -125,8 +126,8 @@ module.exports.downloadPodcastEpisode = (podcastEpisodeDownload) => {
             'User-Agent': userAgent
           },
           timeout: global.PodcastDownloadTimeout,
-          httpAgent: global.DisableSsrfRequestFilter?.(podcastEpisodeDownload.url) ? null : ssrfFilter(podcastEpisodeDownload.url),
-          httpsAgent: global.DisableSsrfRequestFilter?.(podcastEpisodeDownload.url) ? null : ssrfFilter(podcastEpisodeDownload.url)
+          httpAgent: ssrfRequestFilterAgents.httpAgent,
+          httpsAgent: ssrfRequestFilterAgents.httpsAgent
         })
 
         Logger.debug(`[ffmpegHelpers] Successfully connected with User-Agent: ${userAgent}`)

--- a/server/utils/fileUtils.js
+++ b/server/utils/fileUtils.js
@@ -1,11 +1,11 @@
 const axios = require('axios')
 const Path = require('path')
-const ssrfFilter = require('ssrf-req-filter')
 const exec = require('child_process').exec
 const fs = require('../libs/fsExtra')
 const rra = require('../libs/recursiveReaddirAsync')
 const Logger = require('../Logger')
 const { AudioMimeType } = require('./constants')
+const { getSsrfRequestFilterAgents } = require('./ssrfUtils')
 
 /**
  * Make sure folder separator is POSIX for Windows file paths. e.g. "C:\Users\Abs" becomes "C:/Users/Abs"
@@ -298,6 +298,7 @@ module.exports.getFilePathItemFromFileUpdate = (fileUpdate) => {
 module.exports.downloadFile = (url, filepath, contentTypeFilter = null) => {
   return new Promise(async (resolve, reject) => {
     Logger.debug(`[fileUtils] Downloading file to ${filepath}`)
+    const ssrfRequestFilterAgents = getSsrfRequestFilterAgents(url)
     axios({
       url,
       method: 'GET',
@@ -306,8 +307,8 @@ module.exports.downloadFile = (url, filepath, contentTypeFilter = null) => {
         'User-Agent': 'audiobookshelf (+https://audiobookshelf.org)'
       },
       timeout: 30000,
-      httpAgent: global.DisableSsrfRequestFilter?.(url) ? null : ssrfFilter(url),
-      httpsAgent: global.DisableSsrfRequestFilter?.(url) ? null : ssrfFilter(url)
+      httpAgent: ssrfRequestFilterAgents.httpAgent,
+      httpsAgent: ssrfRequestFilterAgents.httpsAgent
     })
       .then((response) => {
         // Validate content type

--- a/server/utils/podcastUtils.js
+++ b/server/utils/podcastUtils.js
@@ -1,9 +1,9 @@
 const axios = require('axios')
-const ssrfFilter = require('ssrf-req-filter')
 const Logger = require('../Logger')
 const { xmlToJSON, timestampToSeconds } = require('./index')
 const htmlSanitizer = require('../utils/htmlSanitizer')
 const Fuse = require('../libs/fusejs')
+const { getSsrfRequestFilterAgents } = require('./ssrfUtils')
 
 /**
  * @typedef RssPodcastChapter
@@ -362,6 +362,7 @@ module.exports.getPodcastFeed = (feedUrl, excludeEpisodeMetadata = false) => {
   if (feedUrl.startsWith('https://www.cbc.ca')) {
     userAgent = 'audiobookshelf (+https://audiobookshelf.org; like iTMS) - CBC'
   }
+  const ssrfRequestFilterAgents = getSsrfRequestFilterAgents(feedUrl)
 
   return axios({
     url: feedUrl,
@@ -373,8 +374,8 @@ module.exports.getPodcastFeed = (feedUrl, excludeEpisodeMetadata = false) => {
       'Accept-Encoding': 'gzip, compress, deflate',
       'User-Agent': userAgent
     },
-    httpAgent: global.DisableSsrfRequestFilter?.(feedUrl) ? null : ssrfFilter(feedUrl),
-    httpsAgent: global.DisableSsrfRequestFilter?.(feedUrl) ? null : ssrfFilter(feedUrl)
+    httpAgent: ssrfRequestFilterAgents.httpAgent,
+    httpsAgent: ssrfRequestFilterAgents.httpsAgent
   })
     .then(async (data) => {
       // Adding support for ios-8859-1 encoded RSS feeds.

--- a/server/utils/ssrfUtils.js
+++ b/server/utils/ssrfUtils.js
@@ -1,0 +1,29 @@
+const ssrfFilter = require('ssrf-req-filter')
+
+function getUrlWithProtocol(url, protocol) {
+  const parsedUrl = new URL(url)
+  parsedUrl.protocol = protocol
+  return parsedUrl.toString()
+}
+
+/**
+ * Creates protocol-specific SSRF filtering agents for clients that may follow
+ * redirects across HTTP and HTTPS.
+ *
+ * @param {string} url
+ * @returns {{httpAgent: import('http').Agent|null, httpsAgent: import('https').Agent|null}}
+ */
+function getSsrfRequestFilterAgents(url) {
+  if (global.DisableSsrfRequestFilter?.(url)) {
+    return {
+      httpAgent: null,
+      httpsAgent: null
+    }
+  }
+
+  return {
+    httpAgent: ssrfFilter(getUrlWithProtocol(url, 'http:')),
+    httpsAgent: ssrfFilter(getUrlWithProtocol(url, 'https:'))
+  }
+}
+module.exports.getSsrfRequestFilterAgents = getSsrfRequestFilterAgents

--- a/test/server/utils/ssrfUtils.test.js
+++ b/test/server/utils/ssrfUtils.test.js
@@ -1,0 +1,46 @@
+const { expect } = require('chai')
+
+const { getSsrfRequestFilterAgents } = require('../../../server/utils/ssrfUtils')
+
+describe('ssrfUtils', () => {
+  afterEach(() => {
+    delete global.DisableSsrfRequestFilter
+  })
+
+  describe('getSsrfRequestFilterAgents', () => {
+    it('should create protocol-specific agents for http urls', () => {
+      const agents = getSsrfRequestFilterAgents('http://example.com/audio.mp3')
+
+      expect(agents.httpAgent).to.have.property('protocol', 'http:')
+      expect(agents.httpsAgent).to.have.property('protocol', 'https:')
+    })
+
+    it('should create an http agent for https urls that redirect to http', () => {
+      const agents = getSsrfRequestFilterAgents('https://pdcn.co/e/http://feeds.soundcloud.com/stream/file.mp3')
+
+      expect(agents.httpAgent).to.have.property('protocol', 'http:')
+      expect(agents.httpsAgent).to.have.property('protocol', 'https:')
+    })
+
+    it('should disable agents when the global SSRF filter hook allows it', () => {
+      global.DisableSsrfRequestFilter = () => true
+
+      const agents = getSsrfRequestFilterAgents('https://example.com/audio.mp3')
+
+      expect(agents.httpAgent).to.equal(null)
+      expect(agents.httpsAgent).to.equal(null)
+    })
+
+    it('should pass the original url to the global SSRF filter hook', () => {
+      let checkedUrl = null
+      global.DisableSsrfRequestFilter = (url) => {
+        checkedUrl = url
+        return true
+      }
+
+      getSsrfRequestFilterAgents('https://example.com/audio.mp3')
+
+      expect(checkedUrl).to.equal('https://example.com/audio.mp3')
+    })
+  })
+})


### PR DESCRIPTION
## Brief summary

Fix cross-protocol podcast episode redirects when SSRF request filtering is enabled.

## Which issue is fixed?

Fixes #5230

## In-depth Description

Podcast episode downloads use Axios with both `httpAgent` and `httpsAgent` wrapped by `ssrf-req-filter`. The previous implementation built both agents from the original URL. Because `ssrf-req-filter` selects the native agent protocol from that URL, an episode URL that starts as HTTPS and redirects to HTTP can leave follow-redirects with an HTTP request backed by an HTTPS agent, causing `ERR_INVALID_PROTOCOL`.

This PR adds a shared helper that creates protocol-specific filtered agents for the same URL: an HTTP filtered agent for HTTP redirects and an HTTPS filtered agent for HTTPS requests. The existing `DISABLE_SSRF_REQUEST_FILTER` and whitelist hook behavior is preserved, and the same helper is used by podcast episode downloads, podcast feed requests, and generic web file downloads.

## How have you tested this?

- `npm test`
    - Result: `345 passing`
- `npm test -- test/server/utils/ssrfUtils.test.js`
    - Result: `4 passing`