### PR TITLE
Enhance PodcastController to handle enclosure updates

### DIFF
--- a/server/controllers/PodcastController.js
+++ b/server/controllers/PodcastController.js
@@ -437,6 +437,17 @@ class PodcastController {
         }
 
         updatePayload[key] = req.body[key]
+      } else if (key === 'enclosure') {
+        const enclosure = req.body.enclosure
+        if (enclosure === null) {
+          updatePayload.enclosureURL = null
+          updatePayload.enclosureSize = null
+          updatePayload.enclosureType = null
+        } else if (typeof enclosure === 'object' && typeof enclosure.url === 'string') {
+          updatePayload.enclosureURL = enclosure.url
+          updatePayload.enclosureType = typeof enclosure.type === 'string' ? enclosure.type : null
+          updatePayload.enclosureSize = enclosure.length !== undefined && enclosure.length !== null ? enclosure.length : null
+        }
       } else if (key === 'chapters' && Array.isArray(req.body[key]) && req.body[key].every((ch) => typeof ch === 'object' && ch.title && ch.start)) {
         updatePayload[key] = req.body[key]
       } else if (key === 'publishedAt' && typeof req.body[key] === 'number') {


### PR DESCRIPTION
## Brief summary

This updates enclosure values in `updateEpisode` if they exist in the request payload.

## Which issue is fixed?

Fixes #5317 

## In-depth Description

This is a small change that updates the enclosure values from the `updateEpisode` (`PATCH: /api/podcasts/:id/episode/:episodeId`) request payload. The web client already sends those, but they're currently ignored by the server.

## How have you tested this?

Manually matched an episode with no enclosure. 
After selecting the match, the details edit view shows the enclosure url, as expeceted.