### PR TITLE
Update outdated in-app help links to new docs site structure

### DIFF
--- a/client/components/app/LazyBookshelf.vue
+++ b/client/components/app/LazyBookshelf.vue
@@ -22,7 +22,7 @@
       <div v-if="entityName === 'collections' || entityName === 'playlists'" class="flex justify-center mt-4">
         {{ emptyMessageHelp }}
         <ui-tooltip :text="$strings.LabelClickForMoreInfo" class="inline-flex ml-2">
-          <a href="https://www.audiobookshelf.org/guides/collections" target="_blank" class="inline-flex">
+          <a href="https://audiobookshelf.org/docs/documentation/libraries/common-content/overview" target="_blank" class="inline-flex">
             <span class="material-symbols text-xl w-5 text-gray-200">help_outline</span>
           </a>
         </ui-tooltip>

--- a/client/components/app/LazyBookshelf.vue
+++ b/client/components/app/LazyBookshelf.vue
@@ -22,7 +22,7 @@
       <div v-if="entityName === 'collections' || entityName === 'playlists'" class="flex justify-center mt-4">
         {{ emptyMessageHelp }}
         <ui-tooltip :text="$strings.LabelClickForMoreInfo" class="inline-flex ml-2">
-          <a href="https://audiobookshelf.org/docs/documentation/libraries/common-content/overview" target="_blank" class="inline-flex">
+          <a href="https://audiobookshelf.org/docs/documentation/libraries/common-content/playlists" target="_blank" class="inline-flex">
             <span class="material-symbols text-xl w-5 text-gray-200">help_outline</span>
           </a>
         </ui-tooltip>

--- a/client/components/modals/ShareModal.vue
+++ b/client/components/modals/ShareModal.vue
@@ -8,7 +8,7 @@
     <div class="px-6 py-8 w-full text-sm rounded-lg bg-bg shadow-lg border border-black-300 overflow-y-auto overflow-x-hidden" style="max-height: 80vh">
       <div class="absolute top-0 right-0 p-4">
         <ui-tooltip :text="$strings.LabelClickForMoreInfo" class="inline-flex ml-2">
-          <a href="https://www.audiobookshelf.org/guides/media-item-shares" target="_blank" class="inline-flex">
+          <a href="https://audiobookshelf.org/docs/documentation/libraries/common-content/public-shares#media-item-shares" target="_blank" class="inline-flex">
             <span class="material-symbols text-xl w-5 text-gray-200">help_outline</span>
           </a>
         </ui-tooltip>

--- a/client/components/modals/collections/AddCreateModal.vue
+++ b/client/components/modals/collections/AddCreateModal.vue
@@ -25,7 +25,7 @@
             <div class="text-sm flex items-center justify-center text-gray-200">
               <p>{{ $strings.MessageBookshelfNoCollectionsHelp }}</p>
               <ui-tooltip :text="$strings.LabelClickForMoreInfo" class="inline-flex ml-2">
-                <a href="https://audiobookshelf.org/docs/documentation/libraries/common-content/overview" target="_blank" class="inline-flex">
+                <a href="https://audiobookshelf.org/docs/documentation/libraries/common-content/playlists" target="_blank" class="inline-flex">
                   <span class="material-symbols text-xl w-5 text-gray-200">help_outline</span>
                 </a>
               </ui-tooltip>

--- a/client/components/modals/collections/AddCreateModal.vue
+++ b/client/components/modals/collections/AddCreateModal.vue
@@ -25,7 +25,7 @@
             <div class="text-sm flex items-center justify-center text-gray-200">
               <p>{{ $strings.MessageBookshelfNoCollectionsHelp }}</p>
               <ui-tooltip :text="$strings.LabelClickForMoreInfo" class="inline-flex ml-2">
-                <a href="https://www.audiobookshelf.org/guides/collections" target="_blank" class="inline-flex">
+                <a href="https://audiobookshelf.org/docs/documentation/libraries/common-content/overview" target="_blank" class="inline-flex">
                   <span class="material-symbols text-xl w-5 text-gray-200">help_outline</span>
                 </a>
               </ui-tooltip>

--- a/client/components/modals/libraries/LibraryScannerSettings.vue
+++ b/client/components/modals/libraries/LibraryScannerSettings.vue
@@ -8,7 +8,7 @@
     <div class="flex items-center justify-between md:justify-start mb-4">
       <p class="text-sm text-gray-300 pr-2">{{ $strings.LabelMetadataOrderOfPrecedenceDescription }}</p>
       <ui-tooltip :text="$strings.LabelClickForMoreInfo" class="inline-flex">
-        <a href="https://www.audiobookshelf.org/guides/book-scanner" target="_blank" class="inline-flex">
+        <a href="https://audiobookshelf.org/docs/documentation/libraries/book-library/book-metadata" target="_blank" class="inline-flex">
           <span class="material-symbols text-xl w-5">help_outline</span>
         </a>
       </ui-tooltip>

--- a/client/components/modals/playlists/AddCreateModal.vue
+++ b/client/components/modals/playlists/AddCreateModal.vue
@@ -25,7 +25,7 @@
             <div class="text-sm flex items-center justify-center text-gray-200">
               <p>{{ $strings.MessageNoUserPlaylistsHelp }}</p>
               <ui-tooltip :text="$strings.LabelClickForMoreInfo" class="inline-flex ml-2">
-                <a href="https://www.audiobookshelf.org/guides/collections" target="_blank" class="inline-flex">
+                <a href="https://audiobookshelf.org/docs/documentation/libraries/common-content/playlists" target="_blank" class="inline-flex">
                   <span class="material-symbols text-xl w-5 text-gray-200">help_outline</span>
                 </a>
               </ui-tooltip>

--- a/client/pages/config/api-keys/index.vue
+++ b/client/pages/config/api-keys/index.vue
@@ -7,7 +7,7 @@
         </div>
 
         <ui-tooltip :text="$strings.LabelClickForMoreInfo" class="inline-flex ml-2">
-          <a href="https://www.audiobookshelf.org/guides/api-keys" target="_blank" class="inline-flex">
+          <a href="https://audiobookshelf.org/docs/documentation/server-management/api-keys" target="_blank" class="inline-flex">
             <span class="material-symbols text-xl w-5 text-gray-200">help_outline</span>
           </a>
         </ui-tooltip>

--- a/client/pages/config/authentication.vue
+++ b/client/pages/config/authentication.vue
@@ -24,7 +24,7 @@
           <ui-checkbox v-model="enableOpenIDAuth" checkbox-bg="bg" />
           <p class="text-lg pl-4">{{ $strings.HeaderOpenIDConnectAuthentication }}</p>
           <ui-tooltip :text="$strings.LabelClickForMoreInfo" class="inline-flex ml-2">
-            <a href="https://www.audiobookshelf.org/guides/oidc_authentication" target="_blank" class="inline-flex">
+            <a href="https://audiobookshelf.org/docs/documentation/server-management/oidc-authentication" target="_blank" class="inline-flex">
               <span class="material-symbols text-xl w-5 text-gray-200">help_outline</span>
             </a>
           </ui-tooltip>

--- a/client/pages/config/email.vue
+++ b/client/pages/config/email.vue
@@ -3,7 +3,7 @@
     <app-settings-content :header-text="$strings.HeaderEmailSettings" :description="''">
       <template #header-items>
         <ui-tooltip :text="$strings.LabelClickForMoreInfo" class="inline-flex ml-2">
-          <a href="https://www.audiobookshelf.org/guides/send_to_ereader" target="_blank" class="inline-flex">
+          <a href="https://audiobookshelf.org/docs/documentation/libraries/book-library/ebooks" target="_blank" class="inline-flex">
             <span class="material-symbols text-xl w-5 text-gray-200">help_outline</span>
           </a>
         </ui-tooltip>

--- a/client/pages/config/item-metadata-utils/custom-metadata-providers.vue
+++ b/client/pages/config/item-metadata-utils/custom-metadata-providers.vue
@@ -8,7 +8,7 @@
       </template>
       <template #header-items>
         <ui-tooltip :text="$strings.LabelClickForMoreInfo" class="inline-flex ml-2">
-          <a href="https://www.audiobookshelf.org/guides/custom-metadata-providers" target="_blank" class="inline-flex">
+          <a href="https://audiobookshelf.org/docs/documentation/community/community-providers" target="_blank" class="inline-flex">
             <span class="material-symbols text-xl w-5 text-gray-200">help_outline</span>
           </a>
         </ui-tooltip>

--- a/client/pages/config/libraries.vue
+++ b/client/pages/config/libraries.vue
@@ -3,7 +3,7 @@
     <app-settings-content :header-text="$strings.HeaderLibraries">
       <template #header-items>
         <ui-tooltip :text="$strings.LabelClickForMoreInfo" class="inline-flex ml-2">
-          <a href="https://www.audiobookshelf.org/guides/library_creation" target="_blank" class="inline-flex">
+          <a href="https://audiobookshelf.org/docs/documentation/libraries/common-content/overview" target="_blank" class="inline-flex">
             <span class="material-symbols text-xl w-5 text-gray-200">help_outline</span>
           </a>
         </ui-tooltip>

--- a/client/pages/config/log.vue
+++ b/client/pages/config/log.vue
@@ -3,7 +3,7 @@
     <app-settings-content :header-text="$strings.HeaderLogs" :description="$strings.MessageLogsDescription">
       <template #header-items>
         <ui-tooltip :text="$strings.LabelClickForMoreInfo" class="inline-flex ml-2">
-          <a href="https://www.audiobookshelf.org/guides/server_logs" target="_blank" class="inline-flex">
+          <a href="https://audiobookshelf.org/docs/documentation/server-management/server-logs" target="_blank" class="inline-flex">
             <span class="material-symbols text-xl w-5 text-gray-200">help_outline</span>
           </a>
         </ui-tooltip>

--- a/client/pages/config/rss-feeds.vue
+++ b/client/pages/config/rss-feeds.vue
@@ -3,7 +3,7 @@
     <app-settings-content :header-text="$strings.HeaderRSSFeeds">
       <template #header-items>
         <ui-tooltip :text="$strings.LabelClickForMoreInfo" class="inline-flex ml-2">
-          <a href="https://www.audiobookshelf.org/guides/rss_feeds" target="_blank" class="inline-flex">
+          <a href="https://audiobookshelf.org/docs/documentation/libraries/common-content/public-shares#rss-feed" target="_blank" class="inline-flex">
             <span class="material-symbols text-xl w-5 text-gray-200">help_outline</span>
           </a>
         </ui-tooltip>

--- a/client/pages/config/users/index.vue
+++ b/client/pages/config/users/index.vue
@@ -7,7 +7,7 @@
         </div>
 
         <ui-tooltip :text="$strings.LabelClickForMoreInfo" class="inline-flex ml-2">
-          <a href="https://www.audiobookshelf.org/guides/users" target="_blank" class="inline-flex">
+          <a href="https://audiobookshelf.org/docs/documentation/server-management/user-management" target="_blank" class="inline-flex">
             <span class="material-symbols text-xl w-5 text-gray-200">help_outline</span>
           </a>
         </ui-tooltip>


### PR DESCRIPTION
## Brief summary

The help (`?`) tooltip links throughout the web client point to the old `www.audiobookshelf.org/guides/*` pages. The documentation site has since moved to `audiobookshelf.org/docs/documentation/*`, so every one of these links now resolves to a 404. This PR updates all 13 in-app help links to their current locations.

## Which issue is fixed?

No open issue — found while using the app. Happy to open one first if preferred.

## In-depth Description

Each `/guides/<slug>` link was remapped to its equivalent page on the current docs site (verified each target resolves rather than soft-404s). The `www.` subdomain was also dropped to match the site's current canonical host.

| Location | Old (`/guides/…`) | New (`/docs/documentation/…`) |
|---|---|---|
| API Keys config | `api-keys` | `server-management/api-keys` |
| Users config | `users` | `server-management/user-management` |
| Logs config | `server_logs` | `server-management/server-logs` |
| Authentication config | `oidc_authentication` | `server-management/oidc-authentication` |
| Share modal | `media-item-shares` | `libraries/common-content/public-shares#media-item-shares` |
| Custom metadata providers | `custom-metadata-providers` | `community/community-providers` |
| Email config | `send_to_ereader` | `libraries/book-library/ebooks` |
| Bookshelf empty state | `collections` | `libraries/common-content/overview` |
| Add-to-collection modal | `collections` | `libraries/common-content/overview` |
| Add-to-playlist modal | `collections` | `libraries/common-content/playlists` |
| Library scanner settings | `book-scanner` | `libraries/book-library/book-metadata` |
| Libraries config | `library_creation` | `libraries/common-content/overview` |
| RSS feeds config | `rss_feeds` | `libraries/common-content/public-shares#rss-feed` |

A couple of mappings are judgment calls where there's no exact 1:1 page on the new site — flagging for maintainer input:
- **Libraries config** (`library_creation`): no dedicated "library creation" page exists; pointed at the Library Overview as the closest fit.
- **Add-to-playlist modal**: the old link reused the `collections` guide; redirected to the dedicated Playlists section instead.

Note: the `readme.md` links (`/docs`, `/guides`, `/support`) are intentionally left out, since they're already covered by draft #5329.

## How have you tested this?

Confirmed each old `/guides/*` URL is dead and each new target loads correctly. Verified no other `/guides/` references remain in the client. Changes are static `href` updates only — no logic touched.

## Screenshots

N/A — link `href` value changes only; no visual change.
