### PR TITLE
Match folder library items by media file inodes when the folder inode changes

### DIFF
--- a/server/scanner/LibraryScanner.js
+++ b/server/scanner/LibraryScanner.js
@@ -173,7 +173,7 @@ class LibraryScanner {
       let libraryItemData = libraryItemDataFound.find((lid) => lid.path === existingLibraryItem.path)
       if (!libraryItemData) {
         // Fallback to finding matching library item with matching inode value
-        libraryItemData = libraryItemDataFound.find((lid) => ItemToItemInoMatch(lid, existingLibraryItem) || ItemToFileInoMatch(lid, existingLibraryItem) || ItemToFileInoMatch(existingLibraryItem, lid))
+        libraryItemData = libraryItemDataFound.find((lid) => ItemToItemInoMatch(lid, existingLibraryItem) || ItemToFileInoMatch(lid, existingLibraryItem) || ItemToFileInoMatch(existingLibraryItem, lid) || ItemToItemFileInoMatch(lid, existingLibraryItem))
         if (libraryItemData) {
           libraryScan.addLog(LogLevel.INFO, `Library item with path "${existingLibraryItem.path}" was not found, but library item inode "${existingLibraryItem.ino}" was found at path "${libraryItemData.path}"`)
         }
@@ -576,7 +576,7 @@ class LibraryScanner {
       let updatedLibraryItemDetails = {}
       if (!existingLibraryItem) {
         const isSingleMedia = isSingleMediaFile(fileUpdateGroup, itemDir)
-        existingLibraryItem = (await findLibraryItemByItemToItemInoMatch(library.id, fullPath)) || (await findLibraryItemByItemToFileInoMatch(library.id, fullPath, isSingleMedia)) || (await findLibraryItemByFileToItemInoMatch(library.id, fullPath, isSingleMedia, fileUpdateGroup[itemDir]))
+        existingLibraryItem = (await findLibraryItemByItemToItemInoMatch(library.id, fullPath)) || (await findLibraryItemByItemToFileInoMatch(library.id, fullPath, isSingleMedia)) || (await findLibraryItemByFileToItemInoMatch(library.id, fullPath, isSingleMedia, fileUpdateGroup[itemDir])) || (await findLibraryItemByFilesToItemFilesInoMatch(library.id, fullPath, isSingleMedia, fileUpdateGroup[itemDir]))
         if (existingLibraryItem) {
           // Update library item paths for scan
           existingLibraryItem.path = fullPath
@@ -652,6 +652,17 @@ function ItemToItemInoMatch(libraryItem1, libraryItem2) {
   return libraryItem1.ino === libraryItem2.ino
 }
 
+function ItemToItemFileInoMatch(libraryItemScanData, existingLibraryItem) {
+  // Check if a scanned folder contains the media files of an existing folder item, matching by file inode.
+  //   Covers an item folder that was recreated (new folder inode) while the media files kept their inodes,
+  //   e.g. an external tool reorganizing the library by moving files into new folders
+  if (libraryItemScanData.isFile || existingLibraryItem.isFile) return false
+  return scanUtils.checkItemFilesMatchByIno(
+    existingLibraryItem.libraryFiles,
+    libraryItemScanData.libraryFiles.map((lf) => lf.ino)
+  )
+}
+
 function hasAudioFiles(fileUpdateGroup, itemDir) {
   return isSingleMediaFile(fileUpdateGroup, itemDir) ? scanUtils.checkFilepathIsAudioFile(fileUpdateGroup[itemDir]) : fileUpdateGroup[itemDir].some(scanUtils.checkFilepathIsAudioFile)
 }
@@ -709,5 +720,39 @@ async function findLibraryItemByFileToItemInoMatch(libraryId, fullPath, isSingle
     }
   })
   if (existingLibraryItem) Logger.debug(`[LibraryScanner] Found library item with inode matching one of "${itemFileInos.join(',')}" at path "${existingLibraryItem.path}"`)
+  return existingLibraryItem
+}
+
+async function findLibraryItemByFilesToItemFilesInoMatch(libraryId, fullPath, isSingleMedia, itemFiles) {
+  if (isSingleMedia) return null
+  // check if this folder is an existing folder item that was recreated by comparing the inos of the scanned files to the library files of existing items
+  let itemFileInos = []
+  for (const itemFile of itemFiles) {
+    const ino = await fileUtils.getIno(Path.posix.join(fullPath, itemFile))
+    if (ino) itemFileInos.push(ino)
+  }
+  if (!itemFileInos.length) return null
+  const existingLibraryItem = await Database.libraryItemModel.findOneExpanded(
+    [
+      {
+        libraryId: libraryId,
+        isFile: false
+      },
+      sequelize.where(sequelize.literal('(SELECT count(*) FROM json_each(libraryFiles) WHERE json_valid(json_each.value) AND json_each.value->>"$.ino" IN (:inodes))'), {
+        [sequelize.Op.gt]: 0
+      })
+    ],
+    {
+      inodes: itemFileInos
+    }
+  )
+  if (!existingLibraryItem) return null
+  if (!scanUtils.checkItemFilesMatchByIno(existingLibraryItem.libraryFiles, itemFileInos)) return null
+  // Do not match an item whose folder still exists, e.g. the scanned files are hardlinks of an item that is still in place
+  if (await fs.pathExists(existingLibraryItem.path)) {
+    Logger.debug(`[LibraryScanner] Library item with library files matching inodes of "${fullPath}" still exists at path "${existingLibraryItem.path}" - not matching`)
+    return null
+  }
+  Logger.debug(`[LibraryScanner] Found library item with library files matching inodes of files in "${fullPath}" at path "${existingLibraryItem.path}"`)
   return existingLibraryItem
 }

--- a/server/utils/scandir.js
+++ b/server/utils/scandir.js
@@ -39,6 +39,28 @@ function checkFilepathIsAudioFile(filepath) {
 module.exports.checkFilepathIsAudioFile = checkFilepathIsAudioFile
 
 /**
+ * Check if enough media files of an existing library item are found by inode in a scanned folder
+ * to consider it the same item. Covers an item folder that was recreated (so the folder inode
+ * changed) while the media files inside kept their inodes, e.g. files moved into a new folder.
+ * Requires at least half of the existing item's media files to be present in the scanned folder.
+ *
+ * @param {{ino:string, metadata:{ext:string}}[]} existingLibraryFiles - library files of the existing library item
+ * @param {string[]} scannedFileInos - inodes of the files found in the scanned folder
+ * @returns {boolean}
+ */
+function checkItemFilesMatchByIno(existingLibraryFiles, scannedFileInos) {
+  const existingMediaFileInos = (existingLibraryFiles || [])
+    .filter((lf) => isMediaFile('book', lf.metadata?.ext))
+    .map((lf) => lf.ino)
+    .filter((ino) => !!ino)
+  if (!existingMediaFileInos.length) return false
+  const scannedInoSet = new Set(scannedFileInos || [])
+  const numMatching = existingMediaFileInos.filter((ino) => scannedInoSet.has(ino)).length
+  return numMatching > 0 && numMatching * 2 >= existingMediaFileInos.length
+}
+module.exports.checkItemFilesMatchByIno = checkItemFilesMatchByIno
+
+/**
  * @param {string} mediaType
  * @param {import('./fileUtils').FilePathItem[]} fileItems
  * @param {boolean} audiobooksOnly

--- a/test/server/utils/scandir.test.js
+++ b/test/server/utils/scandir.test.js
@@ -49,4 +49,51 @@ describe('scanUtils', async () => {
       'Author/Series2/Book5/deeply/nested': ['cd 01/audiofile.mp3', 'cd 02/audiofile.mp3']
     })
   })
+
+  describe('checkItemFilesMatchByIno', () => {
+    const makeLibraryFile = (ino, filename) => ({ ino, metadata: { ext: Path.extname(filename), filename } })
+
+    it('should match a single file audiobook folder recreated with the same audio file inode', () => {
+      const existingLibraryFiles = [makeLibraryFile('100', 'book.m4b'), makeLibraryFile('101', 'cover.jpg')]
+      expect(scanUtils.checkItemFilesMatchByIno(existingLibraryFiles, ['100', '999'])).to.be.true
+    })
+
+    it('should match when a majority of media files kept their inodes', () => {
+      const existingLibraryFiles = [makeLibraryFile('100', 'cd1.mp3'), makeLibraryFile('101', 'cd2.mp3'), makeLibraryFile('102', 'cd3.mp3')]
+      expect(scanUtils.checkItemFilesMatchByIno(existingLibraryFiles, ['100', '101', '999'])).to.be.true
+    })
+
+    it('should not match when only a minority of media files kept their inodes', () => {
+      const existingLibraryFiles = [makeLibraryFile('100', 'cd1.mp3'), makeLibraryFile('101', 'cd2.mp3'), makeLibraryFile('102', 'cd3.mp3')]
+      expect(scanUtils.checkItemFilesMatchByIno(existingLibraryFiles, ['100'])).to.be.false
+    })
+
+    it('should ignore non-media files when matching', () => {
+      const existingLibraryFiles = [makeLibraryFile('100', 'book.m4b'), makeLibraryFile('101', 'cover.jpg'), makeLibraryFile('102', 'metadata.opf'), makeLibraryFile('103', 'desc.txt')]
+      // Only the audio file inode is present, sidecar files were regenerated with new inodes
+      expect(scanUtils.checkItemFilesMatchByIno(existingLibraryFiles, ['100', '201', '202', '203'])).to.be.true
+    })
+
+    it('should match an ebook by file inode', () => {
+      const existingLibraryFiles = [makeLibraryFile('100', 'book.epub')]
+      expect(scanUtils.checkItemFilesMatchByIno(existingLibraryFiles, ['100'])).to.be.true
+    })
+
+    it('should not match when the existing item has no media files', () => {
+      const existingLibraryFiles = [makeLibraryFile('101', 'cover.jpg'), makeLibraryFile('103', 'desc.txt')]
+      expect(scanUtils.checkItemFilesMatchByIno(existingLibraryFiles, ['101', '103'])).to.be.false
+    })
+
+    it('should not match when the scanned folder has no matching inodes', () => {
+      const existingLibraryFiles = [makeLibraryFile('100', 'book.m4b')]
+      expect(scanUtils.checkItemFilesMatchByIno(existingLibraryFiles, ['200', '201'])).to.be.false
+    })
+
+    it('should handle empty or missing inputs', () => {
+      expect(scanUtils.checkItemFilesMatchByIno([], ['100'])).to.be.false
+      expect(scanUtils.checkItemFilesMatchByIno(null, ['100'])).to.be.false
+      expect(scanUtils.checkItemFilesMatchByIno([makeLibraryFile('100', 'book.m4b')], null)).to.be.false
+      expect(scanUtils.checkItemFilesMatchByIno([{ ino: null, metadata: { ext: '.m4b' } }], ['100'])).to.be.false
+    })
+  })
 })


### PR DESCRIPTION
## Brief summary

Folder based library items lose their identity when their folder is renamed or recreated, and every user's progress goes with it, even when the audio files inside kept their inodes. This extends the scanner's inode fallback matching to consult the media files' inodes for folder items, on both the full scan and watcher paths, so those items are updated in place instead of being duplicated.

This is a bug fix rather than new behavior. Rename detection by inode is existing, intended scanner functionality, and the `isFile` gate makes it unreachable for folder based items, which are the most common library shape.

## Which issue is fixed?

Fixes #5379

## In-depth Description

The fallback matching in `LibraryScanner` tries exact path, folder inode (`ItemToItemInoMatch`), then file inode (`ItemToFileInoMatch`). The file inode check is gated on `libraryItem1.isFile`, so it only ever applies to single file items sitting directly in the library root. For a normal folder based book the file inodes are collected during the scan and then never used for matching, which means the most common library shape has the weakest rename detection: recreate the folder, which any external reorganization tool does, and the item can't be matched no matter how intact its files are.

What this adds:

- Full scan: after the existing matchers miss, and only for an item whose own folder no longer exists, `ItemToItemFileInoMatch` matches the item against the scanned folders that hold its media files. It has to match exactly one scanned folder, otherwise the item is left alone and logged.
- Watcher scan (`scanFolderUpdates`): `findLibraryItemByFilesToItemFilesInoMatch` does the same from the other direction, selecting folder items with any overlapping library file inode through a `json_each` query, then applying the same rule in JS and requiring a single surviving candidate.
- The shared rule is `scanUtils.checkItemFilesMatchByIno`: at least half of the item's media files, audio or ebook by the library's media type, have to be found by inode, with sizes compared when both sides know them. Sidecar files are ignored since covers, opf and desc.txt are routinely regenerated.
- Both fallbacks on the watcher path now share one pass of `getFileTimestampsWithIno`, which returns the inode and size together, instead of each matcher statting the same files itself.

Why the constraints are what they are:

- Requiring the item's folder to be gone is what keeps hardlinks honest. If a tool hardlinks a book into a second location while the original is still in place, both paths are real and should remain two items, and the file inodes are identical on both sides. Neither path will match an item whose folder still exists on disk.
- The majority threshold keeps a stray disc from claiming a large multi-file book, while tolerating a folder that was only partly reorganized.
- Sizes are compared because inode numbers are only unique per filesystem and are reused after a file is deleted. A move never changes a file's size, so this costs the real scenario nothing and rules out a recycled inode taking over an item. Library files scanned by older versions may have no size recorded, in which case the inode alone decides.
- Requiring an unambiguous match means a library that already contains hardlinked duplicates falls back to today's behavior instead of guessing.
- Items with no media files, or with no stored inodes, never match.

Matched items go through the existing update in place flow (`rescanLibraryItemMedia`), so the item id and book id are preserved and mediaProgresses rows keep working. No migration needed.

## How have you tested this?

- Unit tests: 11 cases for `checkItemFilesMatchByIno` in `test/server/utils/scandir.test.js`, covering single file and majority matches, minority rejection, sidecar immunity, ebooks, ebooks not counting as media in podcast libraries, an inode reused by a file of a different size, an unknown size falling back to the inode alone, and empty or missing input. Full `npm test` passes: 356 tests, 0 failures.
- Runtime, on a scratch server built from this branch with a throwaway library: a single m4b book and a three file mp3 book, one marked finished and one mid listen. Recreated both folders and moved the files in, so the folder inodes changed and the file inodes did not, then rescanned. Both items kept their ids, paths updated in place, the finished flag and the 45.5s in progress position survived, nothing was marked missing. Hardlinking the m4b into a second folder and rescanning left the original intact and created a separate second item for the copy, as intended. That run was against the first revision of this branch. The rules have since been tightened (the folder gone gate, size comparison, the unambiguous match requirement), which narrows what can match rather than widening it, and the unit tests cover the added rules.
- The bug itself was observed on a production v2.35.1 server: folder recreated, audio file inodes intact, item duplicated and progress stranded.

## Screenshots

Server side only, no web client changes.
