### PR TITLE
Trim whitespace on Match tab Update Details fields

### DIFF
--- a/client/components/modals/item/tabs/Match.vue
+++ b/client/components/modals/item/tabs/Match.vue
@@ -58,7 +58,7 @@
         <div v-if="selectedMatchOrig.title" class="flex items-center py-2">
           <ui-checkbox v-model="selectedMatchUsage.title" checkbox-bg="bg" @input="checkboxToggled" />
           <div class="grow ml-4">
-            <ui-text-input-with-label v-model="selectedMatch.title" :disabled="!selectedMatchUsage.title" :label="$strings.LabelTitle" />
+            <ui-text-input-with-label v-model="selectedMatch.title" :disabled="!selectedMatchUsage.title" :label="$strings.LabelTitle" trim-whitespace />
             <p v-if="mediaMetadata.title" class="text-xs ml-1 text-white/60">
               {{ $strings.LabelCurrently }} <a :title="$strings.LabelClickToUseCurrentValue" class="cursor-pointer hover:underline" @click.stop="setMatchFieldValue('title', mediaMetadata.title)">{{ mediaMetadata.title || '' }}</a>
             </p>
@@ -67,7 +67,7 @@
         <div v-if="selectedMatchOrig.subtitle" class="flex items-center py-2">
           <ui-checkbox v-model="selectedMatchUsage.subtitle" checkbox-bg="bg" @input="checkboxToggled" />
           <div class="grow ml-4">
-            <ui-text-input-with-label v-model="selectedMatch.subtitle" :disabled="!selectedMatchUsage.subtitle" :label="$strings.LabelSubtitle" />
+            <ui-text-input-with-label v-model="selectedMatch.subtitle" :disabled="!selectedMatchUsage.subtitle" :label="$strings.LabelSubtitle" trim-whitespace />
             <p v-if="mediaMetadata.subtitle" class="text-xs ml-1 text-white/60">
               {{ $strings.LabelCurrently }} <a :title="$strings.LabelClickToUseCurrentValue" class="cursor-pointer hover:underline" @click.stop="setMatchFieldValue('subtitle', mediaMetadata.subtitle)">{{ mediaMetadata.subtitle }}</a>
             </p>
@@ -103,7 +103,7 @@
         <div v-if="selectedMatchOrig.publisher" class="flex items-center py-2">
           <ui-checkbox v-model="selectedMatchUsage.publisher" checkbox-bg="bg" @input="checkboxToggled" />
           <div class="grow ml-4">
-            <ui-text-input-with-label v-model="selectedMatch.publisher" :disabled="!selectedMatchUsage.publisher" :label="$strings.LabelPublisher" />
+            <ui-text-input-with-label v-model="selectedMatch.publisher" :disabled="!selectedMatchUsage.publisher" :label="$strings.LabelPublisher" trim-whitespace />
             <p v-if="mediaMetadata.publisher" class="text-xs ml-1 text-white/60">
               {{ $strings.LabelCurrently }} <a :title="$strings.LabelClickToUseCurrentValue" class="cursor-pointer hover:underline" @click.stop="setMatchFieldValue('publisher', mediaMetadata.publisher)">{{ mediaMetadata.publisher }}</a>
             </p>
@@ -149,7 +149,7 @@
         <div v-if="selectedMatchOrig.language" class="flex items-center py-2">
           <ui-checkbox v-model="selectedMatchUsage.language" checkbox-bg="bg" @input="checkboxToggled" />
           <div class="grow ml-4">
-            <ui-text-input-with-label v-model="selectedMatch.language" :disabled="!selectedMatchUsage.language" :label="$strings.LabelLanguage" />
+            <ui-text-input-with-label v-model="selectedMatch.language" :disabled="!selectedMatchUsage.language" :label="$strings.LabelLanguage" trim-whitespace />
             <p v-if="mediaMetadata.language" class="text-xs ml-1 text-white/60">
               {{ $strings.LabelCurrently }} <a :title="$strings.LabelClickToUseCurrentValue" class="cursor-pointer hover:underline" @click.stop="setMatchFieldValue('language', mediaMetadata.language)">{{ mediaMetadata.language }}</a>
             </p>
@@ -158,7 +158,7 @@
         <div v-if="selectedMatchOrig.isbn" class="flex items-center py-2">
           <ui-checkbox v-model="selectedMatchUsage.isbn" checkbox-bg="bg" @input="checkboxToggled" />
           <div class="grow ml-4">
-            <ui-text-input-with-label v-model="selectedMatch.isbn" :disabled="!selectedMatchUsage.isbn" label="ISBN" />
+            <ui-text-input-with-label v-model="selectedMatch.isbn" :disabled="!selectedMatchUsage.isbn" label="ISBN" trim-whitespace />
             <p v-if="mediaMetadata.isbn" class="text-xs ml-1 text-white/60">
               {{ $strings.LabelCurrently }} <a :title="$strings.LabelClickToUseCurrentValue" class="cursor-pointer hover:underline" @click.stop="setMatchFieldValue('isbn', mediaMetadata.isbn)">{{ mediaMetadata.isbn }}</a>
             </p>
@@ -167,7 +167,7 @@
         <div v-if="selectedMatchOrig.asin" class="flex items-center py-2">
           <ui-checkbox v-model="selectedMatchUsage.asin" checkbox-bg="bg" @input="checkboxToggled" />
           <div class="grow ml-4">
-            <ui-text-input-with-label v-model="selectedMatch.asin" :disabled="!selectedMatchUsage.asin" label="ASIN" />
+            <ui-text-input-with-label v-model="selectedMatch.asin" :disabled="!selectedMatchUsage.asin" label="ASIN" trim-whitespace />
             <p v-if="mediaMetadata.asin" class="text-xs ml-1 text-white/60">
               {{ $strings.LabelCurrently }} <a :title="$strings.LabelClickToUseCurrentValue" class="cursor-pointer hover:underline" @click.stop="setMatchFieldValue('asin', mediaMetadata.asin)">{{ mediaMetadata.asin }}</a>
             </p>


### PR DESCRIPTION
## Brief summary

The Match tab's **Update Details** form did not trim leading/trailing whitespace from its text fields, so a title/subtitle/etc. entered or pasted with stray spaces was saved verbatim. The **Details** tab already trims these fields, so the two editors behaved inconsistently. This makes them consistent.

## Which issue is fixed?

Fixes #5293

## In-depth Description

The Details tab (`client/components/widgets/BookDetailsEdit.vue`) trims whitespace on `title`, `subtitle`, `publisher`, `language`, ISBN and ASIN via the shared `ui-text-input` component's existing `trim-whitespace` prop, which trims on blur. The equivalent inputs on the Match tab (`client/components/modals/item/tabs/Match.vue`) simply omitted that prop, which is why stray whitespace survived into the saved values.

This adds `trim-whitespace` to those same six inputs on the Match tab. It reuses the existing, already-tested trim-on-blur behavior rather than introducing any new logic, so the Match tab now behaves identically to the Details tab — which is what the issue asks for. (Author names on the Match tab are already trimmed in `buildMatchUpdatePayload`, so they were never affected.)

Six-line change, no functional risk beyond the trimming itself.

## How have you tested this?

- **Component test (Cypress):** mounted `ui-text-input-with-label` with and without the prop and typed `"  System Collapse  "`. Without the fix the field keeps `"  System Collapse  "`; with the fix it becomes `"System Collapse"` on blur.
- **Live server (v2.35.1):** opened the Match tab, ran a real Audible search, selected a result, typed a title padded with spaces into the Title field and blurred — the field trimmed to the expected value. The subsequent match update then stores the trimmed value.

## Screenshots

Before / after of the **Title** field on the Match → Update Details form (values quoted so the otherwise-invisible whitespace is visible):

![Screenshot_20260718_202027_Claude.jpg](https://github.com/user-attachments/assets/3c80a92e-acc4-45b1-bf26-cd3859527e10)




