### PR TITLE
Allow NAT64 (RFC 6052) addresses in the SSRF request filter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "express-session": "^1.17.3",
         "graceful-fs": "^4.2.10",
         "htmlparser2": "^8.0.1",
+        "ipaddr.js": "^1.9.1",
         "lru-cache": "^10.0.3",
         "node-unrar-js": "^2.0.2",
         "nodemailer": "^6.9.13",
@@ -27,7 +28,6 @@
         "sequelize": "^6.35.2",
         "socket.io": "^4.5.4",
         "sqlite3": "^5.1.7",
-        "ssrf-req-filter": "^1.1.0",
         "xml2js": "^0.5.0"
       },
       "bin": {
@@ -2113,6 +2113,21 @@
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "devOptional": true
     },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -2511,6 +2526,7 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.10"
       }
@@ -4974,22 +4990,6 @@
         "node-gyp": {
           "optional": true
         }
-      }
-    },
-    "node_modules/ssrf-req-filter": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/ssrf-req-filter/-/ssrf-req-filter-1.1.0.tgz",
-      "integrity": "sha512-YUyTinAEm52NsoDvkTFN9BQIa5nURNr2aN0BwOiJxHK3tlyGUczHa+2LjcibKNugAk/losB6kXOfcRzy0LQ4uA==",
-      "dependencies": {
-        "ipaddr.js": "^2.1.0"
-      }
-    },
-    "node_modules/ssrf-req-filter/node_modules/ipaddr.js": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.1.0.tgz",
-      "integrity": "sha512-LlbxQ7xKzfBusov6UMi4MFpEg0m+mAm9xyNGEduwXMEDuf4WfzB/RZwMVYEd7IKGvh4IUkEXYxtAVu9T3OelJQ==",
-      "engines": {
-        "node": ">= 10"
       }
     },
     "node_modules/ssri": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "express-session": "^1.17.3",
     "graceful-fs": "^4.2.10",
     "htmlparser2": "^8.0.1",
+    "ipaddr.js": "^1.9.1",
     "lru-cache": "^10.0.3",
     "node-unrar-js": "^2.0.2",
     "nodemailer": "^6.9.13",
@@ -56,7 +57,6 @@
     "sequelize": "^6.35.2",
     "socket.io": "^4.5.4",
     "sqlite3": "^5.1.7",
-    "ssrf-req-filter": "^1.1.0",
     "xml2js": "^0.5.0"
   },
   "devDependencies": {

--- a/server/utils/ffmpegHelpers.js
+++ b/server/utils/ffmpegHelpers.js
@@ -1,5 +1,5 @@
 const axios = require('axios')
-const ssrfFilter = require('ssrf-req-filter')
+const ssrfFilter = require('./ssrfRequestFilter')
 const Ffmpeg = require('../libs/fluentFfmpeg')
 const ffmpgegUtils = require('../libs/fluentFfmpeg/utils')
 const fs = require('../libs/fsExtra')

--- a/server/utils/fileUtils.js
+++ b/server/utils/fileUtils.js
@@ -1,6 +1,6 @@
 const axios = require('axios')
 const Path = require('path')
-const ssrfFilter = require('ssrf-req-filter')
+const ssrfFilter = require('./ssrfRequestFilter')
 const exec = require('child_process').exec
 const fs = require('../libs/fsExtra')
 const rra = require('../libs/recursiveReaddirAsync')

--- a/server/utils/podcastUtils.js
+++ b/server/utils/podcastUtils.js
@@ -1,5 +1,5 @@
 const axios = require('axios')
-const ssrfFilter = require('ssrf-req-filter')
+const ssrfFilter = require('./ssrfRequestFilter')
 const Logger = require('../Logger')
 const { xmlToJSON, timestampToSeconds } = require('./index')
 const htmlSanitizer = require('../utils/htmlSanitizer')

--- a/server/utils/ssrfRequestFilter.js
+++ b/server/utils/ssrfRequestFilter.js
@@ -1,0 +1,98 @@
+/**
+ * SSRF request filter — http(s) agent wrapper that blocks outbound requests
+ * to non-public addresses, with NAT64 (RFC 6052) support.
+ *
+ * The agent-wrapping approach (createConnection override + post-DNS 'lookup'
+ * check + double-wrap guard) is adapted from the `ssrf-req-filter` package:
+ *   https://github.com/y-mehta/ssrf-req-filter
+ *   Copyright (c) Yash Mehta, MIT License
+ * Replaced here (rather than depended on) because the package does not expose
+ * a way to customize the address check, which is needed to allow NAT64
+ * addresses that embed a public IPv4 (see isAllowedAddress below).
+ */
+const http = require('http')
+const https = require('https')
+const ipaddr = require('ipaddr.js')
+
+/**
+ * Whether an IP address is allowed for outbound server-side requests.
+ * Hostnames (not valid IPs) are allowed here; the real address is checked again after DNS lookup.
+ *
+ * NAT64 well-known prefix addresses (RFC 6052, 64:ff9b::/96) are synthetic IPv6 that embed an
+ * IPv4 address. Rejecting them wholesale breaks DNS64/NAT64 networks when a podcast host is
+ * IPv4-only. Instead, extract the embedded IPv4 and apply the same private/reserved checks to it.
+ * IPv4-mapped IPv6 (::ffff:x.x.x.x) is handled the same way for consistency.
+ *
+ * @param {string} ip
+ * @returns {boolean}
+ */
+function isAllowedAddress(ip) {
+  if (!ipaddr.isValid(ip)) {
+    return true
+  }
+  try {
+    const addr = ipaddr.parse(ip)
+    const range = addr.range()
+
+    // NAT64 well-known prefix (RFC 6052): last 32 bits are the embedded IPv4
+    if (range === 'rfc6052') {
+      const embedded = ipaddr.fromByteArray(addr.toByteArray().slice(12))
+      return embedded.range() === 'unicast'
+    }
+
+    // IPv4-mapped IPv6 (::ffff:a.b.c.d)
+    if (range === 'ipv4Mapped') {
+      return addr.toIPv4Address().range() === 'unicast'
+    }
+
+    return range === 'unicast'
+  } catch (err) {
+    return false
+  }
+}
+
+// Prevent double-wrapping the same agent (memory leak / stacked handlers)
+const ACTIVE = Symbol('ssrfRequestFilterActive')
+
+/**
+ * Wrap an http(s).Agent so connections to non-public addresses are blocked.
+ *
+ * @param {http.Agent|https.Agent} agent
+ * @returns {http.Agent|https.Agent}
+ */
+function requestFilterHandler(agent) {
+  if (agent[ACTIVE]) return agent
+  agent[ACTIVE] = true
+  const { createConnection } = agent
+  agent.createConnection = function (options, func) {
+    const { host: address } = options
+    if (!isAllowedAddress(address)) {
+      throw new Error(`Call to ${address} is blocked.`)
+    }
+    const socket = createConnection.call(this, options, func)
+    socket.on('lookup', (error, lookedUpAddress) => {
+      if (error || isAllowedAddress(lookedUpAddress)) {
+        return false
+      }
+      return socket.destroy(new Error(`Call to ${lookedUpAddress} is blocked.`))
+    })
+    return socket
+  }
+  return agent
+}
+
+/**
+ * Create an SSRF-filtering agent for the given URL's protocol.
+ * Drop-in replacement for the `ssrf-req-filter` package with NAT64 support.
+ *
+ * @param {string} url
+ * @returns {http.Agent|https.Agent}
+ */
+function ssrfRequestFilter(url) {
+  const agent = url.startsWith('https') ? new https.Agent() : new http.Agent()
+  return requestFilterHandler(agent)
+}
+
+module.exports = ssrfRequestFilter
+module.exports.requestFilterHandler = requestFilterHandler
+module.exports.isAllowedAddress = isAllowedAddress

--- a/test/server/utils/ssrfRequestFilter.test.js
+++ b/test/server/utils/ssrfRequestFilter.test.js
@@ -1,0 +1,62 @@
+const chai = require('chai')
+const { expect } = chai
+
+const { isAllowedAddress } = require('../../../server/utils/ssrfRequestFilter')
+
+describe('ssrfRequestFilter', () => {
+  describe('isAllowedAddress', () => {
+    it('allows public IPv4 unicast addresses', () => {
+      expect(isAllowedAddress('151.101.194.133')).to.equal(true)
+      expect(isAllowedAddress('8.8.8.8')).to.equal(true)
+    })
+
+    it('blocks private, loopback, and link-local IPv4 addresses', () => {
+      expect(isAllowedAddress('10.0.0.1')).to.equal(false)
+      expect(isAllowedAddress('192.168.1.1')).to.equal(false)
+      expect(isAllowedAddress('127.0.0.1')).to.equal(false)
+      expect(isAllowedAddress('169.254.1.1')).to.equal(false)
+    })
+
+    it('allows public IPv6 unicast addresses', () => {
+      expect(isAllowedAddress('2606:4700:4700::1111')).to.equal(true)
+    })
+
+    it('blocks non-unicast IPv6 ranges (loopback, link-local, unique local)', () => {
+      expect(isAllowedAddress('::1')).to.equal(false)
+      expect(isAllowedAddress('fe80::1')).to.equal(false)
+      expect(isAllowedAddress('fc00::1')).to.equal(false)
+    })
+
+    it('allows NAT64 (RFC 6052) addresses that embed a public IPv4', () => {
+      // 64:ff9b::9765:c285 embeds 151.101.194.133 (from #5288)
+      expect(isAllowedAddress('64:ff9b::9765:c285')).to.equal(true)
+      // 64:ff9b::12ef:b75f embeds 18.239.183.95 (from #3840)
+      expect(isAllowedAddress('64:ff9b::12ef:b75f')).to.equal(true)
+    })
+
+    it('blocks NAT64 addresses that embed a private or loopback IPv4', () => {
+      // 64:ff9b::c0a8:1 embeds 192.168.0.1
+      expect(isAllowedAddress('64:ff9b::c0a8:1')).to.equal(false)
+      // 64:ff9b::a00:1 embeds 10.0.0.1
+      expect(isAllowedAddress('64:ff9b::a00:1')).to.equal(false)
+      // 64:ff9b::7f00:1 embeds 127.0.0.1
+      expect(isAllowedAddress('64:ff9b::7f00:1')).to.equal(false)
+    })
+
+    it('allows IPv4-mapped IPv6 addresses that embed a public IPv4', () => {
+      expect(isAllowedAddress('::ffff:151.101.194.133')).to.equal(true)
+      expect(isAllowedAddress('::ffff:8.8.8.8')).to.equal(true)
+    })
+
+    it('blocks IPv4-mapped IPv6 addresses that embed a private IPv4', () => {
+      expect(isAllowedAddress('::ffff:10.0.0.1')).to.equal(false)
+      expect(isAllowedAddress('::ffff:192.168.1.1')).to.equal(false)
+      expect(isAllowedAddress('::ffff:127.0.0.1')).to.equal(false)
+    })
+
+    it('allows hostnames (checked again after DNS lookup)', () => {
+      expect(isAllowedAddress('anchor.fm')).to.equal(true)
+      expect(isAllowedAddress('example.com')).to.equal(true)
+    })
+  })
+})


### PR DESCRIPTION
## Brief summary

On DNS64/NAT64 networks, IPv4-only hosts resolve to synthetic IPv6 addresses under the well-known prefix `64:ff9b::/96`. The outbound SSRF filter treated every non-`unicast` range as blocked, so those addresses were rejected and legitimate podcast/cover downloads failed with `Call to 64:ff9b::… is blocked.` This allows NAT64 addresses when the **embedded IPv4** is a public unicast address, while still blocking private/loopback embeddings.

## Which issue is fixed?

Fixes #5288

## In-depth Description

`ssrf-req-filter` only allows `ipaddr.js` range `unicast`. NAT64 addresses are classified as `rfc6052`, so they were always blocked even when they represent a public IPv4 (e.g. `64:ff9b::9765:c285` → `151.101.194.133`). That matches the stack traces on #5288 and the earlier report #3840.

Because the package does not expose a way to customize the address check, this replaces it with a small local module (`server/utils/ssrfRequestFilter.js`) that keeps the same http(s) agent wrapping pattern:

1. Hostnames are still deferred to the post-DNS `lookup` check.
2. Plain public IPv4/IPv6 unicast still allowed; private/loopback/link-local still blocked.
3. **NAT64 (`rfc6052`)**: extract the last 32 bits as IPv4; allow only if that IPv4 is `unicast`.
4. **IPv4-mapped (`::ffff:…`)**: same embedded-IPv4 treatment for consistency.
5. `DISABLE_SSRF_REQUEST_FILTER` / whitelist / proxy support in `Server.js` are unchanged — they still gate whether the agent is attached.

Dependency change: drop `ssrf-req-filter`, add a direct dependency on `ipaddr.js@^1.9.1` — the exact version already in the tree via `express` → `proxy-addr`, so the lockfile dedupes to a single copy and no new code is pulled in. The new module carries an attribution notice to `ssrf-req-filter` (MIT), whose agent-wrapping approach it adapts.

## How have you tested this?

### Unit tests

`test/server/utils/ssrfRequestFilter.test.js` covers `isAllowedAddress`:

- public / private IPv4 and IPv6
- NAT64 with public embedded IPv4 (addresses from #5288 and #3840) → **allowed**
- NAT64 with private/loopback embedded IPv4 → **blocked**
- IPv4-mapped public → allowed; private → blocked
- hostnames → allowed (re-checked after lookup)

Full server suite on this branch: **354 passing**.

### Live smoke test (deployed build)

Deployed the change into a running Docker install and exercised the filter **inside the container** against the exact public targets from the issue reports:

| Source | Address / URL | Result |
|--------|----------------|--------|
| #5288 | NAT64 `64:ff9b::9765:c285` (embeds **`151.101.194.133`**) | **allowed** by `isAllowedAddress` |
| #5288 | public IPv4 `151.101.194.133` | **allowed** |
| #5288 | feed `https://anchor.fm/s/9e4f968/podcast/rss` | fetch via filter agent → **HTTP 200**, ~1.2 MB RSS |
| #3840 | NAT64 `64:ff9b::12ef:b75f` (embeds **`18.239.183.95`**) | **allowed** |
| #3840 | feed `https://feeds.simplecast.com/VQImumnT` | fetch via filter agent → **HTTP 200**, ~0.8 MB RSS |
| control | NAT64 embedding of `192.168.0.1` / plain `10.0.0.1` / `127.0.0.1` | **blocked** |
| control | `http://127.0.0.1/` via filter agent | error `Call to 127.0.0.1 is blocked.` |

Also confirmed in the image: `server/utils/ssrfRequestFilter.js` is present, call sites use it, and the `ssrf-req-filter` package is no longer installed.

### End-to-end on the running server

Added both issue feeds through the web UI (Add Podcast → feed URL → Submit) on the deployed build: `https://anchor.fm/s/9e4f968/podcast/rss` (#5288) and `https://feeds.simplecast.com/VQImumnT` (#3840). Both fetched through the filtered agent, populated metadata, and saved as podcasts successfully.

**Limitation:** the test host is dual-stack IPv4 (DNS returns normal A records for `anchor.fm`, including `151.101.194.133` among others — no DNS64/`64:ff9b::…` path). So this does **not** reproduce a full NAT64 network end-to-end; it does verify the filter decision on the **exact NAT64 and public IPs named in #5288 / #3840**, plus real downloads of those issue feed URLs through the new agent without regressing normal public HTTPS.

## Screenshots

N/A — server-only change (no web client UI).


