### PR TITLE
Let next.js handle file uploads through internal-api routes

### DIFF
--- a/server/Server.js
+++ b/server/Server.js
@@ -302,7 +302,9 @@ class Server {
 
     this.server = http.createServer(app)
 
+    // Skip file upload parsing for internal-api routes (Next.js proxies read multipart bodies).
     router.use(
+      /^(?!\/internal-api).*/,
       fileUpload({
         defCharset: 'utf8',
         defParamCharset: 'utf8',


### PR DESCRIPTION
## Brief summary

This passthrough is required for letting Next.js handle file upload routes on its own.

## Which issue is fixed?

No issue. 

This is required for [audiobokshelf-client-react PR #121](https://github.com/audiobookshelf/audiobookshelf-client-react/pull/121)

## In-depth Description

In order for the new internal-api cover upload route in audiobokshelf-client-react to work correctly, We have to let it consume the multipart request body, so we have to exclude /internal-api/ requests from the server's express-fileupload middleware

## How have you tested this?

Large cover file uploads (~4MB) now work properly (before this change they ended in error)
