### PR TITLE
Fix duplicate bookAuthor creation when renaming authors

### DIFF
--- a/server/controllers/AuthorController.js
+++ b/server/controllers/AuthorController.js
@@ -149,7 +149,7 @@ class AuthorController {
       })
       if (libraryItems.length) {
         await Database.bookAuthorModel.removeByIds(req.author.id) // Remove all old BookAuthor
-        await Database.bookAuthorModel.bulkCreate(bookAuthorsToCreate) // Create all new BookAuthor
+        await Database.bookAuthorModel.bulkCreate(bookAuthorsToCreate, { ignoreDuplicates: true }) // Create all new unique BookAuthor
         for (const libraryItem of libraryItems) {
           await libraryItem.saveMetadataFile()
         }


### PR DESCRIPTION
## Brief summary

This PR fixes violations for the unique attribute of the `bookAuthor` table when renaming an author to another author that is already on a book.

## Which issue is fixed?

Fixes #5247 

## In-depth Description

The `bookAuthor` table has a unique constraint to ensure the same author cannot be added to the same book multiple times. When renaming an author, the server gets all books the author is a part of, removes the author, and then performs a `bulkCreate` to add the author to all of the books. This results in a unique constraint violation if one of those books already have the new author name attached to it.

Sequelize allows using the `ignoreDuplicates` for `bulkCreate` (see https://sequelize.org/api/v6/class/src/model.js~model#static-method-bulkCreate). This function does not work for Postgres < 9.5 (released 2016) or MSSQL (nobody has requested this backend), so I think this attribute is fine to include even with both of these exceptions.

## How have you tested this?

Without patch:
1. Added `Branderson` author to `Oathbringer` (book by `Brandon Sanderson`)
2. Added `Branderson` author to `I, Robot` (not by `Brandon Sanderson`)
3. Renamed `Branderson` to `Brandon Sanderson` and observed error from #5247 

With patch applied:
1. Added `Branderson` author to `Oathbringer` (book by `Brandon Sanderson`)
2. Added `Branderson` author to `I, Robot` (not by `Brandon Sanderson`)
3. Renamed `Branderson` to `Brandon Sanderson`
4. Verified `Branderson` no longer existed and `Brandon Sanderson` had books `Oathbringer` and `I, Robot`

## Screenshots

N/A