### PR TITLE
Reuse missing library items on scan when a new folder matches by metadata or file fingerprint

### DIFF
--- a/server/scanner/BookScanner.js
+++ b/server/scanner/BookScanner.js
@@ -2,7 +2,7 @@ const uuidv4 = require('uuid').v4
 const Path = require('path')
 const sequelize = require('sequelize')
 const { LogLevel } = require('../utils/constants')
-const { getTitleIgnorePrefix, areEquivalent } = require('../utils/index')
+const { getTitleIgnorePrefix, areEquivalent, cleanStringForSearch } = require('../utils/index')
 const parseNameString = require('../utils/parsers/parseNameString')
 const parseEbookMetadata = require('../utils/parsers/parseEbookMetadata')
 const globals = require('../utils/globals')
@@ -471,6 +471,18 @@ class BookScanner {
 
     let duration = 0
     scannedAudioFiles.forEach((af) => (duration += !isNaN(af.duration) ? Number(af.duration) : 0))
+
+    // Check for a missing library item in this library that identity-matches this folder (e.g. a renamed/moved
+    // folder whose inodes changed) and reuse it instead of creating a duplicate, so progress/playlists/collections/
+    // RSS feeds keyed to the old item id are not stranded
+    const missingItemMatch = await this.findMissingBookLibraryItemMatch(libraryItemData.libraryId, bookMetadata, scannedAudioFiles, duration, libraryScan)
+    if (missingItemMatch) {
+      libraryScan.addLog(LogLevel.INFO, `Missing library item "${missingItemMatch.relPath}" matched new folder "${libraryItemData.relPath}" by metadata, reusing existing item`)
+      await libraryItemData.checkLibraryItemData(missingItemMatch, libraryScan)
+      const { libraryItem } = await this.rescanExistingBookLibraryItem(missingItemMatch, libraryItemData, librarySettings, libraryScan)
+      return libraryItem
+    }
+
     const bookObject = {
       ...bookMetadata,
       audioFiles: scannedAudioFiles,
@@ -645,6 +657,111 @@ class BookScanner {
     }
 
     return libraryItem
+  }
+
+  /**
+   * Find an unambiguous missing library item in this library that identity-matches new book metadata, so a
+   * renamed/moved folder with new inodes can be reused instead of creating a duplicate library item.
+   * Tiers are tried in order and the first tier to produce a result is used:
+   *  1. Both sides have a non-empty ASIN that matches (case-insensitive, trimmed) and duration is within 5s
+   *  2. Only when a side has no ASIN to compare: normalized title and normalized author names match and duration is within 5s
+   *  3. Metadata-independent file fingerprint: same audio file count, identical multiset of audio file sizes, and duration within 5s
+   * If a tier matches more than one candidate the match is ambiguous and adoption is skipped entirely.
+   * @param {string} libraryId
+   * @param {BookMetadataObject} bookMetadata
+   * @param {import('../models/Book').AudioFileObject[]} scannedAudioFiles
+   * @param {number} duration
+   * @param {LibraryScan} libraryScan
+   * @returns {Promise<import('../models/LibraryItem')>} null if no unambiguous match
+   */
+  async findMissingBookLibraryItemMatch(libraryId, bookMetadata, scannedAudioFiles, duration, libraryScan) {
+    // Query from the book side: the polymorphic libraryItem to book association does not eager-load
+    // (library item queries elsewhere use getMedia for the same reason), but book to libraryItem does
+    const missingItemBooks = await Database.bookModel.findAll({
+      include: [
+        {
+          model: Database.libraryItemModel,
+          required: true,
+          where: {
+            libraryId,
+            mediaType: 'book',
+            isMissing: true
+          }
+        },
+        {
+          model: Database.authorModel,
+          through: { attributes: [] }
+        }
+      ]
+    })
+    if (!missingItemBooks.length) return null
+
+    const newAsin = bookMetadata.asin ? cleanStringForSearch(bookMetadata.asin) : ''
+    const newTitle = cleanStringForSearch(bookMetadata.title)
+    const newAuthorsKey = bookMetadata.authors
+      .map((au) => cleanStringForSearch(au))
+      .sort()
+      .join('|')
+    const newAudioFileSizes = scannedAudioFiles.map((af) => af.metadata.size).sort((a, b) => a - b)
+
+    // Candidates where an ASIN comparison is possible (both sides non-empty) are decided by tier 1 alone and are
+    // never considered for tier 2/3 - a differing ASIN is a confident signal that it is a different book/edition
+    const asinComparableCandidates = []
+    const otherCandidates = []
+    for (const book of missingItemBooks) {
+      if (!book.libraryItem) continue
+      if (Math.abs((book.duration || 0) - duration) > 5) continue
+
+      const candidateAsin = book.asin ? cleanStringForSearch(book.asin) : ''
+      if (newAsin && candidateAsin) {
+        if (newAsin === candidateAsin) asinComparableCandidates.push(book)
+      } else {
+        otherCandidates.push(book)
+      }
+    }
+
+    if (asinComparableCandidates.length) {
+      if (asinComparableCandidates.length > 1) {
+        libraryScan.addLog(LogLevel.DEBUG, `Found ${asinComparableCandidates.length} missing library items matching new folder "${bookMetadata.title}" by ASIN - skipping adoption as ambiguous`)
+        return null
+      }
+      return asinComparableCandidates[0].libraryItem
+    }
+
+    const titleAuthorMatches = otherCandidates.filter((book) => {
+      const candidateAuthorsKey = (book.authors || [])
+        .map((au) => cleanStringForSearch(au.name))
+        .sort()
+        .join('|')
+      return cleanStringForSearch(book.title) === newTitle && candidateAuthorsKey === newAuthorsKey
+    })
+    if (titleAuthorMatches.length) {
+      if (titleAuthorMatches.length > 1) {
+        libraryScan.addLog(LogLevel.DEBUG, `Found ${titleAuthorMatches.length} missing library items matching new folder "${bookMetadata.title}" by title/author - skipping adoption as ambiguous`)
+        return null
+      }
+      return titleAuthorMatches[0].libraryItem
+    }
+
+    // File fingerprint requires at least one audio file - an empty size multiset would trivially match any
+    // missing ebook-only item with the same (zero) duration
+    if (!newAudioFileSizes.length) return null
+
+    const fingerprintMatches = otherCandidates.filter((book) => {
+      const candidateAudioFiles = book.audioFiles || []
+      if (candidateAudioFiles.length !== newAudioFileSizes.length) return false
+      const candidateSizes = candidateAudioFiles.map((af) => af.metadata.size).sort((a, b) => a - b)
+      return candidateSizes.every((size, i) => size === newAudioFileSizes[i])
+    })
+    if (fingerprintMatches.length) {
+      if (fingerprintMatches.length > 1) {
+        libraryScan.addLog(LogLevel.DEBUG, `Found ${fingerprintMatches.length} missing library items matching new folder "${bookMetadata.title}" by file fingerprint - skipping adoption as ambiguous`)
+        return null
+      }
+      return fingerprintMatches[0].libraryItem
+    }
+
+    return null
   }
 
   /**

--- a/server/scanner/LibraryScanner.js
+++ b/server/scanner/LibraryScanner.js
@@ -257,26 +257,42 @@ class LibraryScanner {
 
     // Add new library items
     if (libraryItemDataFound.length) {
+      // Ids of items missing before this phase - a returned item with one of these ids was adopted from a missing
+      // item (matched by metadata) rather than newly created, since new items always get a freshly generated id
+      const missingLibraryItemIds = new Set(existingLibraryItems.filter((li) => li.isMissing).map((li) => li.id).concat(libraryItemIdsMissing))
+
       let newLibraryItems = []
+      let adoptedLibraryItems = []
       for (const libraryItemData of libraryItemDataFound) {
         const newLibraryItem = await LibraryItemScanner.scanNewLibraryItem(libraryItemData, libraryScan.library.settings, libraryScan)
         if (newLibraryItem) {
-          newLibraryItems.push(newLibraryItem)
-
-          libraryScan.resultsAdded++
+          if (missingLibraryItemIds.has(newLibraryItem.id)) {
+            adoptedLibraryItems.push(newLibraryItem)
+            libraryScan.resultsUpdated++
+          } else {
+            newLibraryItems.push(newLibraryItem)
+            libraryScan.resultsAdded++
+          }
         }
 
-        // Emit new items in chunks of 10 to client
+        // Emit new/adopted items in chunks of 10 to client
         if (newLibraryItems.length === 10) {
           SocketAuthority.libraryItemsEmitter('items_added', newLibraryItems)
           newLibraryItems = []
         }
+        if (adoptedLibraryItems.length === 10) {
+          SocketAuthority.libraryItemsEmitter('items_updated', adoptedLibraryItems)
+          adoptedLibraryItems = []
+        }
 
         if (this.shouldCancelScan(libraryScan)) return true
       }
-      // Emit new items to client
+      // Emit new/adopted items to client
       if (newLibraryItems.length) {
         SocketAuthority.libraryItemsEmitter('items_added', newLibraryItems)
+      }
+      if (adoptedLibraryItems.length) {
+        SocketAuthority.libraryItemsEmitter('items_updated', adoptedLibraryItems)
       }
     }
 


### PR DESCRIPTION
## Brief summary

Unlike the inode matching fix, there's no broken code here: metadata-based identity across moves is something Audiobookshelf has never had, so treat this as a feature proposal. I'm making it because the filesystem-identity approach has a hard ceiling, however good the matchers get.

When a book's folder is moved in a way that survives no filesystem identity at all (cross-filesystem move, copy+delete reorganization, seedbox pull), the scanner marks the old item missing and creates a brand new item for the same book, stranding progress, playlists, collections, and RSS feeds on the missing item's id. This PR checks, before creating a new book item, whether an unambiguous missing item in the same library identity-matches the scanned folder, and if so updates that item in place instead of creating a duplicate.

## Which issue is fixed?

Part of #5379 (covers moves where inodes don't survive; companion PRs cover inode matching, the watcher path, and progress recovery)

## In-depth Description

This is the same problem class Jellyfin hit with watched state during their 10.11 cycle (jellyfin/jellyfin#15001, jellyfin/jellyfin#16149), and the shape of their solution is instructive: user data keys prefer provider IDs over filesystem identity, so an item that reappears under a new path can be recognized as the same logical media. Audiobookshelf already stores the equivalent stable identity (ASIN, plus rich media metadata), it just never consults it at scan time. This PR does that, at the point in `scanNewBookLibraryItem` where metadata and duration are first known.

Matching is tiered. The first decisive tier wins, and any tier with more than one candidate aborts adoption entirely, falling back to exactly today's behavior:

1. ASIN: both sides have a non-empty ASIN and they're equal (case-insensitive), and total audio duration is within 5 seconds. A candidate whose ASIN is present but different is excluded from the later tiers too; a disagreeing ASIN is a confident "different book" signal.
2. Title + authors (only where an ASIN comparison isn't possible): normalized title and normalized author set are equal, duration within 5 seconds.
3. File fingerprint, fully metadata-independent: identical audio file count, identical multiset of audio file byte sizes, duration within 5 seconds.

Tier 3 deserves a note, because it's what makes this work in practice. Metadata on the existing item is often curated by hand inside Audiobookshelf (matched against Audible etc.), while a newly scanned folder only has whatever the raw tags happen to say, so ASIN and even title frequently disagree for the same files. Byte sizes and durations don't: files that were moved or copied match exactly, while re-encoded or re-tagged files change size and correctly fall out of the tier. Zero-audio-file folders never fingerprint-match, so ebook-only edge cases can't trivially collide.

The candidate query is built from the book side (books joined to their missing library items), because the polymorphic libraryItem to book association does not eager-load; that's the same reason library item queries elsewhere in the codebase go through `getMedia`. On a match, the missing item goes through `checkLibraryItemData` plus the existing `rescanExistingBookLibraryItem` path, the same code ordinary matched items use, so path/ino/files all update and the item id and book id survive. Adopted items are counted and emitted as updated rather than added, so scan results and client sockets stay truthful. Books only; podcasts are untouched (episode identity is a different problem). The watcher's new-folder path funnels through the same book scanner, so live folder additions benefit too.

Known limitations, stated up front:

- Two editions sharing an ASIN with near-identical duration could in theory be confused at tier 1; in that situation there are usually two candidates, which the ambiguity rule turns into a no-op.
- The generic "Created new library item" log line still fires after adoption; distinguishing the two outcomes in that wrapper needs a wider signature change than this PR wants to make.

This affects anyone whose files move between filesystems or get reorganized by external tools, not just my setup.

## How have you tested this?

- Runtime, on a scratch server built from this branch: a finished book was moved by copy+delete (new file inode, new folder inode, and a rename to a different naming scheme including a "Last, First" author folder). On rescan the missing item was adopted in place: same item id, path updated, finished status intact, exactly one item in the library afterwards, the scan counted it as updated rather than added, and the "reusing existing item" log line fired. The match came through the file fingerprint tier, since the folder-derived metadata differed between the two layouts.
- Ambiguity, same server: two byte-identical missing books, then one new folder containing the same file. The scan logged "skipping adoption as ambiguous", created a plain new item, and left both missing items untouched.
- Worth knowing for review: the first version of this branch queried from the library item side with a book include, which silently returns items with no media attached (the polymorphic association doesn't eager-load). The runtime test caught it, and the query now goes from the book side, the same direction `cleanDatabase` uses.
- Also traced against a production database where a reorganization had duplicated 21 books, confirming the tiers select the correct missing item for every affected book (curated metadata on the old side only, which the fingerprint tier handles).

## Screenshots

No web client changes, server-side only.
