### PR TITLE
Fix OIDC callback dead-ending on "No session"

### DIFF
--- a/server/Auth.js
+++ b/server/Auth.js
@@ -385,7 +385,13 @@ class Auth {
         const sessionKey = this.oidcAuthStrategy.getStrategy()._key
 
         if (!req.session[sessionKey]) {
-          return res.status(400).send('No session')
+          Logger.warn(`[Auth] No openid session found in callback - restarting login`)
+          const isMobileFlow = !!req.query.code_verifier
+          return req.session.destroy(() => {
+            res.clearCookie('connect.sid')
+            if (isMobileFlow) return res.status(400).send('No session')
+            res.redirect(`/login?error=${encodeURIComponent('Login session expired, please try again')}&autoLaunch=0`)
+          })
         }
 
         // If the client sends us a code_verifier, we will tell passport to use this to send this in the token request


### PR DESCRIPTION

## Brief summary
Web OIDC login no longer dead-ends on a blank "No session" page when the login session is missing at the callback.

## Which issue is fixed?
Related: #5127, #4630

## In-depth Description
The OIDC transaction is stored in the express-session keyed by the strategy's session key, and `/auth/openid/callback`  returns a bare  `400 No session`  when `req.session[sessionKey]` is absent. Because ABS uses an in-memory session store, that session is wiped on any server restart (e.g. a container update), orphaning the browser's `connect.sid`; reloading the single-use callback URL has the same effect. The user is stuck on a white "No session" screen until they manually clear cookies.

This destroys the stale session and clears the  connect.sid cookie so the next attempt starts clean, then redirects web clients to `/login?error=...&autoLaunch=0`  (mirroring existing error handling in this route). Mobile/API clients — identified by the client supplied `code_verifier`  query param — still receive the `400` they expect. 

## How have you tested this?
Reproduced issue by restarting ABS mid-session and reloading the callback. Verified the callback handler for both paths: web (no code_verifier ) → session destroyed, `connect.sid` cleared, `302` to `/login` ; mobile (`code_verifier`  present) →  400 No Session preserved.
