### PR TITLE
Show stats icon in appbar on mobile portrait

### DIFF
--- a/client/components/app/Appbar.vue
+++ b/client/components/app/Appbar.vue
@@ -24,7 +24,7 @@
 
         <widgets-notification-widget class="hidden md:block" />
 
-        <nuxt-link v-if="currentLibrary" to="/config/stats" class="hover:text-gray-200 cursor-pointer w-8 h-8 hidden sm:flex items-center justify-center mx-1">
+        <nuxt-link v-if="currentLibrary" to="/config/stats" class="hover:text-gray-200 cursor-pointer w-8 h-8 flex items-center justify-center mx-1">
           <ui-tooltip :text="$strings.HeaderYourStats" direction="bottom" class="flex items-center">
             <span class="material-symbols text-2xl" aria-label="User Stats" role="button">&#xe01d;</span>
           </ui-tooltip>


### PR DESCRIPTION
## Brief summary

Show the "Your Stats" icon in the appbar on mobile portrait. It was hidden below the `sm` breakpoint, so it only appeared once the viewport was at least 640px wide (landscape phones, tablets, desktop).

## Which issue is fixed?

Fixes #5227

## In-depth Description

The stats link in `client/components/app/Appbar.vue` used the classes `hidden sm:flex`, which hides the element below the 640px `sm` breakpoint. On a phone in portrait the viewport is narrower than that, so the icon disappeared; rotating to landscape widened the viewport past 640px and the icon came back. That matches the behavior described in the issue.

Stats are now available to all users, so there is no reason to hide the control on small screens. The sibling controls in the same appbar (the upload and settings icons) already use plain `flex` and are shown at every breakpoint. This change makes the stats icon match them by dropping `hidden sm:` so the class becomes `flex`. The rest of the classes (`w-8 h-8 items-center justify-center mx-1`) are unchanged, so the icon keeps the same size and spacing as its neighbors.

There is no mobile overflow menu in this appbar; controls render directly in the toolbar, so making the icon visible is the correct way to make stats reachable on mobile. The added icon is 32px wide with an 8px horizontal margin and sits in the right-hand control cluster next to upload, settings, and the account button, which already render on mobile, so it does not crowd the toolbar.

## How have you tested this?

Static build was not run for this change since it only edits Tailwind utility classes on one element. Verified by reasoning about the breakpoint behavior:

- Before: `hidden sm:flex` renders `display: none` under 640px and `display: flex` at 640px and up. Icon hidden on mobile portrait, visible on landscape and larger. This reproduces the report.
- After: `flex` renders `display: flex` at all widths. Icon visible on mobile portrait, and unchanged at `sm`, `md`, and `lg` where it was already shown.

The `v-if="currentLibrary"` guard is untouched, so the icon still only appears when a library is selected, same as before.

## Screenshots

Not attached in this draft. The change is a single-class visibility fix; the icon is the same "Your Stats" control already visible on landscape and desktop, now also shown in mobile portrait.
