### PR TITLE
Relink media progress from missing library items when a matching book is rescanned

### DIFF
--- a/server/models/MediaProgress.js
+++ b/server/models/MediaProgress.js
@@ -1,6 +1,6 @@
 const { DataTypes, Model } = require('sequelize')
 const Logger = require('../Logger')
-const { isNullOrNaN } = require('../utils')
+const { isNullOrNaN, cleanStringForSearch } = require('../utils')
 
 class MediaProgress extends Model {
   constructor(values, options) {
@@ -44,6 +44,170 @@ class MediaProgress extends Model {
         id: mediaProgressId
       }
     })
+  }
+
+  /**
+   * When a new book library item is created by a scan, look for media progress left behind by
+   * missing (or deleted) library items in the same library and re-link it to the new book, so
+   * users don't lose their listening progress when a folder is recreated and rescanned.
+   *
+   * Candidates are matched using a tiered check (the first tier with any match wins):
+   *   1. Both ASINs non-empty and equal, and duration within 5 seconds
+   *   2. Only for books where ASIN can't be compared on at least one side: normalized title and
+   *      author names equal, and duration within 5 seconds
+   *   3. Only when neither tier above matched: same number of audio files with an identical set
+   *      of audio file byte sizes, and duration within 5 seconds - metadata-independent, catches
+   *      files that were moved or copied with no tag changes
+   * A tier with more than one match is ambiguous and is skipped entirely (nothing is relinked).
+   * Users who already have progress on the new book are left alone.
+   *
+   * Best-effort: failures are logged and swallowed so a scan is never broken by this.
+   *
+   * @param {import('./LibraryItem').LibraryItemExpanded} newExpandedLibraryItem
+   */
+  static async relinkFromMissingItems(newExpandedLibraryItem) {
+    if (newExpandedLibraryItem?.mediaType !== 'book' || !newExpandedLibraryItem.media) return
+
+    try {
+      const newBook = newExpandedLibraryItem.media
+      const bookModel = this.sequelize.models.book
+      const libraryItemModel = this.sequelize.models.libraryItem
+      const authorModel = this.sequelize.models.author
+
+      // Books left behind by missing library items in the same library
+      const missingItemBooks = await bookModel.findAll({
+        include: [
+          {
+            model: libraryItemModel,
+            required: true,
+            where: {
+              libraryId: newExpandedLibraryItem.libraryId,
+              isMissing: true
+            }
+          },
+          {
+            model: authorModel,
+            through: { attributes: [] }
+          }
+        ]
+      })
+
+      // Books whose library item no longer exists at all (library cannot be determined for these)
+      const orphanedBooks = await bookModel.findAll({
+        include: [
+          {
+            model: libraryItemModel,
+            required: false
+          },
+          {
+            model: authorModel,
+            through: { attributes: [] }
+          }
+        ],
+        where: { '$libraryItem.id$': null }
+      })
+
+      const candidateBooks = [...missingItemBooks, ...orphanedBooks]
+      if (!candidateBooks.length) return
+
+      const durationsMatch = (book) => Math.abs((book.duration || 0) - (newBook.duration || 0)) <= 5
+      const getAudioFileSizes = (book) =>
+        (book.audioFiles || [])
+          .map((af) => af.metadata?.size)
+          .filter((size) => !isNaN(size))
+          .sort((a, b) => a - b)
+      const getAuthorNamesKey = (book) =>
+        (book.authors || [])
+          .map((au) => cleanStringForSearch(au.name))
+          .sort()
+          .join(',')
+
+      const newAsin = newBook.asin?.trim().toLowerCase() || ''
+      const newTitle = cleanStringForSearch(newBook.title)
+      const newAuthorNamesKey = getAuthorNamesKey(newBook)
+      const newAudioFileSizes = getAudioFileSizes(newBook)
+
+      // Sort candidates into tier 1 matches, tier 2 candidates (ASIN not comparable on one side)
+      // and books explicitly excluded by a disagreeing ASIN (never matched at any tier)
+      const tier1Matches = []
+      const tier2Candidates = []
+      const excludedByAsinMismatch = new Set()
+      for (const book of candidateBooks) {
+        const asin = book.asin?.trim().toLowerCase() || ''
+        if (newAsin && asin) {
+          if (asin === newAsin && durationsMatch(book)) {
+            tier1Matches.push(book)
+          } else if (asin !== newAsin) {
+            excludedByAsinMismatch.add(book.id)
+          }
+        } else {
+          tier2Candidates.push(book)
+        }
+      }
+
+      let winningTierMatches = tier1Matches
+
+      if (!winningTierMatches.length) {
+        winningTierMatches = tier2Candidates.filter((book) => cleanStringForSearch(book.title) === newTitle && getAuthorNamesKey(book) === newAuthorNamesKey && durationsMatch(book))
+      }
+
+      if (!winningTierMatches.length && newAudioFileSizes.length) {
+        winningTierMatches = candidateBooks.filter((book) => {
+          if (excludedByAsinMismatch.has(book.id)) return false
+          const audioFileSizes = getAudioFileSizes(book)
+          return JSON.stringify(audioFileSizes) === JSON.stringify(newAudioFileSizes) && durationsMatch(book)
+        })
+      }
+
+      if (winningTierMatches.length !== 1) {
+        if (winningTierMatches.length > 1) {
+          Logger.debug(`[MediaProgress] Not relinking media progress for new book "${newBook.title}" because ${winningTierMatches.length} missing/orphaned books matched`)
+        }
+        return
+      }
+
+      const oldBook = winningTierMatches[0]
+
+      const oldProgresses = await this.findAll({
+        where: {
+          mediaItemId: oldBook.id,
+          mediaItemType: 'book'
+        }
+      })
+      if (!oldProgresses.length) return
+
+      const existingUserIds = (
+        await this.findAll({
+          attributes: ['userId'],
+          where: {
+            mediaItemId: newBook.id,
+            mediaItemType: 'book'
+          }
+        })
+      ).map((mp) => mp.userId)
+
+      const progressesToRelink = oldProgresses.filter((mp) => !existingUserIds.includes(mp.userId))
+      if (!progressesToRelink.length) return
+
+      // Per-row updates rather than one bulk update: extraData is serialized to clients as the
+      // progress row's libraryItemId (see toOldJSON), so it has to be repointed at the new library
+      // item, and the JSON merge preserving each row's other extraData keys is per-row by nature
+      await Promise.all(
+        progressesToRelink.map((mp) =>
+          mp.update({
+            mediaItemId: newBook.id,
+            extraData: { ...(mp.extraData || {}), libraryItemId: newExpandedLibraryItem.id }
+          })
+        )
+      )
+
+      // Cached user objects hold their media progress rows, so evict affected users to avoid serving stale progress
+      this.sequelize.models.user.mediaProgressesRelinked(progressesToRelink.map((mp) => mp.userId))
+
+      Logger.info(`[MediaProgress] Relinked media progress for ${progressesToRelink.length} user${progressesToRelink.length === 1 ? '' : 's'} from missing item "${oldBook.title}" to new library item "${newExpandedLibraryItem.path}"`)
+    } catch (error) {
+      Logger.error(`[MediaProgress] Failed to relink media progress for new library item "${newExpandedLibraryItem.path}"`, error)
+    }
   }
 
   /**

--- a/server/models/User.js
+++ b/server/models/User.js
@@ -499,6 +499,21 @@ class User extends Model {
   }
 
   /**
+   * Evict cached users whose media progress rows were updated outside of the user instance,
+   * e.g. re-linked to a different media item by the scanner, so they reload fresh on next request
+   *
+   * @param {string[]} userIds
+   */
+  static mediaProgressesRelinked(userIds) {
+    for (const userId of userIds) {
+      if (userCache.getById(userId)) {
+        Logger.debug(`[User] mediaProgressesRelinked: invalidating cached user ${userId}`)
+        userCache.delete(userId)
+      }
+    }
+  }
+
+  /**
    * Initialize model
    * @param {import('../Database').sequelize} sequelize
    */

--- a/server/scanner/LibraryItemScanner.js
+++ b/server/scanner/LibraryItemScanner.js
@@ -192,6 +192,10 @@ class LibraryItemScanner {
     }
     if (newLibraryItem) {
       libraryScan.addLog(LogLevel.INFO, `Created new library item "${newLibraryItem.relPath}" with id "${newLibraryItem.id}"`)
+
+      if (newLibraryItem.mediaType === 'book') {
+        await Database.mediaProgressModel.relinkFromMissingItems(newLibraryItem)
+      }
     }
     return newLibraryItem
   }


### PR DESCRIPTION
## Brief summary

The stranded progress feels like a bug from the user's chair, but the mechanism here is new functionality, so I'd file this under enhancement: it cleans up after a data-loss situation rather than fixing broken code.

When the scanner cannot connect a new item to the missing item it replaced, the mediaProgresses rows quietly stay pointed at the old book id forever: the association is declared with `constraints: false` and nothing anywhere re-links or even notices orphaned progress, so users see a book they finished show up as never started. This PR adds a safety net: when a scan creates a new book library item, progress attached to identity-matching missing or orphaned books in the same library is migrated to the new book, per user.

## Which issue is fixed?

Part of #5379 (the recovery layer; companion PRs improve matching so this fires as rarely as possible)

## In-depth Description

Jellyfin dealt with exactly this failure mode after their 10.11 database rewrite: watched state was lost whenever an item was replaced or renamed and the item ids diverged (jellyfin/jellyfin#15001, jellyfin/jellyfin#16149, and the nastier variant jellyfin/jellyfin#15795 where stale user-data rows blocked new ones). Their fix wasn't to make item ids immortal; it was to actively migrate disconnected user data to the surviving item (jellyfin/jellyfin#14339, follow-up jellyfin/jellyfin#16071). This PR is the Audiobookshelf equivalent.

A new static `MediaProgress.relinkFromMissingItems(newExpandedLibraryItem)` is called from `scanNewLibraryItem` right after a new book item is created. Candidates are books under missing library items in the same library, plus books whose library item row no longer exists at all (found with the same `'$libraryItem.id$': null` pattern `cleanDatabase` already uses). Identity matching uses the same tiers as the adoption PR, for consistency: ASIN + duration within 5 seconds; then title + authors + duration where ASIN can't be compared; then the metadata-independent file fingerprint (audio file count and exact byte-size multiset + duration). A present-but-different ASIN excludes a candidate outright, and any ambiguity means nothing is touched. The metadata-independent tier matters here for the same reason as in the adoption PR: existing items often carry hand-curated metadata that raw file tags will never reproduce.

Migration is deliberately conservative:

- Only `mediaItemId` changes, plus `extraData.libraryItemId` which is repointed at the new library item because the serializer exposes it to clients; currentTime, isFinished, finishedAt and ebook position are preserved as-is. Rows are updated individually so each row's other `extraData` keys survive the JSON merge.
- Affected users are evicted from the in-memory user cache afterwards (a new `User.mediaProgressesRelinked`, modeled on the existing `mediaProgressRemoved` helper). Cached user objects carry their progress rows, so without this the API keeps serving the stale rows until the cache turns over; Jellyfin hit the same thing and fixed it by rehydrating user data after reattachment (jellyfin/jellyfin#16071).
- A user who already has progress on the new book is never overwritten; only users with no row on the new book get their old row moved.
- The whole routine is wrapped so any failure logs and returns; a scan can never break on this path.
- Books only; podcasts are excluded at the call site and inside the method.

If the matching PRs connect the item at scan time, the item id never changes and this code never fires. It acts only when a genuinely new item appears while a matching missing or orphaned book is holding progress, and it's the only piece of the set that can heal libraries that already have stranded progress from past renames: the next time the affected book's folder is rescanned as new, its history comes back.

One accepted tradeoff, same as Jellyfin's relink: if the old missing item later reappears on disk after its progress moved (a backup restore, say), it rescans clean but shows as unstarted, since its progress now lives on the newer item. Progress follows the copy people are actually listening to.

## How have you tested this?

- Runtime, on a scratch server built from this branch: finished a book, deleted its folder (item marked missing on scan), then added a copy of the same file under a new folder and file name with new inodes. The scan created a new item and the relink fired: the API immediately shows the progress on the new item, finished with the original finishedAt preserved to the millisecond, and the database rows confirm `mediaItemId` and `extraData.libraryItemId` both point at the new item.
- The user-cache eviction exists because the runtime test caught the failure mode: without it the database was correct but the API kept reporting the progress on the old item, since cached user objects hold their own progress rows. With the eviction in place the very next request reflects the move.
- Verified the matching tiers against a production database where a reorganization duplicated 21 books holding progress for five users: the old and new copies share identical audio files, so the fingerprint tier selects the correct source for every affected book even where curated metadata differs between the copies.

## Screenshots

No web client changes, server-side only.
