### PR TITLE
Expand custom metadata provider field mapping

### DIFF
--- a/server/providers/CustomProviderAdapter.js
+++ b/server/providers/CustomProviderAdapter.js
@@ -89,6 +89,18 @@ class CustomProviderAdapter {
         })
         .filter((s) => s !== undefined)
     }
+    const firstStringOrUndefined = (value) => {
+      if (typeof value === 'string' || typeof value === 'number') return String(value)
+      if (Array.isArray(value)) return toStringOrUndefined(value.find((v) => typeof v === 'string' || typeof v === 'number'))
+      return undefined
+    }
+    const publishedYearFromDate = (value) => {
+      const date = toStringOrUndefined(value)
+      return date ? date.split('-')[0] : undefined
+    }
+    const toBooleanOrUndefined = (value) => {
+      return typeof value === 'boolean' ? value : undefined
+    }
     /**
      * Validates and dedupes tags/genres array
      * Can be comma separated string or array of strings
@@ -113,24 +125,53 @@ class CustomProviderAdapter {
 
     // re-map keys to throw out
     return matches.map((match) => {
-      const { title, subtitle, author, narrator, publisher, publishedYear, description, cover, isbn, asin, genres, tags, series, language, duration } = match
+      const {
+        title,
+        subtitle,
+        author,
+        authors,
+        narrator,
+        narrators,
+        publisher,
+        publishedYear,
+        publishDate,
+        description,
+        cover,
+        covers,
+        isbn,
+        asin,
+        genres,
+        tags,
+        series,
+        language,
+        duration,
+        explicit,
+        abridged,
+        region,
+        rating
+      } = match
 
       const payload = {
         title: toStringOrUndefined(title),
         subtitle: toStringOrUndefined(subtitle),
-        author: toStringOrUndefined(author),
-        narrator: toStringOrUndefined(narrator),
+        author: toStringOrUndefined(author ?? authors),
+        narrator: toStringOrUndefined(narrator ?? narrators),
         publisher: toStringOrUndefined(publisher),
-        publishedYear: toStringOrUndefined(publishedYear),
+        publishedYear: toStringOrUndefined(publishedYear) ?? publishedYearFromDate(publishDate),
         description: description && typeof description === 'string' ? htmlSanitizer.sanitize(description) : undefined,
-        cover: toStringOrUndefined(cover),
+        cover: toStringOrUndefined(cover) ?? firstStringOrUndefined(covers),
+        covers: validateTagsGenresArray(covers),
         isbn: toStringOrUndefined(isbn),
         asin: toStringOrUndefined(asin),
         genres: validateTagsGenresArray(genres),
         tags: validateTagsGenresArray(tags),
         series: validateSeriesArray(series),
         language: toStringOrUndefined(language),
-        duration: !isNaN(duration) && duration !== null ? Number(duration) : undefined
+        duration: !isNaN(duration) && duration !== null ? Number(duration) : undefined,
+        explicit: toBooleanOrUndefined(explicit),
+        abridged: toBooleanOrUndefined(abridged),
+        region: toStringOrUndefined(region),
+        rating: toStringOrUndefined(rating)
       }
 
       // Remove undefined values


### PR DESCRIPTION
## Brief summary

This expands `CustomProviderAdapter` so custom metadata providers can return a few richer or commonly-used metadata field shapes.

The adapter now additionally accepts:

- `authors` as an array fallback for `author`
- `narrators` as an array fallback for `narrator`
- `publishDate` as a fallback source for `publishedYear`
- `covers` as an additional cover list, with the first cover used when `cover` is not provided
- `abridged`
- `region`
- `rating`

## Which issue is fixed?

None

## In-depth Description

It doesn't solve anything apart from adding more fields and covering some metadata shapes that might not match ABS exactly.

## How have you tested this?

Yes on my server with my custom metadata server as a source

## Screenshots

None