### PR TITLE
fix: collapsed series with filters

### DIFF
--- a/server/utils/queries/libraryItemsBookFilters.js
+++ b/server/utils/queries/libraryItemsBookFilters.js
@@ -311,7 +311,7 @@ module.exports = {
    */
   async getCollapseSeriesBooksToExclude(bookFindOptions, seriesWhere, replacements = {}) {
     const allSeries = await Database.seriesModel.findAll({
-      attributes: ['id', 'name'],
+      attributes: ['id', 'name', [Sequelize.literal('(SELECT count(*) FROM bookSeries bs WHERE bs.seriesId = series.id)'), 'numBooks']],
       distinct: true,
       subQuery: false,
       replacements,
@@ -339,7 +339,7 @@ module.exports = {
           booksToInclude.push(book.id)
           bookSeriesToInclude.push({
             id: book.bookSeries.id,
-            numBooks: s.books.length,
+            numBooks: s.dataValues.numBooks,
             libraryItemIds: s.books?.map((b) => b.libraryItem.id) || []
           })
           booksToExclude = booksToExclude.filter((bid) => bid !== book.id)

--- a/server/utils/queries/libraryItemsBookFilters.js
+++ b/server/utils/queries/libraryItemsBookFilters.js
@@ -309,11 +309,12 @@ module.exports = {
    * @param {Sequelize.WhereOptions} seriesWhere
    * @returns {object} { booksToExclude, bookSeriesToInclude }
    */
-  async getCollapseSeriesBooksToExclude(bookFindOptions, seriesWhere) {
+  async getCollapseSeriesBooksToExclude(bookFindOptions, seriesWhere, replacements = {}) {
     const allSeries = await Database.seriesModel.findAll({
       attributes: ['id', 'name', [Sequelize.literal('(SELECT count(*) FROM bookSeries bs WHERE bs.seriesId = series.id)'), 'numBooks']],
       distinct: true,
       subQuery: false,
+      replacements,
       where: seriesWhere,
       include: [
         {
@@ -581,7 +582,7 @@ module.exports = {
           ...bookIncludes
         ]
       }
-      const { booksToExclude, bookSeriesToInclude } = await this.getCollapseSeriesBooksToExclude(bookFindOptions, seriesWhere)
+      const { booksToExclude, bookSeriesToInclude } = await this.getCollapseSeriesBooksToExclude(bookFindOptions, seriesWhere, replacements)
       if (booksToExclude.length) {
         bookWhere.push({
           id: {

--- a/server/utils/queries/libraryItemsBookFilters.js
+++ b/server/utils/queries/libraryItemsBookFilters.js
@@ -311,7 +311,7 @@ module.exports = {
    */
   async getCollapseSeriesBooksToExclude(bookFindOptions, seriesWhere, replacements = {}) {
     const allSeries = await Database.seriesModel.findAll({
-      attributes: ['id', 'name', [Sequelize.literal('(SELECT count(*) FROM bookSeries bs WHERE bs.seriesId = series.id)'), 'numBooks']],
+      attributes: ['id', 'name'],
       distinct: true,
       subQuery: false,
       replacements,
@@ -339,7 +339,7 @@ module.exports = {
           booksToInclude.push(book.id)
           bookSeriesToInclude.push({
             id: book.bookSeries.id,
-            numBooks: s.dataValues.numBooks,
+            numBooks: s.books.length,
             libraryItemIds: s.books?.map((b) => b.libraryItem.id) || []
           })
           booksToExclude = booksToExclude.filter((bid) => bid !== book.id)


### PR DESCRIPTION
## Brief summary

The "Collapse Series" feature in the Library view doesn't work when certain filters are active - for example a Tag filter.
And it never worked for users whose access is restricted by tags, because they always use a Tag filter implicitly.
This PR fixes the broken query.

## Which issue is fixed?

Fixes #2807
Fixes #3049

## In-depth Description

The filter results in a `(SELECT count(*) FROM json_each(tags) WHERE json_valid(tags) AND json_each.value = :filterValue)` query but the `replacements` were not included before, so `:filterValue` could not be resolved and the query returned empty.

There remains a related, but independent issue for users that are restricted by tags, which should be tackled in a separate PR: The count badge on the series tile includes all books in the series. That can be confusing for restricted users because the count does not match what they see once the open the series up and see less books.

## How have you tested this?

I started a fresh instance of ABS, created two users - a root user and a user restricted by a tgs.
Then I uploaded a few books and tagged some of them with the same tag.
I tested both the root users's Library view with an active tag filter and the restricted user's Library view without filters.
In both cases the "Collapse Series" option did nothing before the fix and worked after the fix.

## Screenshots

Before:
<img width="779" height="320" alt="image" src="https://github.com/user-attachments/assets/463b3cf9-d693-4281-9d80-9c7207ba7da1" />

After:
<img width="794" height="305" alt="image" src="https://github.com/user-attachments/assets/a0cc1961-0d72-480b-8618-e0e026436124" />