### PR TITLE
fix: case-insensitive author merge check on rename

### DIFF
--- a/server/controllers/AuthorController.js
+++ b/server/controllers/AuthorController.js
@@ -121,7 +121,9 @@ class AuthorController {
           id: {
             [sequelize.Op.not]: req.author.id
           },
-          name: payload.name,
+          name: {
+            [sequelize.Op.iLike]: payload.name
+          },
           libraryId: req.author.libraryId
         }
       })


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

Renaming an author from e.g. "max" to "Max" now triggers the merge prompt, because the merge check compares names case-insensitively (Op.iLike) instead of with exact string equality.

## Which issue is fixed?

Fixes #5278

## In-depth Description

The previous code used an exact string comparison for the author merge check, so renaming to the same name with different casing was treated as no change and reported "No updates were necessary". Switching to a case-insensitive comparison makes the rename detectable and prompts the user to merge the two author records.

## How have you tested this?

Tested locally by renaming an author with only a casing change and confirming the merge prompt now appears. Existing exact-match merges continue to work.

## Screenshots

N/A