### PR TITLE
Fix narrator/author name lists mangled by non-breaking spaces (U+202F)

### DIFF
--- a/server/utils/parsers/parseNameString.js
+++ b/server/utils/parsers/parseNameString.js
@@ -5,6 +5,17 @@
 //
 const parseFullName = require('./parseFullName')
 
+// Some taggers join a first and last name with a non-breaking or other Unicode
+// space (e.g. U+202F NARROW NO-BREAK SPACE, U+00A0 NO-BREAK SPACE) instead of a
+// regular space. These are not matched by ' ', so a name like "First Last" reads
+// as a single space-less token - i.e. a last name only - which can flip an entire
+// comma-separated list into "Last, First" pairing mode and mangle it. Normalize
+// such spaces to a regular space before parsing. U+3000 (ideographic space) is
+// intentionally left alone so CJK names are returned untouched.
+function normalizeNameSpaces(name) {
+  return name.replace(/[\u00A0\u1680\u2000-\u200A\u202F\u205F]/g, ' ')
+}
+
 function parseName(name) {
   var parts = parseFullName(name)
   var firstName = parts.first
@@ -29,7 +40,7 @@ function checkIsALastName(name) {
 
 // Handle name already in First Last format and return Last, First
 module.exports.nameToLastFirst = (firstLast) => {
-  var nameObj = parseName(firstLast)
+  var nameObj = parseName(normalizeNameSpaces(firstLast))
   if (!nameObj.last_name) return nameObj.first_name
   else if (!nameObj.first_name) return nameObj.last_name
   return `${nameObj.last_name}, ${nameObj.first_name}`
@@ -43,6 +54,8 @@ module.exports.nameToLastFirst = (firstLast) => {
  */
 module.exports.parse = (nameString) => {
   if (!nameString) return null
+
+  nameString = normalizeNameSpaces(nameString)
 
   let splitNames = []
   const isCommaSeparated = nameString.includes(',')

--- a/test/server/utils/parsers/parseNameString.test.js
+++ b/test/server/utils/parsers/parseNameString.test.js
@@ -69,6 +69,33 @@ describe('parseNameString', () => {
       expect(result.names).to.deep.equal(['张三', '李四'])
     })
 
+    // Regression: https://github.com/advplyr/audiobookshelf/issues/5367
+    // Some taggers join first/last names with U+202F (narrow no-break space) or
+    // U+00A0 (no-break space) instead of a regular space. Those are not matched
+    // by ' ', so every chunk read as a space-less "last name" and the whole
+    // First Last list was flipped into "Last, First" pairing mode.
+    it('does not pair a First Last list joined by narrow no-break spaces (U+202F)', () => {
+      const result = parse('Joanna\u202fWyatt, Paul\u202fPanting, Stephen\u202fWebb, Julian\u202fGlover')
+      expect(result.names).to.deep.equal(['Joanna Wyatt', 'Paul Panting', 'Stephen Webb', 'Julian Glover'])
+    })
+
+    it('does not pair a First Last list joined by no-break spaces (U+00A0)', () => {
+      const result = parse('Jane\u00a0Doe, John\u00a0Smith')
+      expect(result.names).to.deep.equal(['Jane Doe', 'John Smith'])
+    })
+
+    it('keeps every name in a large odd-length First Last list joined by narrow no-break spaces', () => {
+      const expected = ['Joanna Wyatt', 'Paul Panting', 'Stephen Webb', 'Julian Glover', 'Tim Bentinck']
+      const input = expected.map((n) => n.replace(' ', '\u202f')).join(', ')
+      const result = parse(input)
+      expect(result.names).to.deep.equal(expected)
+    })
+
+    it('still pairs a genuine Last, First list that uses narrow no-break spaces inside first/last parts', () => {
+      const result = parse('von\u202fMises, Ludwig, Smith, John')
+      expect(result.names).to.deep.equal(['Ludwig von Mises', 'John Smith'])
+    })
+
     it('removes duplicate names', () => {
       const result = parse('John Smith & John Smith')
       expect(result.names).to.deep.equal(['John Smith'])


### PR DESCRIPTION
## Brief summary

Narrator/author lists are mangled when the names are separated **inside** each name by a non-breaking space (e.g. `U+202F` NARROW NO-BREAK SPACE) instead of a regular space. A list like `First Last, First Last, ...` then gets treated as `Last, First` pairs, merged two-at-a-time in swapped order, with the odd trailing name dropped — a 23-narrator list collapses to 11 mangled names.

## Which issue is fixed?

Fixes #5367

## Root cause

`parseNameString.parse()` decides whether a comma-separated list is `Last, First` or `First Last` by asking `checkIsALastName()` whether a chunk is a bare last name:

```js
function checkIsALastName(name) {
  if (!name.includes(' ')) return true // No spaces must be a Last name
  ...
}
```

That `' '` is a regular space (`U+0020`). In the reported files the first and last names are joined by **`U+202F` NARROW NO-BREAK SPACE**, not a regular space. So `"Joanna[U+202F]Wyatt".includes(' ')` is `false`, the chunk reads as a single space-less token — i.e. a "last name only" — and `firstChunkIsALastName` becomes `true`. The pairing loop then runs over the whole list:

```
"Joanna Wyatt, Paul Panting, Stephen Webb, Julian Glover, ..."   (first/last joined by U+202F)
  → ["Paul Panting Joanna Wyatt", "Julian Glover Stephen Webb", ...]
```

which is exactly the failure in the reporter's screenshots.

### Why it only happens *sometimes*

The format is decided from the **first chunk alone** (`checkIsALastName(splitNames[0])`). So whether a list is mangled depends entirely on whether its *first* name happens to use a regular space or a narrow no-break space:

- The **first** list in the issue (`Joanna[U+202F]Wyatt, ...`) starts with `U+202F` → mangled.
- The **second** list (`Douglas Gresham, Paul Scofield, David[U+202F]Suchet, ...`) starts with a **regular** space (only the later names use `U+202F`) → parsed correctly, as the reporter observed.
- The **third** list (`Douglas[U+202F]Gresham, ...`) starts with `U+202F` → mangled.

This matches the reporter's note that it "does not always happen."

> **Correction to an earlier revision of this PR:** a previous version of this description blamed a leading *mononym* / particle surname and changed the `Last, First` vs `First Last` decision heuristic. That was wrong — the reporter's list does start with a normal two-word name (`Joanna Wyatt`), and that change did not fix the reported input. Thanks to @gravethief13 for pushing back; their guess that `parseFullName` wasn't seeing a first name was correct, and the reason is the `U+202F` separator.

## The fix

Normalize non-breaking / other Unicode space separators to a regular space before parsing, at both entry points (`parse` and `nameToLastFirst`, which had the same latent bug):

```js
function normalizeNameSpaces(name) {
  return name.replace(/[\u00A0\u1680\u2000-\u200A\u202F\u205F]/g, ' ')
}
```

The `Last, First` vs `First Last` decision logic is left exactly as it was on `master`.

## How to verify

### 1. Confirm the separator really is `U+202F` (the invisible part)

The whole reason this is confusing is that `U+202F` renders identically to a normal space. To see it:

1. Open **https://leafo.net/characters/** (a per-character Unicode inspector).
2. Copy the narrator list straight out of issue #5367 — the `Joanna Wyatt, Paul Panting, Stephen Webb, Julian Glover, ...` list — and paste it into the input box.
3. In the character table, the separator between `Joanna` and `Wyatt` (and inside every other name) is listed as **`U+202F` — NARROW NO-BREAK SPACE**, while the separators after each comma are ordinary **`U+0020` — SPACE**.

That single difference is the entire bug: `checkIsALastName` only recognises `U+0020`, so every `First[U+202F]Last` chunk looks like a bare last name.

### 2. Before / after on the parser

```
Input (first/last joined by U+202F):
  "Joanna Wyatt, Paul Panting, Stephen Webb, Julian Glover"   (4 narrators)

master   → ["Paul Panting Joanna Wyatt", "Julian Glover Stephen Webb"]   (2, swapped)
this PR  → ["Joanna Wyatt", "Paul Panting", "Stephen Webb", "Julian Glover"]   (4, in order)
```

The full 23-name list from the issue goes from 11 mangled names on `master` to all 23 preserved with this change.

## Tests

Extended `test/server/utils/parsers/parseNameString.test.js` with cases built from the real issue strings (using explicit `\u202f` / `\u00a0` escapes):

- a `First Last` list joined by `U+202F` is no longer paired;
- the same for `U+00A0`;
- a large **odd-length** `U+202F` list keeps **every** name (nothing dropped);
- a genuine `Last, First` list that contains `U+202F` inside a compound surname still pairs **and** is normalized.

All four fail on `master` and pass with the fix. Existing `parseNameString` tests are unchanged and still pass (22 total). Files are Prettier-clean.

## Screenshots

N/A — server-side parsing change (no web client UI).
