### PR TITLE
fix: case-insensitive author merge check on rename

### DIFF
--- a/server/controllers/AuthorController.js
+++ b/server/controllers/AuthorController.js
@@ -121,7 +121,9 @@ class AuthorController {
           id: {
             [sequelize.Op.not]: req.author.id
           },
-          name: payload.name,
+          name: {
+            [sequelize.Op.iLike]: payload.name
+          },
           libraryId: req.author.libraryId
         }
       })

--- a/server/scanner/PodcastScanner.js
+++ b/server/scanner/PodcastScanner.js
@@ -241,6 +241,10 @@ class PodcastScanner {
       await media.save()
       await this.saveMetadataFile(existingLibraryItem, libraryScan)
       libraryItemUpdated = global.ServerSettings.storeMetadataWithItem
+    } else if (global.ServerSettings.storeMetadataWithItem) {
+      // Always save metadata file when setting is enabled, even without media changes
+      await this.saveMetadataFile(existingLibraryItem, libraryScan)
+      libraryItemUpdated = true
     }
 
     if (libraryItemUpdated) {


### PR DESCRIPTION
When renaming an author from e.g. max to Max, the merge check now uses case-insensitive comparison (Op.iLike) instead of exact match. Fixes #5278