### PR TITLE
Updated/removed documentation links in readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -4,11 +4,11 @@
 
   <p align="center">
     <br />
-    <a href="https://audiobookshelf.org/docs">Documentation</a>
+    <a href="https://audiobookshelf.org/docs/documentation/introduction/">Documentation</a>
     ·
-    <a href="https://audiobookshelf.org/guides">User Guides</a>
+    <a>User Guides</a>
     ·
-    <a href="https://audiobookshelf.org/support">Support</a>
+    <a>Support</a>
   </p>
 </div>
 


### PR DESCRIPTION
Documentation link in README was broken, updated from https://audiobookshelf.org/docs/ to https://audiobookshelf.org/docs/documentation/introduction/

links to "user guides" and "support" were also broken. couldn't find the proper links for those, so the hyperlink was removed.

(Sorry that this branch is named "patch-1". It was a tiny change, so I wasn't thinking of naming it when I made the fork. I didn't realize GitHub named the branch "patch-1" until I'm about to submit the PR, and I don't know how to change it.)

<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

The "Documentation" "User Guides" and "Support" links were broken. This tried to fix that.

## Which issue is fixed?

No issue number. Didn't look like a standard issue, so I figured best way to point it out was to make this PR.

## In-depth Description

"Documentation" link was updated. 
Proper "User Guides" and "Support" links could not be found, so they were removed to remove confusion. (Hoping you know where to link them to, and can update them also.

## How have you tested this?

I opened the new link a few times. 
It opened. 
Yay.

## Screenshots

Before: 
<img width="445" height="140" alt="image" src="https://github.com/user-attachments/assets/16a704df-a4b8-456f-afb4-3ccb6512984c" />
(links broken)

After:
<img width="433" height="161" alt="image" src="https://github.com/user-attachments/assets/f4f6f56e-f9ec-40d7-9403-f60d8007f995" />
(links not broken)
