### PR TITLE
Allow uploading author images from a file in the edit modal

### DIFF
--- a/client/components/modals/authors/EditModal.vue
+++ b/client/components/modals/authors/EditModal.vue
@@ -16,10 +16,19 @@
           </div>
         </div>
         <div class="grow">
-          <form @submit.prevent="submitUploadCover" class="flex grow mb-2 p-2">
-            <ui-text-input v-model="imageUrl" :placeholder="$strings.LabelImageURLFromTheWeb" class="h-9 w-full" />
-            <ui-btn color="bg-success" type="submit" :padding-x="4" :disabled="!imageUrl" class="ml-2 sm:ml-3 w-24 h-9">{{ $strings.ButtonSubmit }}</ui-btn>
-          </form>
+          <div class="flex items-center mb-2 p-2">
+            <div v-if="userCanUpload" class="w-10 md:w-40 pr-2 md:min-w-32">
+              <ui-file-input ref="fileInput" @change="fileUploadSelected">
+                <span class="hidden md:inline-block">{{ $strings.ButtonUpload }}</span>
+                <span class="material-symbols text-2xl inline-block md:hidden!">upload</span>
+              </ui-file-input>
+            </div>
+
+            <form @submit.prevent="submitUploadCover" class="flex grow">
+              <ui-text-input v-model="imageUrl" :placeholder="$strings.LabelImageURLFromTheWeb" class="h-9 w-full" />
+              <ui-btn color="bg-success" type="submit" :padding-x="4" :disabled="!imageUrl" class="ml-2 sm:ml-3 w-24 h-9">{{ $strings.ButtonSubmit }}</ui-btn>
+            </form>
+          </div>
 
           <form v-if="author" @submit.prevent="submitForm">
             <div class="flex">
@@ -44,6 +53,18 @@
           </form>
         </div>
       </div>
+
+      <div v-if="previewUpload" class="absolute top-0 left-0 w-full h-full z-10 bg-bg p-8">
+        <p class="text-lg">{{ $strings.HeaderPreviewCover }}</p>
+        <span class="absolute top-4 right-4 material-symbols text-2xl cursor-pointer" @click="resetImagePreview">close</span>
+        <div class="flex justify-center py-4">
+          <img :src="previewUpload" class="max-h-64 max-w-full object-contain" />
+        </div>
+        <div class="absolute bottom-0 right-0 flex py-4 px-5">
+          <ui-btn :disabled="processingUpload" class="mx-2" @click="resetImagePreview">{{ $strings.ButtonReset }}</ui-btn>
+          <ui-btn :loading="processingUpload" color="bg-success" @click="submitImageUpload">{{ $strings.ButtonUpload }}</ui-btn>
+        </div>
+      </div>
     </div>
   </modals-modal>
 </template>
@@ -58,7 +79,10 @@ export default {
         description: ''
       },
       imageUrl: '',
-      processing: false
+      processing: false,
+      processingUpload: false,
+      previewUpload: null,
+      selectedFile: null
     }
   },
   watch: {
@@ -98,14 +122,53 @@ export default {
     },
     userCanDelete() {
       return this.$store.getters['user/getUserCanDelete']
+    },
+    userCanUpload() {
+      return this.$store.getters['user/getUserCanUpload']
     }
   },
   methods: {
     init() {
       this.imageUrl = ''
+      this.resetImagePreview()
       this.authorCopy = {
         ...this.author
       }
+    },
+    fileUploadSelected(file) {
+      this.previewUpload = URL.createObjectURL(file)
+      this.selectedFile = file
+    },
+    resetImagePreview() {
+      if (this.$refs.fileInput) {
+        this.$refs.fileInput.reset()
+      }
+      this.previewUpload = null
+      this.selectedFile = null
+    },
+    submitImageUpload() {
+      if (!this.selectedFile) return
+
+      this.processingUpload = true
+      const form = new FormData()
+      form.set('image', this.selectedFile)
+
+      this.$axios
+        .$post(`/api/authors/${this.authorId}/image`, form)
+        .then((data) => {
+          this.resetImagePreview()
+          this.$toast.success(this.$strings.ToastAuthorUpdateSuccess)
+
+          this.authorCopy.updatedAt = data.author.updatedAt
+          this.authorCopy.imagePath = data.author.imagePath
+        })
+        .catch((error) => {
+          console.error('Failed', error)
+          this.$toast.error(error.response?.data || this.$strings.ToastUnknownError)
+        })
+        .finally(() => {
+          this.processingUpload = false
+        })
     },
     removeClick() {
       const payload = {

--- a/docs/controllers/AuthorController.yaml
+++ b/docs/controllers/AuthorController.yaml
@@ -200,24 +200,41 @@ paths:
     post:
       operationId: addAuthorImageById
       summary: Add an author image to the server
-      description: Add an author image to the server. The image will be downloaded from the provided URL and stored on the server.
+      description: Add an author image to the server. Provide either a URL to download or a multipart image file upload. The image is stored on the server.
       tags:
         - Authors
       requestBody:
         required: true
-        description: The author image to add by URL.
+        description: The author image to add by URL or file upload.
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/imageUrl'
+              type: object
+              required:
+                - url
+              properties:
+                url:
+                  $ref: '#/components/schemas/imageUrl'
+          multipart/form-data:
+            schema:
+              type: object
+              required:
+                - image
+              properties:
+                image:
+                  type: string
+                  format: binary
+                  description: Author image file (png, jpg, jpeg, or webp)
       responses:
         '200':
           description: addAuthorImageById OK
           content:
-            image/*:
+            application/json:
               schema:
-                type: string
-                format: binary
+                type: object
+                properties:
+                  author:
+                    $ref: '../objects/entities/Author.yaml#/components/schemas/author'
         '404':
           $ref: '#/components/responses/author404'
     patch:

--- a/server/controllers/AuthorController.js
+++ b/server/controllers/AuthorController.js
@@ -259,7 +259,7 @@ class AuthorController {
 
   /**
    * POST: /api/authors/:id/image
-   * Upload author image from web URL
+   * Upload author image from web URL or multipart file
    *
    * @param {AuthorControllerRequest} req
    * @param {Response} res
@@ -269,17 +269,22 @@ class AuthorController {
       Logger.warn(`User "${req.user.username}" attempted to upload an image without permission`)
       return res.sendStatus(403)
     }
-    if (!req.body.url) {
-      Logger.error(`[AuthorController] Invalid request payload. 'url' not in request body`)
-      return res.status(400).send(`Invalid request payload. 'url' not in request body`)
-    }
-    if (!req.body.url.startsWith?.('http:') && !req.body.url.startsWith?.('https:')) {
-      Logger.error(`[AuthorController] Invalid request payload. Invalid url "${req.body.url}"`)
-      return res.status(400).send(`Invalid request payload. Invalid url "${req.body.url}"`)
-    }
 
-    Logger.debug(`[AuthorController] Requesting download author image from url "${req.body.url}"`)
-    const result = await AuthorFinder.saveAuthorImage(req.author.id, req.body.url)
+    let result = null
+    if (req.body?.url) {
+      if (!req.body.url.startsWith?.('http:') && !req.body.url.startsWith?.('https:')) {
+        Logger.error(`[AuthorController] Invalid request payload. Invalid url "${req.body.url}"`)
+        return res.status(400).send(`Invalid request payload. Invalid url "${req.body.url}"`)
+      }
+
+      Logger.debug(`[AuthorController] Requesting download author image from url "${req.body.url}"`)
+      result = await AuthorFinder.saveAuthorImage(req.author.id, req.body.url, req.author.imagePath)
+    } else if (req.files?.image) {
+      Logger.debug(`[AuthorController] Handling uploaded author image`)
+      result = await AuthorFinder.uploadAuthorImage(req.author.id, req.files.image, req.author.imagePath)
+    } else {
+      return res.status(400).send('Invalid request no file or url')
+    }
 
     if (result?.error) {
       return res.status(400).send(result.error)
@@ -357,7 +362,7 @@ class AuthorController {
     if (authorData.image && (!req.author.imagePath || hasUpdates)) {
       await CacheManager.purgeImageCache(req.author.id)
 
-      const imageData = await AuthorFinder.saveAuthorImage(req.author.id, authorData.image)
+      const imageData = await AuthorFinder.saveAuthorImage(req.author.id, authorData.image, req.author.imagePath)
       if (imageData?.path) {
         req.author.imagePath = imageData.path
         hasUpdates = true

--- a/server/finders/AuthorFinder.js
+++ b/server/finders/AuthorFinder.js
@@ -2,7 +2,9 @@ const fs = require('../libs/fsExtra')
 const Logger = require('../Logger')
 const Path = require('path')
 const Audnexus = require('../providers/Audnexus')
+const CoverManager = require('../managers/CoverManager')
 
+const globals = require('../utils/globals')
 const { downloadImageFile } = require('../utils/fileUtils')
 
 class AuthorFinder {
@@ -35,12 +37,13 @@ class AuthorFinder {
 
   /**
    * Download author image from url and save in authors folder
-   * 
-   * @param {string} authorId 
-   * @param {string} url 
-   * @returns {Promise<{path:string, error:string}>}
+   *
+   * @param {string} authorId
+   * @param {string} url
+   * @param {string} [existingImagePath]
+   * @returns {Promise<{path:string}|{error:string}>}
    */
-  async saveAuthorImage(authorId, url) {
+  async saveAuthorImage(authorId, url, existingImagePath = null) {
     const authorDir = Path.join(global.MetadataPath, 'authors')
 
     if (!await fs.pathExists(authorDir)) {
@@ -52,7 +55,10 @@ class AuthorFinder {
     const filename = authorId + '.' + ext
     const outputPath = Path.posix.join(authorDir, filename)
 
-    return downloadImageFile(url, outputPath).then(() => {
+    return downloadImageFile(url, outputPath).then(async () => {
+      if (existingImagePath && existingImagePath !== outputPath) {
+        await CoverManager.removeFile(existingImagePath)
+      }
       return {
         path: outputPath
       }
@@ -63,6 +69,52 @@ class AuthorFinder {
         error: errorMsg
       }
     })
+  }
+
+  /**
+   * Upload author image file and save in authors folder
+   *
+   * @param {string} authorId
+   * @param {*} imageFile - file object from req.files
+   * @param {string} [existingImagePath]
+   * @returns {Promise<{path:string}|{error:string}>}
+   */
+  async uploadAuthorImage(authorId, imageFile, existingImagePath = null) {
+    const extname = Path.extname(imageFile.name.toLowerCase())
+    if (!extname || !globals.SupportedImageTypes.includes(extname.slice(1))) {
+      return {
+        error: `Invalid image type ${extname} (Supported: ${globals.SupportedImageTypes.join(',')})`
+      }
+    }
+
+    const authorDir = Path.join(global.MetadataPath, 'authors')
+    await fs.ensureDir(authorDir)
+
+    const outputPath = Path.posix.join(authorDir, `${authorId}${extname}`)
+
+    const success = await imageFile
+      .mv(outputPath)
+      .then(() => true)
+      .catch((error) => {
+        Logger.error('[AuthorFinder] Failed to move author image file', outputPath, error)
+        return false
+      })
+
+    if (!success) {
+      return {
+        error: 'Failed to move image into destination'
+      }
+    }
+
+    if (existingImagePath && existingImagePath !== outputPath) {
+      await CoverManager.removeFile(existingImagePath)
+    }
+
+    Logger.info(`[AuthorFinder] Uploaded author image "${outputPath}"`)
+
+    return {
+      path: outputPath
+    }
   }
 }
 module.exports = new AuthorFinder()


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

Added the ability to upload an image for an Author.
This is a feature I would personally like, since I've noticed that when using a URL for the Author it doesn't usually work.
Maybe others would appreciate it as well.

## In-depth Description

- Add a file upload option to the Update Author modal (alongside the existing Image URL), matching the book cover UI
- Extend `POST /api/authors/:id/image` to accept a multipart image file as well as a URL
- Clean up the previous author image file when replacing with a different extension (URL or upload)

## How have you tested this?

Manual test when running the container locally with my changes. I was able to upload the image of an Author when selecting a file after clicking the new Upload button.

## Screenshots
Before:
<img width="541" height="304" alt="image" src="https://github.com/user-attachments/assets/a5001f4a-6516-48d1-a40d-016f9856eb45" />

After:
<img width="541" height="304" alt="image" src="https://github.com/user-attachments/assets/bff779c3-b690-4177-a246-65cd4d6e1588" />
<img width="541" height="304" alt="image" src="https://github.com/user-attachments/assets/a49c6d1e-a4ba-4b19-b1fd-0cbbecee401a" />
<img width="541" height="304" alt="image" src="https://github.com/user-attachments/assets/0628b6e6-ace9-490c-b353-9f7f1d7b58b3" />

<!-- If your PR includes any changes to the web client, please include screenshots or a short video from before and after your changes. -->
