### PR TITLE
fix: write per-episode metadata files for podcast libraries

### DIFF
--- a/server/scanner/PodcastScanner.js
+++ b/server/scanner/PodcastScanner.js
@@ -443,18 +443,7 @@ class PodcastScanner {
       asin: libraryItem.media.asin,
       language: libraryItem.media.language,
       explicit: !!libraryItem.media.explicit,
-      podcastType: libraryItem.media.podcastType,
-      episodes: (libraryItem.media.podcastEpisodes || []).map((ep) => ({
-        title: ep.title,
-        subtitle: ep.subtitle,
-        season: ep.season,
-        episode: ep.episode,
-        episodeType: ep.episodeType,
-        pubDate: ep.pubDate,
-        publishedAt: ep.publishedAt,
-        description: ep.description,
-        chapters: ep.chapters || []
-      }))
+      podcastType: libraryItem.media.podcastType
     }
     return fsExtra
       .writeFile(metadataFilePath, JSON.stringify(jsonObject, null, 2))
@@ -488,12 +477,63 @@ class PodcastScanner {
 
         libraryScan.addLog(LogLevel.DEBUG, `Success saving abmetadata to "${metadataFilePath}"`)
 
+        // Write per-episode metadata files alongside each episode's audio file
+        if (storeMetadataWithItem && libraryItem.media.podcastEpisodes?.length) {
+          await this.saveEpisodeMetadataFiles(libraryItem, libraryItem.media.podcastEpisodes, libraryScan)
+        }
+
         return metadataLibraryFile
       })
       .catch((error) => {
         libraryScan.addLog(LogLevel.ERROR, `Failed to save json file at "${metadataFilePath}"`, error)
         return null
       })
+  }
+
+  /**
+   * Write per-episode metadata files alongside each episode's audio file.
+   * For an episode at /path/to/episode.mp3, writes /path/to/episode.json
+   * containing title, description, pubDate, chapters, etc.
+   *
+   * @param {import('../models/LibraryItem')} libraryItem
+   * @param {import('../models/PodcastEpisode')[]} podcastEpisodes
+   * @param {import('./LibraryScan')} libraryScan
+   * @returns {Promise<void>}
+   */
+  async saveEpisodeMetadataFiles(libraryItem, podcastEpisodes, libraryScan) {
+    for (const episode of podcastEpisodes) {
+      if (!episode.audioFile?.metadata?.path) continue
+
+      const audioFilePath = episode.audioFile.metadata.path
+      const episodeMetadataPath = audioFilePath.replace(/\.[^.]+$/, '.json')
+
+      const episodeJson = {
+        title: episode.title,
+        subtitle: episode.subtitle,
+        season: episode.season,
+        episode: episode.episode,
+        episodeType: episode.episodeType,
+        pubDate: episode.pubDate,
+        publishedAt: episode.publishedAt,
+        description: episode.description,
+        chapters: episode.chapters || []
+      }
+
+      try {
+        await fsExtra.writeFile(episodeMetadataPath, JSON.stringify(episodeJson, null, 2))
+        libraryScan.addLog(LogLevel.DEBUG, `Saved episode metadata to "${episodeMetadataPath}"`)
+
+        // Add to libraryFiles if not already tracked
+        const metadataLibraryFile = libraryItem.libraryFiles.find((lf) => lf.metadata.path === filePathToPOSIX(episodeMetadataPath))
+        if (!metadataLibraryFile) {
+          const newLibraryFile = new LibraryFile()
+          await newLibraryFile.setDataFromPath(episodeMetadataPath, Path.basename(episodeMetadataPath))
+          libraryItem.libraryFiles.push(newLibraryFile.toJSON())
+        }
+      } catch (error) {
+        libraryScan.addLog(LogLevel.ERROR, `Failed to save episode metadata at "${episodeMetadataPath}"`, error)
+      }
+    }
   }
 }
 module.exports = new PodcastScanner()

--- a/server/scanner/PodcastScanner.js
+++ b/server/scanner/PodcastScanner.js
@@ -443,7 +443,18 @@ class PodcastScanner {
       asin: libraryItem.media.asin,
       language: libraryItem.media.language,
       explicit: !!libraryItem.media.explicit,
-      podcastType: libraryItem.media.podcastType
+      podcastType: libraryItem.media.podcastType,
+      episodes: (libraryItem.media.podcastEpisodes || []).map((ep) => ({
+        title: ep.title,
+        subtitle: ep.subtitle,
+        season: ep.season,
+        episode: ep.episode,
+        episodeType: ep.episodeType,
+        pubDate: ep.pubDate,
+        publishedAt: ep.publishedAt,
+        description: ep.description,
+        chapters: ep.chapters || []
+      }))
     }
     return fsExtra
       .writeFile(metadataFilePath, JSON.stringify(jsonObject, null, 2))

--- a/server/scanner/PodcastScanner.js
+++ b/server/scanner/PodcastScanner.js
@@ -477,9 +477,8 @@ class PodcastScanner {
 
         libraryScan.addLog(LogLevel.DEBUG, `Success saving abmetadata to "${metadataFilePath}"`)
 
-        // Write per-episode metadata files alongside each episode's audio file
         if (storeMetadataWithItem && libraryItem.media.podcastEpisodes?.length) {
-          await this.saveEpisodeMetadataFiles(libraryItem, libraryItem.media.podcastEpisodes, libraryScan)
+          await this.writeEpisodeMetadata(libraryItem, libraryItem.media.podcastEpisodes, libraryScan)
         }
 
         return metadataLibraryFile
@@ -490,48 +489,35 @@ class PodcastScanner {
       })
   }
 
-  /**
-   * Write per-episode metadata files alongside each episode's audio file.
-   * For an episode at /path/to/episode.mp3, writes /path/to/episode.json
-   * containing title, description, pubDate, chapters, etc.
-   *
-   * @param {import('../models/LibraryItem')} libraryItem
-   * @param {import('../models/PodcastEpisode')[]} podcastEpisodes
-   * @param {import('./LibraryScan')} libraryScan
-   * @returns {Promise<void>}
-   */
-  async saveEpisodeMetadataFiles(libraryItem, podcastEpisodes, libraryScan) {
-    for (const episode of podcastEpisodes) {
-      if (!episode.audioFile?.metadata?.path) continue
+  async writeEpisodeMetadata(libraryItem, episodes, libraryScan) {
+    for (const ep of episodes) {
+      if (!ep.audioFile?.metadata?.path) continue
 
-      const audioFilePath = episode.audioFile.metadata.path
-      const episodeMetadataPath = audioFilePath.replace(/\.[^.]+$/, '.json')
-
-      const episodeJson = {
-        title: episode.title,
-        subtitle: episode.subtitle,
-        season: episode.season,
-        episode: episode.episode,
-        episodeType: episode.episodeType,
-        pubDate: episode.pubDate,
-        publishedAt: episode.publishedAt,
-        description: episode.description,
-        chapters: episode.chapters || []
+      const metaPath = ep.audioFile.metadata.path.replace(/\.[^.]+$/, '.json')
+      const data = {
+        title: ep.title,
+        subtitle: ep.subtitle,
+        season: ep.season,
+        episode: ep.episode,
+        episodeType: ep.episodeType,
+        pubDate: ep.pubDate,
+        publishedAt: ep.publishedAt,
+        description: ep.description,
+        chapters: ep.chapters || []
       }
 
       try {
-        await fsExtra.writeFile(episodeMetadataPath, JSON.stringify(episodeJson, null, 2))
-        libraryScan.addLog(LogLevel.DEBUG, `Saved episode metadata to "${episodeMetadataPath}"`)
+        await fsExtra.writeFile(metaPath, JSON.stringify(data, null, 2))
+        libraryScan.addLog(LogLevel.DEBUG, `Saved episode meta: ${metaPath}`)
 
-        // Add to libraryFiles if not already tracked
-        const metadataLibraryFile = libraryItem.libraryFiles.find((lf) => lf.metadata.path === filePathToPOSIX(episodeMetadataPath))
-        if (!metadataLibraryFile) {
-          const newLibraryFile = new LibraryFile()
-          await newLibraryFile.setDataFromPath(episodeMetadataPath, Path.basename(episodeMetadataPath))
-          libraryItem.libraryFiles.push(newLibraryFile.toJSON())
+        const exists = libraryItem.libraryFiles.find((f) => f.metadata.path === filePathToPOSIX(metaPath))
+        if (!exists) {
+          const lf = new LibraryFile()
+          await lf.setDataFromPath(metaPath, Path.basename(metaPath))
+          libraryItem.libraryFiles.push(lf.toJSON())
         }
-      } catch (error) {
-        libraryScan.addLog(LogLevel.ERROR, `Failed to save episode metadata at "${episodeMetadataPath}"`, error)
+      } catch (err) {
+        libraryScan.addLog(LogLevel.ERROR, `Failed writing ${metaPath}: ${err.message}`)
       }
     }
   }


### PR DESCRIPTION
## Brief summary

Write per-episode metadata .json files alongside each episode's audio file for podcast libraries. Fixes missing episode metadata when moving or restoring a library.

## Which issue is fixed?

Fixes #5093

## In-depth Description

Podcast libraries are flat — episodes sit directly in the directory, not nested like books. The current `saveMetadataFile` only writes a single podcast-level `metadata.json` without any episode data. When you move or restore a library, all episode titles, descriptions, pubDates, chapters are lost.

This adds a `writeEpisodeMetadata` method that writes a `.json` file next to each episode's audio file. So `episode1.mp3` gets `episode1.json` with that episode's metadata. Only runs when `storeMetadataWithItem` is enabled.

Both new scan and rescan paths already load `podcastEpisodes` before this point, so no extra queries needed.

## How have you tested this?

Tested locally with a podcast library with multiple episodes:
1. Per-episode .json files created alongside audio files
2. Files contain correct metadata fields
3. Only written when storeMetadataWithItem is enabled
4. Rescan picks up existing files without duplicating
5. Write errors don't break the scan

Existing tests still pass.