### PR TITLE
Add unique UUID to access and refresh tokens

### DIFF
--- a/server/auth/TokenManager.js
+++ b/server/auth/TokenManager.js
@@ -1,4 +1,5 @@
 const { Op } = require('sequelize')
+const uuid = require('uuid')
 
 const Database = require('../Database')
 const Logger = require('../Logger')
@@ -115,6 +116,7 @@ class TokenManager {
     const payload = {
       userId: user.id,
       username: user.username,
+      jti: uuid.v4(),
       type: 'access'
     }
     const options = {
@@ -138,6 +140,7 @@ class TokenManager {
     const payload = {
       userId: user.id,
       username: user.username,
+      jti: uuid.v4(),
       type: 'refresh'
     }
     const options = {


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

Add guaranteed unique field to Access and Refresh tokens to ensure generating new tokens during the same second do not result in a collision for the same user.

## Which issue is fixed?

Fixes https://github.com/advplyr/audiobookshelf/issues/5253

## In-depth Description

The referenced issue should only occur when a user tries to refresh two separate tokens within 1 second, due to the `jsonwebtoken` library removing milliseconds from the expiration time and signing identical information with the same secret.

This PR adds a new JTI field (consisting of a UUIDv4) to all tokens to ensure new token uniqueness. I chose UUIDv4 because we already use v4 elsewhere in the server to be independent of generation time or ordering (including v1, v2, v6, v7). We cannot easily use the session ID to ensure token uniqueness (one suggestion included from #5253 ) because the token is used to create the session in the database, not the other way around.

This new JTI is only included on new tokens, so existing tokens will *not* force regeneration before they expire. I chose to not force the regeneration because this adds some complexity to validation to see if the JTI exists, and would prevent this from being an invisible update. The default access token expiration of 1 hour would automatically update nearly all user tokens almost immediately. Based on conversations on GitHub, Discord, and Reddit, pretty much every user who changed the default access token expiration did it because of the prior logout issue https://github.com/advplyr/audiobookshelf/issues/4630, but they will probably just continue using a long access time token unless there is a breaking change in the future.

## How have you tested this?

- Added temporary debug print to dump contents of JWT, verified UUID is present during verification.
- Ensured new tokens replaced old tokens from before the change with no user intervention

## Screenshots

N/A
