### PR TITLE
Use the watcher rename event's old path to match renamed library items before inode heuristics

### DIFF
--- a/server/Watcher.js
+++ b/server/Watcher.js
@@ -13,6 +13,8 @@ const { filePathToPOSIX, isSameOrSubPath, getFileMTimeMs, shouldIgnoreFile } = r
  * @property {string} relPath
  * @property {string} folderId
  * @property {string} type
+ * @property {string} [oldPath] - Previous full path, only set for 'renamed' updates
+ * @property {string} [oldRelPath] - Previous path relative to the library folder, only set for 'renamed' updates
  */
 class FolderWatcher extends EventEmitter {
   constructor() {
@@ -218,14 +220,15 @@ class FolderWatcher extends EventEmitter {
    * Watcher detected file renamed
    *
    * @param {string} libraryId
-   * @param {string} path
+   * @param {string} pathFrom
+   * @param {string} pathTo
    */
   onFileRename(libraryId, pathFrom, pathTo) {
     if (this.checkShouldIgnorePath(pathTo)) {
       return
     }
     Logger.debug(`[Watcher] Rename ${pathFrom} => ${pathTo}`)
-    this.addFileUpdate(libraryId, pathTo, 'renamed')
+    this.addFileUpdate(libraryId, pathTo, 'renamed', pathFrom)
   }
 
   /**
@@ -263,9 +266,10 @@ class FolderWatcher extends EventEmitter {
    * @param {string} libraryId
    * @param {string} path
    * @param {string} type
+   * @param {string} [oldPath] - Previous full path, only used for 'renamed' updates
    * @returns {boolean} - If file was added to pending updates
    */
-  addFileUpdate(libraryId, path, type) {
+  addFileUpdate(libraryId, path, type, oldPath = null) {
     if (this.pendingFilePaths.includes(path)) return false
 
     // Get file library
@@ -307,13 +311,18 @@ class FolderWatcher extends EventEmitter {
       }
       this.pendingTask = TaskManager.createAndAddTask('watcher-scan', taskTitleString, null, true, taskData)
     }
-    this.pendingFileUpdates.push({
+    const pendingFileUpdate = {
       path,
       relPath,
       folderId: folder.id,
       libraryId,
       type
-    })
+    }
+    if (oldPath) {
+      pendingFileUpdate.oldPath = oldPath
+      pendingFileUpdate.oldRelPath = oldPath.replace(folderPath, '')
+    }
+    this.pendingFileUpdates.push(pendingFileUpdate)
 
     this.handlePendingFileUpdatesTimeout()
     return true

--- a/server/scanner/LibraryScanner.js
+++ b/server/scanner/LibraryScanner.js
@@ -415,7 +415,17 @@ class LibraryScanner {
         Logger.info(`[LibraryScanner] No important changes to scan for in folder "${folderId}"`)
         continue
       }
-      const folderScanResults = await this.scanFolderUpdates(library, folder, fileUpdateGroup)
+
+      // Map new relPath (as used in fileUpdateGroup) to the old relPath reported by the watcher for renamed files
+      const renamedPathsByRelPath = new Map()
+      folderGroups[folderId].fileUpdates.forEach((fileUpdate) => {
+        if (fileUpdate.type !== 'renamed' || !fileUpdate.oldRelPath) return
+        const relPath = fileUpdate.relPath.startsWith('/') ? fileUpdate.relPath.slice(1) : fileUpdate.relPath
+        const oldRelPath = fileUpdate.oldRelPath.startsWith('/') ? fileUpdate.oldRelPath.slice(1) : fileUpdate.oldRelPath
+        renamedPathsByRelPath.set(relPath, oldRelPath)
+      })
+
+      const folderScanResults = await this.scanFolderUpdates(library, folder, fileUpdateGroup, renamedPathsByRelPath)
       Logger.debug(`[LibraryScanner] Folder scan results`, folderScanResults)
 
       // Tally results to share with client
@@ -489,9 +499,10 @@ class LibraryScanner {
    * @param {import('../models/Library')} library
    * @param {import('../models/LibraryFolder')} folder
    * @param {Record<string, string[]>} fileUpdateGroup
+   * @param {Map<string,string>} [renamedPathsByRelPath] - new relPath -> old relPath, from watcher rename events in this folder
    * @returns {Promise<Record<string,number>>}
    */
-  async scanFolderUpdates(library, folder, fileUpdateGroup) {
+  async scanFolderUpdates(library, folder, fileUpdateGroup, renamedPathsByRelPath = new Map()) {
     // Make sure library filter data is set
     //   this is used to check for existing authors & series
     await libraryFilters.getFilterData(library.mediaType, library.id)
@@ -576,7 +587,7 @@ class LibraryScanner {
       let updatedLibraryItemDetails = {}
       if (!existingLibraryItem) {
         const isSingleMedia = isSingleMediaFile(fileUpdateGroup, itemDir)
-        existingLibraryItem = (await findLibraryItemByItemToItemInoMatch(library.id, fullPath)) || (await findLibraryItemByItemToFileInoMatch(library.id, fullPath, isSingleMedia)) || (await findLibraryItemByFileToItemInoMatch(library.id, fullPath, isSingleMedia, fileUpdateGroup[itemDir]))
+        existingLibraryItem = (await findLibraryItemByRenameOldPath(library.id, folder, itemDir, fileUpdateGroup, renamedPathsByRelPath)) || (await findLibraryItemByItemToItemInoMatch(library.id, fullPath)) || (await findLibraryItemByItemToFileInoMatch(library.id, fullPath, isSingleMedia)) || (await findLibraryItemByFileToItemInoMatch(library.id, fullPath, isSingleMedia, fileUpdateGroup[itemDir]))
         if (existingLibraryItem) {
           // Update library item paths for scan
           existingLibraryItem.path = fullPath
@@ -658,6 +669,92 @@ function hasAudioFiles(fileUpdateGroup, itemDir) {
 
 function isSingleMediaFile(fileUpdateGroup, itemDir) {
   return itemDir === fileUpdateGroup[itemDir]
+}
+
+/**
+ * Given the new item dir and the relPath/oldRelPath pair reported by the watcher for a renamed file inside it,
+ * derive the old item dir by truncating oldRelPath the same number of path segments that were truncated from
+ * relPath to produce itemDir. Assumes the rename did not change the item's directory depth.
+ *
+ * @param {string} itemDir
+ * @param {string} relPath
+ * @param {string} oldRelPath
+ * @returns {string|null}
+ */
+function deriveOldItemDir(itemDir, relPath, oldRelPath) {
+  const depthDiff = relPath.split('/').length - itemDir.split('/').length
+  if (depthDiff <= 0) return oldRelPath
+
+  const oldRelPathParts = oldRelPath.split('/')
+  if (oldRelPathParts.length <= depthDiff) return null
+
+  return oldRelPathParts.slice(0, oldRelPathParts.length - depthDiff).join('/')
+}
+
+/**
+ * Build a dir and its ancestor dirs up to the library folder root, mirroring the potentialChildDirs
+ * built for the new item dir, so an old item dir can be matched at any of the same depths
+ *
+ * @param {string} folderPath
+ * @param {string} dir
+ * @returns {string[]}
+ */
+function getPotentialDirPaths(folderPath, dir) {
+  const dirParts = dir.split('/').slice(0, -1)
+  const potentialDirs = [Path.posix.join(folderPath, dir)]
+  for (let i = 0; i < dirParts.length; i++) {
+    potentialDirs.push(Path.posix.join(folderPath, dir.split('/').slice(0, -1 - i).join('/')))
+  }
+  return potentialDirs
+}
+
+/**
+ * Look for an existing library item at the pre-rename path reported by the watcher for this item dir.
+ * Checked before the inode-based matchers because the old path is authoritative rename information,
+ * while inode matching is a heuristic that can fail on filesystems/operations where inodes change
+ *
+ * @param {string} libraryId
+ * @param {import('../models/LibraryFolder')} folder
+ * @param {string} itemDir
+ * @param {Record<string, string[]|string>} fileUpdateGroup
+ * @param {Map<string,string>} renamedPathsByRelPath - new relPath -> old relPath, from watcher rename events
+ * @returns {Promise<import('../models/LibraryItem')|null>}
+ */
+async function findLibraryItemByRenameOldPath(libraryId, folder, itemDir, fileUpdateGroup, renamedPathsByRelPath) {
+  if (!renamedPathsByRelPath.size) return null
+
+  const isSingleMedia = isSingleMediaFile(fileUpdateGroup, itemDir)
+  const relPaths = isSingleMedia ? [itemDir] : fileUpdateGroup[itemDir].map((subpath) => Path.posix.join(itemDir, subpath))
+
+  let matchedRelPath = null
+  let oldRelPath = null
+  for (const relPath of relPaths) {
+    if (renamedPathsByRelPath.has(relPath)) {
+      matchedRelPath = relPath
+      oldRelPath = renamedPathsByRelPath.get(relPath)
+      break
+    }
+  }
+  if (!oldRelPath) return null
+
+  const oldItemDir = deriveOldItemDir(itemDir, matchedRelPath, oldRelPath)
+  if (!oldItemDir) return null
+
+  const folderPath = fileUtils.filePathToPOSIX(folder.path)
+  const existingLibraryItem = await Database.libraryItemModel.findOneExpanded({
+    libraryId: libraryId,
+    path: getPotentialDirPaths(folderPath, oldItemDir)
+  })
+  if (!existingLibraryItem) return null
+
+  // Guard against adopting an item whose old path is still present on disk (e.g. a copy, not a real move)
+  if (await fs.pathExists(existingLibraryItem.path)) {
+    Logger.debug(`[LibraryScanner] Found library item "${existingLibraryItem.media.title}" at watcher rename old path "${existingLibraryItem.path}" but that path still exists - not adopting`)
+    return null
+  }
+
+  Logger.debug(`[LibraryScanner] Found library item "${existingLibraryItem.media.title}" at watcher rename old path "${existingLibraryItem.path}"`)
+  return existingLibraryItem
 }
 
 async function findLibraryItemByItemToItemInoMatch(libraryId, fullPath) {


### PR DESCRIPTION
## Brief summary

I'd call this hardening rather than a bug fix. On a plain local filesystem a folder rename keeps its inode, so the watcher path usually matches fine today; this closes the cases where inodes are not stable (copy+delete moves, some mounts) by using information the watcher already provides.

When the file watcher detects a rename it hands us both paths, but `Watcher.onFileRename()` throws the old path away. The scanner then has to reverse-engineer what happened from inode heuristics, which fail on filesystems and operations where inodes change. This PR carries the old path through the pending-update pipeline and checks it with an exact-path lookup before the inode matchers, so watcher-observed renames keep the item's identity deterministically.

## Which issue is fixed?

Part of #5379 (this covers the watcher path; companion PRs cover scan-time matching and progress recovery)

## In-depth Description

The old path is authoritative rename information and we already have it in hand; discarding it is just a loss. The change is additive plumbing:

- `addFileUpdate()` accepts an optional `oldPath` and stores `oldPath`/`oldRelPath` on the `PendingFileUpdate` (the other call sites are unchanged, the param defaults to null).
- `scanFilesChanged()` builds a small map of new relPath to old relPath for the folder group and passes it to `scanFolderUpdates()`.
- In the second pass, a new `findLibraryItemByRenameOldPath()` runs before the three inode matchers: it derives the old item directory from the renamed file's old relPath, checks it and its ancestor dirs (mirroring the existing `potentialChildDirs` pattern) with an exact-path DB lookup, and on a hit routes into the existing "update library item paths for scan" branch so the item keeps its id.

Failure modes all degrade to today's behavior:

- If the item found at the old path still exists on disk it is not adopted (a copy rather than a move legitimately produces two items).
- The old-dir derivation assumes the rename didn't change directory depth; when that doesn't hold it returns null and everything falls through to the inode matchers unchanged.
- Renames across library folders fall through to the existing heuristics as well.

This benefits anyone renaming media on a locally-watched filesystem, independent of my setup.

## How have you tested this?

- Runtime, on a scratch server built from this branch with the watcher live on a local filesystem: renamed a root-level single-file audiobook while the server was running. The watcher's rename event carried both paths, and the debug log confirms the new lookup matched the item at its old path before any inode matcher ran; the item kept its id, the path updated, and its finished status survived. Copying a file instead (so both paths stay alive) produced a separate new item and left the original untouched.
- No behavior change when no rename metadata is present: the new lookup returns null immediately when the rename map is empty, and all pre-existing call sites of `addFileUpdate` are unchanged since the new parameter defaults to null.
- Traced the data flow end to end against the watcher library's event contract (`rename` fires with both paths, both already POSIX-normalized at the listener) and the grouping in `scanFilesChanged`, confirming the relPath keys used by the lookup are built the same way `groupFileItemsIntoLibraryItemDirs` builds them.

## Screenshots

No web client changes, server-side only.
