### PR TITLE
Fix library search to ignore punctuation when matching

### DIFF
--- a/server/Database.js
+++ b/server/Database.js
@@ -967,6 +967,20 @@ WHERE EXISTS (
     }
 
     /**
+     * Returns an expression that strips punctuation the older in-memory search ignored.
+     *
+     * @param {string} expression
+     * @returns {string}
+     */
+    stripPunctuation(expression) {
+      const punctuationChars = ["'", '.', '`', '"', ',']
+      punctuationChars.forEach((char) => {
+        expression = `replace(${expression}, ${this.sequelize.escape(char)}, '')`
+      })
+      return expression
+    }
+
+    /**
      * Initialize the text query.
      *
      */
@@ -983,15 +997,17 @@ WHERE EXISTS (
      * Get match expression for the specified column.
      * If the query contains accents, match against the column as-is (case-insensitive exact match).
      * otherwise match against a normalized column (case-insensitive match with accents removed).
+     * Punctuation is stripped from both sides in all cases.
      *
      * @param {string} column
      * @returns {string}
      */
     matchExpression(column) {
-      const pattern = this.sequelize.escape(`%${this.query}%`)
-      if (!this.supportsUnaccent) return `${column} LIKE ${pattern}`
+      const queryExpr = this.stripPunctuation(this.sequelize.escape(this.query))
+      const pattern = `'%' || ${queryExpr} || '%'`
+      if (!this.supportsUnaccent) return `${this.stripPunctuation(column)} LIKE ${pattern}`
       const normalizedColumn = this.hasAccents ? column : this.normalize(column)
-      return `${normalizedColumn} LIKE ${pattern}`
+      return `${this.stripPunctuation(normalizedColumn)} LIKE ${pattern}`
     }
   }
 }

--- a/test/server/utils/queries/libraryItemsBookFilters.test.js
+++ b/test/server/utils/queries/libraryItemsBookFilters.test.js
@@ -14,7 +14,7 @@ describe('libraryItemsBookFilters.search', () => {
   })
 
   afterEach(async () => {
-    await Database.sequelize.close()
+    await Database.sequelize.sync({ force: true })
   })
 
   it('matches titles when the query omits commas', async () => {
@@ -40,5 +40,30 @@ describe('libraryItemsBookFilters.search', () => {
 
     expect(results.book).to.have.length(1)
     expect(results.book[0].libraryItem.media.metadata.title).to.equal('And Now, Back to You')
+  })
+
+  it('matches titles when the query omits apostrophes', async () => {
+    const library = await Database.libraryModel.create({ name: 'Test Library', mediaType: 'book' })
+    const libraryFolder = await Database.libraryFolderModel.create({ path: '/test', libraryId: library.id })
+    const book = await Database.bookModel.create({
+      title: "Don't Panic",
+      audioFiles: [],
+      tags: [],
+      narrators: [],
+      genres: [],
+      chapters: []
+    })
+    await Database.libraryItemModel.create({
+      libraryFiles: [],
+      mediaId: book.id,
+      mediaType: 'book',
+      libraryId: library.id,
+      libraryFolderId: libraryFolder.id
+    })
+
+    const results = await libraryItemsBookFilters.search(null, library, 'Dont Panic', 10, 0)
+
+    expect(results.book).to.have.length(1)
+    expect(results.book[0].libraryItem.media.metadata.title).to.equal("Don't Panic")
   })
 })

--- a/test/server/utils/queries/libraryItemsBookFilters.test.js
+++ b/test/server/utils/queries/libraryItemsBookFilters.test.js
@@ -1,0 +1,44 @@
+const { expect } = require('chai')
+const { Sequelize } = require('sequelize')
+
+const Database = require('../../../../server/Database')
+const libraryItemsBookFilters = require('../../../../server/utils/queries/libraryItemsBookFilters')
+
+describe('libraryItemsBookFilters.search', () => {
+  beforeEach(async () => {
+    global.ServerSettings = {}
+    Database.sequelize = new Sequelize({ dialect: 'sqlite', storage: ':memory:', logging: false })
+    Database.sequelize.uppercaseFirst = (str) => (str ? `${str[0].toUpperCase()}${str.substr(1)}` : '')
+    Database.supportsUnaccent = false
+    await Database.buildModels()
+  })
+
+  afterEach(async () => {
+    await Database.sequelize.close()
+  })
+
+  it('matches titles when the query omits commas', async () => {
+    const library = await Database.libraryModel.create({ name: 'Test Library', mediaType: 'book' })
+    const libraryFolder = await Database.libraryFolderModel.create({ path: '/test', libraryId: library.id })
+    const book = await Database.bookModel.create({
+      title: 'And Now, Back to You',
+      audioFiles: [],
+      tags: [],
+      narrators: [],
+      genres: [],
+      chapters: []
+    })
+    await Database.libraryItemModel.create({
+      libraryFiles: [],
+      mediaId: book.id,
+      mediaType: 'book',
+      libraryId: library.id,
+      libraryFolderId: libraryFolder.id
+    })
+
+    const results = await libraryItemsBookFilters.search(null, library, 'And Now Back to You', 10, 0)
+
+    expect(results.book).to.have.length(1)
+    expect(results.book[0].libraryItem.media.metadata.title).to.equal('And Now, Back to You')
+  })
+})


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

Restores punctuation-insensitive matching in library search by stripping the same five characters (`` ' . ` " , ``) `cleanStringForSearch()` stripped before search was migrated to DB-backed queries.

## Which issue is fixed?

Fixes #4991 : implements @andrew-hill's first proposed solution (ignore punctuation)

## In-depth Description

Punctuation stripping used to live in `cleanStringForSearch()` (5b4d3f71, #750, Jun 2022), which stripped `` ' . ` " , `` before matching. It got lost in the move to DB-backed search — the new `TextSearchQuery` class (501dc938, Sep 2024) took on accent normalization but not punctuation. `cleanStringForSearch()` is still at `server/utils/index.js:173`, unused.

This change adds a `stripPunctuation()` helper on `TextSearchQuery` and applies it inside `matchExpression()` to both the query and the column being matched, using the same character set as 5b4d3f71. Since `matchExpression()` is column-agnostic, the fix benefits every column the search path uses: book title, subtitle, author, and JSON-array values (series, tags, genres) as well as the equivalent fields on podcasts.

This is just restoring the prior behavior, so curly apostrophes (U+2019), fuzzy search (#1401), and extending the character set (eg. !, ?) are still open for follow-up.

## How have you tested this?

**Unit tests**:  added regression tests in `test/server/utils/queries/libraryItemsBookFilters.test.js` for the comma-omission and apostrophe-omission cases. Tests use the same in-memory `Database` pattern as `test/server/controllers/LibraryItemController.test.js`. Run with `npm test` — full suite  passes.

**Manual** :  built a docker image from this branch and ran it against a sandbox library with punctuation-heavy titles. Confirmed that searches like `howls moving castle` (matching `Howl's Moving Castle`) and `robert c martin` (matching `Robert C. Martin / Clean Architecture`) now return the expected results.

## Screenshots

No ui changes, but will see search results that previously didn't match: ie:  
Before:
<img width="584" height="172" alt="Screenshot 2026-05-20 at 5 53 01 PM" src="https://github.com/user-attachments/assets/23391b8c-ee6e-4e54-99f8-c56045e734c9" />

After(with fix):
<img width="606" height="364" alt="Screenshot 2026-05-20 at 5 53 18 PM" src="https://github.com/user-attachments/assets/b6f81044-9d4b-4c51-a76f-cc75f5339341" />

