### PR TITLE
Emit author socket events when book scans create or link authors

### DIFF
--- a/server/models/BookAuthor.js
+++ b/server/models/BookAuthor.js
@@ -1,4 +1,4 @@
-const { DataTypes, Model } = require('sequelize')
+const { DataTypes, Model, fn, col } = require('sequelize')
 
 class BookAuthor extends Model {
   constructor(values, options) {
@@ -35,6 +35,32 @@ class BookAuthor extends Model {
         authorId
       }
     })
+  }
+
+  /**
+   * Get number of books for each author
+   *
+   * @param {string[]} authorIds
+   * @returns {Promise<Record<string, number>>}
+   */
+  static async getCountsForAuthors(authorIds) {
+    if (!authorIds.length) return {}
+
+    const rows = await this.findAll({
+      attributes: ['authorId', [fn('COUNT', col('id')), 'count']],
+      where: {
+        authorId: authorIds
+      },
+      group: ['authorId'],
+      raw: true
+    })
+
+    /** @type {Record<string, number>} */
+    const counts = {}
+    for (const row of rows) {
+      counts[row.authorId] = Number(row.count)
+    }
+    return counts
   }
 
   /**

--- a/server/scanner/BookScanner.js
+++ b/server/scanner/BookScanner.js
@@ -228,6 +228,11 @@ class BookScanner {
                 bookId: media.id,
                 authorId: existingAuthorId
               })
+              const author = await Database.authorModel.findByPk(existingAuthorId)
+              if (author) {
+                const numBooks = await Database.bookAuthorModel.getCountForAuthor(existingAuthorId)
+                SocketAuthority.emitter('author_updated', author.toOldJSONExpanded(numBooks))
+              }
               libraryScan.addLog(LogLevel.DEBUG, `Updating book "${bookMetadata.title}" added author "${authorName}"`)
               authorsUpdated = true
             } else {
@@ -238,6 +243,7 @@ class BookScanner {
               })
               await media.addAuthor(newAuthor)
               Database.addAuthorToFilterData(libraryItemData.libraryId, newAuthor.name, newAuthor.id)
+              SocketAuthority.emitter('author_added', newAuthor.toOldJSON())
               libraryScan.addLog(LogLevel.DEBUG, `Updating book "${bookMetadata.title}" added new author "${authorName}"`)
               authorsUpdated = true
             }
@@ -478,6 +484,8 @@ class BookScanner {
     }
 
     const createdAtTimestamp = new Date().getTime()
+    const linkedAuthorIds = new Set()
+    const newAuthorNames = new Set()
     if (bookMetadata.authors.length) {
       for (const authorName of bookMetadata.authors) {
         const matchingAuthorId = await Database.getAuthorIdByName(libraryItemData.libraryId, authorName)
@@ -485,6 +493,7 @@ class BookScanner {
           bookObject.bookAuthors.push({
             authorId: matchingAuthorId
           })
+          linkedAuthorIds.add(matchingAuthorId)
         } else {
           // New author
           bookObject.bookAuthors.push({
@@ -496,6 +505,7 @@ class BookScanner {
               lastFirst: Database.authorModel.getLastFirst(authorName)
             }
           })
+          newAuthorNames.add(authorName)
         }
       }
     }
@@ -593,6 +603,12 @@ class BookScanner {
       for (const ba of libraryItem.book.bookAuthors) {
         if (ba.author) {
           Database.addAuthorToFilterData(libraryItemData.libraryId, ba.author.name, ba.author.id)
+          if (newAuthorNames.has(ba.author.name)) {
+            SocketAuthority.emitter('author_added', ba.author.toOldJSON())
+          } else if (linkedAuthorIds.has(ba.author.id)) {
+            const numBooks = await Database.bookAuthorModel.getCountForAuthor(ba.author.id)
+            SocketAuthority.emitter('author_updated', ba.author.toOldJSONExpanded(numBooks))
+          }
         }
       }
     }

--- a/server/scanner/BookScanner.js
+++ b/server/scanner/BookScanner.js
@@ -228,11 +228,7 @@ class BookScanner {
                 bookId: media.id,
                 authorId: existingAuthorId
               })
-              const author = await Database.authorModel.findByPk(existingAuthorId)
-              if (author) {
-                const numBooks = await Database.bookAuthorModel.getCountForAuthor(existingAuthorId)
-                SocketAuthority.emitter('author_updated', author.toOldJSONExpanded(numBooks))
-              }
+              libraryScan.authorsNumBooksChangedIds.add(existingAuthorId)
               libraryScan.addLog(LogLevel.DEBUG, `Updating book "${bookMetadata.title}" added author "${authorName}"`)
               authorsUpdated = true
             } else {
@@ -253,6 +249,7 @@ class BookScanner {
         for (const author of media.authors) {
           if (!bookMetadata.authors.includes(author.name)) {
             await author.bookAuthor.destroy()
+            libraryScan.authorsNumBooksChangedIds.add(author.id)
             libraryScan.addLog(LogLevel.DEBUG, `Updating book "${bookMetadata.title}" removed author "${author.name}"`)
             authorsUpdated = true
             bookAuthorsRemoved.push(author.id)
@@ -484,7 +481,6 @@ class BookScanner {
     }
 
     const createdAtTimestamp = new Date().getTime()
-    const linkedAuthorIds = new Set()
     const newAuthorNames = new Set()
     if (bookMetadata.authors.length) {
       for (const authorName of bookMetadata.authors) {
@@ -493,7 +489,8 @@ class BookScanner {
           bookObject.bookAuthors.push({
             authorId: matchingAuthorId
           })
-          linkedAuthorIds.add(matchingAuthorId)
+          // Existing author — only numBooks changes; batch emit at scan end
+          libraryScan.authorsNumBooksChangedIds.add(matchingAuthorId)
         } else {
           // New author
           bookObject.bookAuthors.push({
@@ -605,9 +602,6 @@ class BookScanner {
           Database.addAuthorToFilterData(libraryItemData.libraryId, ba.author.name, ba.author.id)
           if (newAuthorNames.has(ba.author.name)) {
             SocketAuthority.emitter('author_added', ba.author.toOldJSON())
-          } else if (linkedAuthorIds.has(ba.author.id)) {
-            const numBooks = await Database.bookAuthorModel.getCountForAuthor(ba.author.id)
-            SocketAuthority.emitter('author_updated', ba.author.toOldJSONExpanded(numBooks))
           }
         }
       }
@@ -905,6 +899,34 @@ class BookScanner {
         libraryScan.addLog(LogLevel.ERROR, `Failed to save json file at "${metadataFilePath}"`, error)
         return null
       })
+  }
+
+  /**
+   * Emit authors_num_books_updated for authors whose book count changed during a scan (linked or unlinked).
+   * Authors with no book links are omitted — orphans are handled by author_removed.
+   * @param {string} libraryId
+   * @param {import('./LibraryScan')|import('./ScanLogger')} scanLogger
+   * @returns {Promise}
+   */
+  async emitAuthorsNumBooksUpdated(libraryId, scanLogger) {
+    if (!scanLogger.authorsNumBooksChangedIds?.size) return
+
+    const authorIds = [...scanLogger.authorsNumBooksChangedIds]
+    scanLogger.authorsNumBooksChangedIds.clear()
+
+    const countsByAuthorId = await Database.bookAuthorModel.getCountsForAuthors(authorIds)
+
+    const authors = Object.entries(countsByAuthorId).map(([id, numBooks]) => ({
+      id,
+      numBooks
+    }))
+
+    if (!authors.length) return
+
+    SocketAuthority.emitter('authors_num_books_updated', {
+      libraryId,
+      authors
+    })
   }
 
   /**

--- a/server/scanner/LibraryItemScanner.js
+++ b/server/scanner/LibraryItemScanner.js
@@ -66,7 +66,7 @@ class LibraryItemScanner {
     if (libraryItemDataUpdated || wasUpdated) {
       SocketAuthority.libraryItemEmitter('item_updated', expandedLibraryItem)
 
-      await this.checkAuthorsAndSeriesRemovedFromBooks(library.id, scanLogger)
+      await this.finalizeAuthorsAndSeriesFromScan(library.id, scanLogger)
 
       return ScanResult.UPDATED
     }
@@ -76,12 +76,13 @@ class LibraryItemScanner {
   }
 
   /**
-   * Remove empty authors and series
+   * Emit author book count updates, then remove empty authors/series left after the scan
    * @param {string} libraryId
    * @param {ScanLogger} scanLogger
    * @returns {Promise}
    */
-  async checkAuthorsAndSeriesRemovedFromBooks(libraryId, scanLogger) {
+  async finalizeAuthorsAndSeriesFromScan(libraryId, scanLogger) {
+    await BookScanner.emitAuthorsNumBooksUpdated(libraryId, scanLogger)
     if (scanLogger.authorsRemovedFromBooks.length) {
       await BookScanner.checkAuthorsRemovedFromBooks(libraryId, scanLogger)
     }
@@ -215,7 +216,10 @@ class LibraryItemScanner {
     scanLogger.verbose = true
     scanLogger.setData('libraryItem', libraryItemScanData.relPath)
 
-    return this.scanNewLibraryItem(libraryItemScanData, library.settings, scanLogger)
+    const newLibraryItem = await this.scanNewLibraryItem(libraryItemScanData, library.settings, scanLogger)
+    // Watcher path does not go through full-library scan cleanup — emit author book count updates here
+    await BookScanner.emitAuthorsNumBooksUpdated(library.id, scanLogger)
+    return newLibraryItem
   }
 }
 module.exports = new LibraryItemScanner()

--- a/server/scanner/LibraryScan.js
+++ b/server/scanner/LibraryScan.js
@@ -24,6 +24,8 @@ class LibraryScan {
 
     /** @type {string[]} */
     this.authorsRemovedFromBooks = []
+    /** @type {Set<string>} */
+    this.authorsNumBooksChangedIds = new Set()
     /** @type {string[]} */
     this.seriesRemovedFromBooks = []
 

--- a/server/scanner/LibraryScanner.js
+++ b/server/scanner/LibraryScanner.js
@@ -234,8 +234,7 @@ class LibraryScanner {
       SocketAuthority.libraryItemsEmitter('items_updated', libraryItemsUpdated)
     }
 
-    // Authors and series that were removed from books should be removed if they are now empty
-    await LibraryItemScanner.checkAuthorsAndSeriesRemovedFromBooks(libraryScan.libraryId, libraryScan)
+    if (this.shouldCancelScan(libraryScan)) return true
 
     // Update missing library items
     if (libraryItemIdsMissing.length) {
@@ -280,6 +279,9 @@ class LibraryScanner {
         SocketAuthority.libraryItemsEmitter('items_added', newLibraryItems)
       }
     }
+
+    // Author book count updates and empty authors/series cleanup after all items are processed
+    await LibraryItemScanner.finalizeAuthorsAndSeriesFromScan(libraryScan.libraryId, libraryScan)
 
     libraryScan.addLog(LogLevel.INFO, `Scan completed. ${libraryScan.resultStats}`)
     return false

--- a/server/scanner/ScanLogger.js
+++ b/server/scanner/ScanLogger.js
@@ -14,6 +14,8 @@ class ScanLogger {
 
     /** @type {string[]} */
     this.authorsRemovedFromBooks = []
+    /** @type {Set<string>} */
+    this.authorsNumBooksChangedIds = new Set()
     /** @type {string[]} */
     this.seriesRemovedFromBooks = []
 


### PR DESCRIPTION
## Brief summary

Emit `author_added` and `author_updated` socket events from `BookScanner` when library scans create or link authors.

## Which issue is fixed?

No issue.

## In-depth Description

Book scans were creating and linking authors without emitting socket events. Metadata edits via `Book.updateAuthorNames()` already emitted these events, but the scan paths in `BookScanner` did not.

This adds emissions for:
- **New book scan** — `author_added` for newly created authors, `author_updated` for linked existing authors (with `numBooks`)
- **Rescan / update existing book** — same events when authors are added during metadata reconciliation

Payload shapes match existing emitters (`author.toOldJSON()` / `author.toOldJSONExpanded(numBooks)`), so this is backward compatible.

## How have you tested this?

### `author_added` (new author created during scan)

1. Remove a book whose author has no other books (soft delete)
2. On a different window, open the library Authors page
3. Rescan the library
4. Confirm the author **reappears on the Authors page** without a full page refresh

### `author_updated` (existing author re-linked during scan)

1. Remove a book whose author has **two books** in the library (soft delete)
2. On a different window, open the library Authors page
3. Rescan the library
4. Confirm the author’s **book count updates to 2** on the Authors page without a full page refresh
