### PR TITLE
Decode HTML entities in Audible metadata title and subtitle

### DIFF
--- a/server/providers/Audible.js
+++ b/server/providers/Audible.js
@@ -1,6 +1,7 @@
 const axios = require('axios').default
 const Logger = require('../Logger')
 const { isValidASIN } = require('../utils/index')
+const htmlSanitizer = require('../utils/htmlSanitizer')
 
 class Audible {
   #responseTimeout = 10000
@@ -66,8 +67,10 @@ class Audible {
     }
 
     return {
-      title,
-      subtitle: subtitle || null,
+      // Audible metadata can contain HTML entities (e.g. `&quot;`, `&amp;`) that are otherwise
+      // shown literally in titles/subtitles. Decode them at the ingestion boundary. See #5340
+      title: title ? htmlSanitizer.stripAllTags(title) : title,
+      subtitle: subtitle ? htmlSanitizer.stripAllTags(subtitle) : null,
       author: authors ? authors.map(({ name }) => name).join(', ') : null,
       narrator: narrators ? narrators.map(({ name }) => name).join(', ') : null,
       publisher: publisherName,

--- a/test/server/providers/Audible.test.js
+++ b/test/server/providers/Audible.test.js
@@ -45,4 +45,22 @@ describe('Audible', () => {
       expect(result).to.equal('.5')
     })
   })
+
+  describe('cleanResult', () => {
+    it('should decode HTML entities in the title and subtitle (#5340)', () => {
+      const result = audible.cleanResult({
+        title: 'The &quot;Hitler&quot; Myth',
+        subtitle: 'Image &amp; Reality in the Third Reich',
+        asin: 'B0TESTASIN'
+      })
+      expect(result.title).to.equal('The "Hitler" Myth')
+      expect(result.subtitle).to.equal('Image & Reality in the Third Reich')
+    })
+
+    it('should keep a null subtitle when none is provided', () => {
+      const result = audible.cleanResult({ title: 'A Plain Title', asin: 'B0TESTASIN' })
+      expect(result.title).to.equal('A Plain Title')
+      expect(result.subtitle).to.equal(null)
+    })
+  })
 })


### PR DESCRIPTION
## Brief summary

Audible search/match results showed HTML entities literally in titles and subtitles (e.g. `The &quot;Hitler&quot; Myth` instead of `The "Hitler" Myth`). This decodes those entities when ingesting Audible metadata.

## Which issue is fixed?

Fixes #5340

## In-depth Description

The Audible provider's `cleanResult()` returned the `title` and `subtitle` fields exactly as received from the audnex/Audible API. Those values can contain HTML entities (`&quot;`, `&amp;`, etc.), and nothing decodes title/subtitle anywhere downstream — the sanitizer is only applied to description fields — so the raw entities were stored and rendered literally in the UI.

The fix decodes the entities at the ingestion boundary in `cleanResult()` using the existing `htmlSanitizer.stripAllTags()` helper, which is already the standard plain-text treatment in this codebase (collection/playlist names, device info). It strips any stray tags and decodes entities in a single pass, so legitimate literal entities in a title are not double-decoded. No new dependencies are added.

## How have you tested this?

Added unit tests in `test/server/providers/Audible.test.js` covering `cleanResult` (entity decoding in title and subtitle, and a preserved null subtitle). Run with `npx mocha test/server/providers/Audible.test.js` — all 9 tests pass.

## Screenshots

N/A — server-side metadata fix, no web client changes.