### PR TITLE
Make library scan symlink resolution configurable

### DIFF
--- a/server/utils/fileUtils.js
+++ b/server/utils/fileUtils.js
@@ -199,7 +199,7 @@ module.exports.recurseFiles = async (path, relPathToReplace = null) => {
     ignoreFolders: true,
     extensions: true,
     deep: true,
-    realPath: true,
+    realPath: process.env.SCANNER_RESOLVE_SYMLINKS !== '0',
     normalizePath: false
   }
   let list = await rra.list(path, options)


### PR DESCRIPTION
## Brief summary

Make the library scanner's symlink resolution configurable so libraries on a symlinked storage root scan correctly.

## In-depth Description

`recurseFiles` (`server/utils/fileUtils.js`) passes `realPath: true` to `recursive-readdir-async`, which resolves symlinks and returns each file's canonical real path. The relative path is then computed as:

```js
const relpath = item.fullname.replace(relPathToReplace, '')
```

which assumes `fullname` stays under the scanned folder path. When the library folder **is** a symlink (or lives under one) — e.g. `/data -> /opt/disk/external` — the resolved `realpath` (`/opt/disk/external/library/Book`) no longer starts with the folder path (`/data/library`), so the `replace()` is a no-op and the item path is rebuilt as `folderPath + realpath`, producing a doubled, non-existent path. Those items fail to scan ("no inode") and the library appears empty.

`realPath: true` was introduced in 28ccd4e (2021) when adopting `recursive-readdir-async`, as part of an unrelated change (posix paths / dotfile ignoring); it isn't tied to any symlink requirement and contradicts the `replace()` logic above.

This change keeps the default behavior (resolve) but lets operators opt out via an env var, so deployments that put libraries on a symlinked path (common on NAS / self-hosting platforms where the data disk is a symlink) can scan correctly:

```js
realPath: process.env.SCANNER_RESOLVE_SYMLINKS !== '0',
```

## Which issue is fixed?

Libraries whose folder path is (or is under) a symlink fail to scan — items get doubled, non-existent paths.

## How have you tested this?

On a deployment where `/data` is a symlink to the storage disk: with the default the library scanned to doubled paths and showed empty; with `SCANNER_RESOLVE_SYMLINKS=0` the same library scanned correctly. No change to default behavior when the env var is unset.

## Screenshots

No UI changes.
