### PR TITLE
Read AllowedDevOrigins from dev.js into ALLOWED_DEV_ORIGINS env var

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,6 +31,11 @@ if (isDev || options['prod-with-dev-env']) {
   if (devEnv.AllowIframe) process.env.ALLOW_IFRAME = '1'
   if (devEnv.BackupPath) process.env.BACKUP_PATH = devEnv.BackupPath
   if (devEnv.ReactClientPath) process.env.REACT_CLIENT_PATH = devEnv.ReactClientPath
+  if (devEnv.AllowedDevOrigins) {
+    process.env.ALLOWED_DEV_ORIGINS = Array.isArray(devEnv.AllowedDevOrigins)
+      ? devEnv.AllowedDevOrigins.join(',')
+      : String(devEnv.AllowedDevOrigins)
+  }
   process.env.SOURCE = 'local'
   process.env.ROUTER_BASE_PATH = devEnv.RouterBasePath ?? '/audiobookshelf'
 }


### PR DESCRIPTION
## Brief summary

Reads `AllowedDevOrigins` option from dev.js into the `ALLOWED_DEV_ORIGINS` environment variable, so that we can run the Next.js dev server with non-localhost (reverse proxy) address.

## Which issue is fixed?

No issue.

## In-depth Description

Next.js 16 blocks cross-origin access to dev resources by default for safety. This causes access to a dev server via reverse proxy not to work anymore. The `allowedDevOrigins` option in dev.js will be read into an environment variable which will then be used to set the Next.js `allowedDevOrigins` config option (the latter happens in `audiobookshelf-client-react`, implemented in [PR #114](https://github.com/audiobookshelf/audiobookshelf-client-react/pull/114))

## How have you tested this?

- Brought up a dev server with `ReactClientPath` and `allowedDevOrigins` set properly in my `dev.js` file.
- Accessed the dev server using the hostname defined in `allowedDevOrigins`
- Dev server rendered the app correctly, with no errors.

When not setting `allowedDevOrigins` properly, Next.js dev server does not render pages properly, and displays an error in the console.