### PR TITLE
fix: write metadata.json for podcast libraries when storeMetadataWithItem is enabled

### DIFF
--- a/server/scanner/PodcastScanner.js
+++ b/server/scanner/PodcastScanner.js
@@ -240,11 +240,7 @@ class PodcastScanner {
     if (hasMediaChanges) {
       await media.save()
       await this.saveMetadataFile(existingLibraryItem, libraryScan)
-      libraryItemUpdated = global.ServerSettings.storeMetadataWithItem
-    } else if (global.ServerSettings.storeMetadataWithItem) {
-      // Always save metadata file when setting is enabled, even without media changes
-      await this.saveMetadataFile(existingLibraryItem, libraryScan)
-      libraryItemUpdated = true
+      libraryItemUpdated = global.ServerSettings.storeMetadataWithItem && !existingLibraryItem.isFile
     }
 
     if (libraryItemUpdated) {

--- a/server/scanner/PodcastScanner.js
+++ b/server/scanner/PodcastScanner.js
@@ -241,6 +241,10 @@ class PodcastScanner {
       await media.save()
       await this.saveMetadataFile(existingLibraryItem, libraryScan)
       libraryItemUpdated = global.ServerSettings.storeMetadataWithItem
+    } else if (global.ServerSettings.storeMetadataWithItem) {
+      // Always save metadata file when setting is enabled, even without media changes
+      await this.saveMetadataFile(existingLibraryItem, libraryScan)
+      libraryItemUpdated = true
     }
 
     if (libraryItemUpdated) {


### PR DESCRIPTION
## What is changed

BookScanner has the check 'storeMetadataWithItem && !existingLibraryItem.isFile' when setting libraryItemUpdated after writing metadata. PodcastScanner was missing the !isFile guard so file-type podcast items would still try to set libraryItemUpdated even though there is no directory to write metadata.json into.

This aligns PodcastScanner with how BookScanner already works.

Fixes #5093

## Review response

Fair point on the original code structure. I removed the else-if branch and the actual fix is just adding the missing !isFile check that BookScanner already has.