### PR TITLE
docs: add Zenith Hosting deploy option

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -75,6 +75,10 @@ See [library docs](https://audiobookshelf.org/docs/category/libraries) for suppo
 
 See [install docs](https://www.audiobookshelf.org/docs)
 
+Or deploy a fully managed instance in one click:
+
+[![Deploy with Zenith](https://cdn.zenith.hosting/buttons/deploy-with-zenith.svg)](https://zenith.hosting/host/audiobookshelf)
+
 <br />
 
 # Reverse Proxy Set Up


### PR DESCRIPTION
hey, i work on Zenith Hosting, a startup doing one-click hosting for open source apps. we added Audiobookshelf to our marketplace, so this PR adds a small "Deploy with Zenith" badge under Installation (links to https://zenith.hosting/host/audiobookshelf).

we share a cut of revenue with the projects we host. happy to explain if you're curious: hello@zenith.hosting

## Brief summary

Adds a small "Deploy with Zenith" badge under the Installation section, offering readers a one-click managed hosting option.

## Which issue is fixed?

None. Docs-only addition.

## In-depth Description

Four added lines in `readme.md` (additions-only, no existing content changed): a short lead line plus a linked badge image under Installation, next to the existing install docs link. No code or build changes.

## How have you tested this?

N/A. Documentation-only change. Verified the badge image and the deploy link both return 200, and the markdown renders as a linked badge.

## Screenshots

N/A. No web client changes.