### PR TITLE
Carry finished status to a replacement edition when playback position cannot transfer

### DIFF
--- a/client/pages/config/index.vue
+++ b/client/pages/config/index.vue
@@ -80,6 +80,16 @@
             </ui-tooltip>
           </div>
 
+          <div role="article" :aria-label="$strings.LabelSettingsCarryFinishedToNewEditionsHelp" class="flex items-center py-2">
+            <ui-toggle-switch :label="$strings.LabelSettingsCarryFinishedToNewEditions" v-model="newServerSettings.scannerCarryFinishedToNewEditions" :disabled="updatingServerSettings" @input="(val) => updateSettingsKey('scannerCarryFinishedToNewEditions', val)" />
+            <ui-tooltip aria-hidden="true" :text="$strings.LabelSettingsCarryFinishedToNewEditionsHelp">
+              <p class="pl-4">
+                <span id="settings-carry-finished-to-new-editions">{{ $strings.LabelSettingsCarryFinishedToNewEditions }}</span>
+                <span class="material-symbols icon-text">info</span>
+              </p>
+            </ui-tooltip>
+          </div>
+
           <div role="article" :aria-label="$strings.LabelSettingsEnableWatcherHelp" class="flex items-center py-2">
             <ui-toggle-switch :label="$strings.LabelSettingsEnableWatcher" v-model="scannerEnableWatcher" :disabled="updatingServerSettings" @input="(val) => updateSettingsKey('scannerDisableWatcher', !val)" />
             <ui-tooltip aria-hidden="true" :text="$strings.LabelSettingsEnableWatcherHelp">

--- a/client/strings/en-us.json
+++ b/client/strings/en-us.json
@@ -586,6 +586,8 @@
   "LabelSettingsAudiobooksOnly": "Audiobooks only",
   "LabelSettingsAudiobooksOnlyHelp": "Enabling this setting will ignore ebook files unless they are inside an audiobook folder in which case they will be set as supplementary ebooks",
   "LabelSettingsBookshelfViewHelp": "Skeumorphic design with wooden shelves",
+  "LabelSettingsCarryFinishedToNewEditions": "Carry finished status to replacement editions",
+  "LabelSettingsCarryFinishedToNewEditionsHelp": "When a book is replaced by a different edition and playback position cannot be carried over, move the finished status of users who finished the old edition to the new one.",
   "LabelSettingsChromecastSupport": "Chromecast support",
   "LabelSettingsDateFormat": "Date Format",
   "LabelSettingsEnableWatcher": "Automatically watch libraries for changes",

--- a/server/models/MediaProgress.js
+++ b/server/models/MediaProgress.js
@@ -1,6 +1,6 @@
 const { DataTypes, Model } = require('sequelize')
 const Logger = require('../Logger')
-const { isNullOrNaN } = require('../utils')
+const { isNullOrNaN, cleanStringForSearch } = require('../utils')
 
 class MediaProgress extends Model {
   constructor(values, options) {
@@ -44,6 +44,170 @@ class MediaProgress extends Model {
         id: mediaProgressId
       }
     })
+  }
+
+  /**
+   * When a new book library item is created by a scan, look for media progress left behind by
+   * missing (or deleted) library items in the same library and re-link it to the new book, so
+   * users don't lose their listening progress when a folder is recreated and rescanned.
+   *
+   * Candidates are matched using a tiered check (the first tier with any match wins):
+   *   1. Both ASINs non-empty and equal, and duration within 5 seconds
+   *   2. Only for books where ASIN can't be compared on at least one side: normalized title and
+   *      author names equal, and duration within 5 seconds
+   *   3. Only when neither tier above matched: same number of audio files with an identical set
+   *      of audio file byte sizes, and duration within 5 seconds - metadata-independent, catches
+   *      files that were moved or copied with no tag changes
+   * A tier with more than one match is ambiguous and is skipped entirely (nothing is relinked).
+   * Users who already have progress on the new book are left alone.
+   *
+   * Best-effort: failures are logged and swallowed so a scan is never broken by this.
+   *
+   * @param {import('./LibraryItem').LibraryItemExpanded} newExpandedLibraryItem
+   */
+  static async relinkFromMissingItems(newExpandedLibraryItem) {
+    if (newExpandedLibraryItem?.mediaType !== 'book' || !newExpandedLibraryItem.media) return
+
+    try {
+      const newBook = newExpandedLibraryItem.media
+      const bookModel = this.sequelize.models.book
+      const libraryItemModel = this.sequelize.models.libraryItem
+      const authorModel = this.sequelize.models.author
+
+      // Books left behind by missing library items in the same library
+      const missingItemBooks = await bookModel.findAll({
+        include: [
+          {
+            model: libraryItemModel,
+            required: true,
+            where: {
+              libraryId: newExpandedLibraryItem.libraryId,
+              isMissing: true
+            }
+          },
+          {
+            model: authorModel,
+            through: { attributes: [] }
+          }
+        ]
+      })
+
+      // Books whose library item no longer exists at all (library cannot be determined for these)
+      const orphanedBooks = await bookModel.findAll({
+        include: [
+          {
+            model: libraryItemModel,
+            required: false
+          },
+          {
+            model: authorModel,
+            through: { attributes: [] }
+          }
+        ],
+        where: { '$libraryItem.id$': null }
+      })
+
+      const candidateBooks = [...missingItemBooks, ...orphanedBooks]
+      if (!candidateBooks.length) return
+
+      const durationsMatch = (book) => Math.abs((book.duration || 0) - (newBook.duration || 0)) <= 5
+      const getAudioFileSizes = (book) =>
+        (book.audioFiles || [])
+          .map((af) => af.metadata?.size)
+          .filter((size) => !isNaN(size))
+          .sort((a, b) => a - b)
+      const getAuthorNamesKey = (book) =>
+        (book.authors || [])
+          .map((au) => cleanStringForSearch(au.name))
+          .sort()
+          .join(',')
+
+      const newAsin = newBook.asin?.trim().toLowerCase() || ''
+      const newTitle = cleanStringForSearch(newBook.title)
+      const newAuthorNamesKey = getAuthorNamesKey(newBook)
+      const newAudioFileSizes = getAudioFileSizes(newBook)
+
+      // Sort candidates into tier 1 matches, tier 2 candidates (ASIN not comparable on one side)
+      // and books explicitly excluded by a disagreeing ASIN (never matched at any tier)
+      const tier1Matches = []
+      const tier2Candidates = []
+      const excludedByAsinMismatch = new Set()
+      for (const book of candidateBooks) {
+        const asin = book.asin?.trim().toLowerCase() || ''
+        if (newAsin && asin) {
+          if (asin === newAsin && durationsMatch(book)) {
+            tier1Matches.push(book)
+          } else if (asin !== newAsin) {
+            excludedByAsinMismatch.add(book.id)
+          }
+        } else {
+          tier2Candidates.push(book)
+        }
+      }
+
+      let winningTierMatches = tier1Matches
+
+      if (!winningTierMatches.length) {
+        winningTierMatches = tier2Candidates.filter((book) => cleanStringForSearch(book.title) === newTitle && getAuthorNamesKey(book) === newAuthorNamesKey && durationsMatch(book))
+      }
+
+      if (!winningTierMatches.length && newAudioFileSizes.length) {
+        winningTierMatches = candidateBooks.filter((book) => {
+          if (excludedByAsinMismatch.has(book.id)) return false
+          const audioFileSizes = getAudioFileSizes(book)
+          return JSON.stringify(audioFileSizes) === JSON.stringify(newAudioFileSizes) && durationsMatch(book)
+        })
+      }
+
+      if (winningTierMatches.length !== 1) {
+        if (winningTierMatches.length > 1) {
+          Logger.debug(`[MediaProgress] Not relinking media progress for new book "${newBook.title}" because ${winningTierMatches.length} missing/orphaned books matched`)
+        }
+        return
+      }
+
+      const oldBook = winningTierMatches[0]
+
+      const oldProgresses = await this.findAll({
+        where: {
+          mediaItemId: oldBook.id,
+          mediaItemType: 'book'
+        }
+      })
+      if (!oldProgresses.length) return
+
+      const existingUserIds = (
+        await this.findAll({
+          attributes: ['userId'],
+          where: {
+            mediaItemId: newBook.id,
+            mediaItemType: 'book'
+          }
+        })
+      ).map((mp) => mp.userId)
+
+      const progressesToRelink = oldProgresses.filter((mp) => !existingUserIds.includes(mp.userId))
+      if (!progressesToRelink.length) return
+
+      // Per-row updates rather than one bulk update: extraData is serialized to clients as the
+      // progress row's libraryItemId (see toOldJSON), so it has to be repointed at the new library
+      // item, and the JSON merge preserving each row's other extraData keys is per-row by nature
+      await Promise.all(
+        progressesToRelink.map((mp) =>
+          mp.update({
+            mediaItemId: newBook.id,
+            extraData: { ...(mp.extraData || {}), libraryItemId: newExpandedLibraryItem.id }
+          })
+        )
+      )
+
+      // Cached user objects hold their media progress rows, so evict affected users to avoid serving stale progress
+      this.sequelize.models.user.mediaProgressesRelinked(progressesToRelink.map((mp) => mp.userId))
+
+      Logger.info(`[MediaProgress] Relinked media progress for ${progressesToRelink.length} user${progressesToRelink.length === 1 ? '' : 's'} from missing item "${oldBook.title}" to new library item "${newExpandedLibraryItem.path}"`)
+    } catch (error) {
+      Logger.error(`[MediaProgress] Failed to relink media progress for new library item "${newExpandedLibraryItem.path}"`, error)
+    }
   }
 
   /**

--- a/server/models/MediaProgress.js
+++ b/server/models/MediaProgress.js
@@ -61,6 +61,20 @@ class MediaProgress extends Model {
    * A tier with more than one match is ambiguous and is skipped entirely (nothing is relinked).
    * Users who already have progress on the new book are left alone.
    *
+   * If none of the tiers above find a match, a second, looser pass runs to carry over only the
+   * "finished" flag (not the full progress row). This pass is opt-in via the
+   * scannerCarryFinishedToNewEditions server setting (default off) and is skipped entirely when
+   * disabled. It covers a book being replaced by a different edition of the same work (remaster,
+   * re-encode, different narration length), where duration legitimately falls outside the 5 second
+   * window and playback position cannot transfer, but "finished" is a fact about the work rather
+   * than the recording. The match rule for this pass is normalized title and author names equal,
+   * with no duration constraint, and, unlike the tiers above, a disagreeing ASIN does not exclude a
+   * candidate (different editions of the same audiobook legitimately have different ASINs). Only
+   * rows with isFinished true are carried, and only for users with no existing row on the new book -
+   * in-progress rows are left on the old book since their position is not meaningful for a different
+   * recording. More than one matching book is ambiguous and is skipped entirely, same as the tiers
+   * above.
+   *
    * Best-effort: failures are logged and swallowed so a scan is never broken by this.
    *
    * @param {import('./LibraryItem').LibraryItemExpanded} newExpandedLibraryItem
@@ -159,10 +173,73 @@ class MediaProgress extends Model {
         })
       }
 
-      if (winningTierMatches.length !== 1) {
-        if (winningTierMatches.length > 1) {
-          Logger.debug(`[MediaProgress] Not relinking media progress for new book "${newBook.title}" because ${winningTierMatches.length} missing/orphaned books matched`)
+      if (winningTierMatches.length > 1) {
+        Logger.debug(`[MediaProgress] Not relinking media progress for new book "${newBook.title}" because ${winningTierMatches.length} missing/orphaned books matched`)
+        return
+      }
+
+      if (!winningTierMatches.length) {
+        if (!global.ServerSettings.scannerCarryFinishedToNewEditions) return
+
+        // No candidate was a close enough duration match to relink the full progress row. This is
+        // expected when a book was replaced by a different edition of the same work (remaster,
+        // re-encode, different narration), so fall back to a looser, finished-only pass: same
+        // candidate pool, title/author match with no duration constraint. An ASIN mismatch is
+        // deliberately NOT exclusionary here (unlike the tiers above) since different editions of
+        // the same audiobook legitimately ship with different ASINs.
+        const finishedCarryMatches = candidateBooks.filter((book) => cleanStringForSearch(book.title) === newTitle && getAuthorNamesKey(book) === newAuthorNamesKey)
+
+        if (finishedCarryMatches.length !== 1) {
+          if (finishedCarryMatches.length > 1) {
+            Logger.debug(`[MediaProgress] Not carrying finished status for new book "${newBook.title}" because ${finishedCarryMatches.length} missing/orphaned books matched by title/author`)
+          }
+          return
         }
+
+        const finishedCarryOldBook = finishedCarryMatches[0]
+
+        const oldFinishedProgresses = await this.findAll({
+          where: {
+            mediaItemId: finishedCarryOldBook.id,
+            mediaItemType: 'book',
+            isFinished: true
+          }
+        })
+        if (!oldFinishedProgresses.length) return
+
+        const existingNewBookUserIds = (
+          await this.findAll({
+            attributes: ['userId'],
+            where: {
+              mediaItemId: newBook.id,
+              mediaItemType: 'book'
+            }
+          })
+        ).map((mp) => mp.userId)
+
+        const progressesToCarry = oldFinishedProgresses.filter((mp) => !existingNewBookUserIds.includes(mp.userId))
+        if (!progressesToCarry.length) return
+
+        // Move each row to the new book, mirroring how the mark-as-finished API path represents a
+        // finished item (see applyProgressUpdate above): isFinished true and extraData.progress 1.
+        // finishedAt is preserved from the old row instead of being reset to now. currentTime and
+        // duration are left untouched, same as that path, since the UI treats isFinished as 100%
+        // complete on its own and playback start ignores currentTime for a finished item anyway.
+        await Promise.all(
+          progressesToCarry.map((mp) =>
+            mp.update({
+              mediaItemId: newBook.id,
+              isFinished: true,
+              extraData: { ...(mp.extraData || {}), progress: 1, libraryItemId: newExpandedLibraryItem.id }
+            })
+          )
+        )
+
+        // Cached user objects hold their media progress rows, so evict affected users to avoid serving stale progress
+        this.sequelize.models.user.mediaProgressesRelinked(progressesToCarry.map((mp) => mp.userId))
+
+        Logger.info(`[MediaProgress] Carried finished status for ${progressesToCarry.length} user${progressesToCarry.length === 1 ? '' : 's'} from a different edition "${finishedCarryOldBook.title}" to new library item "${newExpandedLibraryItem.path}" (duration did not match closely enough to relink playback position)`)
+
         return
       }
 

--- a/server/models/User.js
+++ b/server/models/User.js
@@ -499,6 +499,21 @@ class User extends Model {
   }
 
   /**
+   * Evict cached users whose media progress rows were updated outside of the user instance,
+   * e.g. re-linked to a different media item by the scanner, so they reload fresh on next request
+   *
+   * @param {string[]} userIds
+   */
+  static mediaProgressesRelinked(userIds) {
+    for (const userId of userIds) {
+      if (userCache.getById(userId)) {
+        Logger.debug(`[User] mediaProgressesRelinked: invalidating cached user ${userId}`)
+        userCache.delete(userId)
+      }
+    }
+  }
+
+  /**
    * Initialize model
    * @param {import('../Database').sequelize} sequelize
    */

--- a/server/objects/settings/ServerSettings.js
+++ b/server/objects/settings/ServerSettings.js
@@ -17,6 +17,7 @@ class ServerSettings {
     this.scannerCoverProvider = 'google'
     this.scannerPreferMatchedMetadata = false
     this.scannerDisableWatcher = false
+    this.scannerCarryFinishedToNewEditions = false
 
     // Metadata - choose to store inside users library item folder
     this.storeCoverWithItem = false
@@ -96,6 +97,7 @@ class ServerSettings {
     this.scannerParseSubtitle = settings.scannerParseSubtitle
     this.scannerPreferMatchedMetadata = !!settings.scannerPreferMatchedMetadata
     this.scannerDisableWatcher = !!settings.scannerDisableWatcher
+    this.scannerCarryFinishedToNewEditions = !!settings.scannerCarryFinishedToNewEditions
 
     this.storeCoverWithItem = !!settings.storeCoverWithItem
     this.storeMetadataWithItem = !!settings.storeMetadataWithItem
@@ -213,6 +215,7 @@ class ServerSettings {
       scannerParseSubtitle: this.scannerParseSubtitle,
       scannerPreferMatchedMetadata: this.scannerPreferMatchedMetadata,
       scannerDisableWatcher: this.scannerDisableWatcher,
+      scannerCarryFinishedToNewEditions: this.scannerCarryFinishedToNewEditions,
       storeCoverWithItem: this.storeCoverWithItem,
       storeMetadataWithItem: this.storeMetadataWithItem,
       metadataFileFormat: this.metadataFileFormat,

--- a/server/scanner/LibraryItemScanner.js
+++ b/server/scanner/LibraryItemScanner.js
@@ -192,6 +192,10 @@ class LibraryItemScanner {
     }
     if (newLibraryItem) {
       libraryScan.addLog(LogLevel.INFO, `Created new library item "${newLibraryItem.relPath}" with id "${newLibraryItem.id}"`)
+
+      if (newLibraryItem.mediaType === 'book') {
+        await Database.mediaProgressModel.relinkFromMissingItems(newLibraryItem)
+      }
     }
     return newLibraryItem
   }


### PR DESCRIPTION
## Brief summary

This one is a pure enhancement, and an opinionated one: it changes what users see after an edition swap. Because of that it ships disabled, behind a new server setting (`scannerCarryFinishedToNewEditions`) that admins opt into from the Scanner settings section.

When a book is replaced by a different edition of the same work (a better-quality release, a remaster, a different encode length), the progress relink safety net correctly refuses to move playback positions, since a timestamp into one recording is meaningless in another. But whether a user *finished the book* is a fact about the work, not the recording, and today it's lost along with everything else. This PR adds a finished-only carry-over pass for exactly that case.

## Which issue is fixed?

Part of #5379. Builds on #5383 (the progress relink safety net); only the finished-carry pass is new here.

## In-depth Description

The relink method's tiered matching requires total duration within 5 seconds, which is the right bar for moving a full progress row: same recording, positions transfer. When no tier matches, this PR runs a second, deliberately looser pass over the same candidate pool (books of missing items in the library, plus orphaned books):

- Match rule: normalized title and normalized author set equal, with no duration constraint. Unlike the full-relink tiers, a disagreeing ASIN does not exclude a candidate here, and that difference is the point: different editions of the same audiobook legitimately ship with different ASINs, so for cross-edition identity the work-level signal (title + authors) is the right key and ASIN disagreement is expected rather than disqualifying.
- More than one matching book is ambiguous and does nothing, same convention as the tiers.
- Only rows with `isFinished` true move, and only for users with no existing row on the new book. In-progress rows stay on the old book untouched; their positions cannot mean anything in a different recording.

The moved rows mirror exactly how the mark-as-finished API path represents a finished item (`applyProgressUpdate`: `isFinished` true, `extraData.progress` 1, `currentTime`/`duration` untouched), because the client renders `isFinished` as 100% on its own and playback start ignores stored position for finished items. `finishedAt` is preserved from the original row rather than reset, so "finished in Feb 2024" stays true. `extraData.libraryItemId` is repointed at the new library item since the serializer exposes it to clients.

Everything runs inside the relink method's existing containment: books only, any failure logs and returns, a scan can never break on this path.

The toggle is wired the same way as the existing scanner settings: `scannerCarryFinishedToNewEditions` on ServerSettings (default false, absent keys on existing installs coerce to false so there's no migration), read via `global.ServerSettings` in the model (the same pattern `storeMetadataWithItem` uses, since models can't require Database without a cycle), with a checkbox next to its scanner siblings in the web client config page and an en-us string (other locales fall through, per the repo's convention for new settings). Older web clients simply don't render the toggle and never send the key, so the setting stays off for them.

## How have you tested this?

- Runtime, setting off (the default), on a scratch server built from this branch: replaced a finished book's folder with a different-duration edition (60s to 90s, same title and author tags). The scan created a new item, nothing carried, and the carry pass logged nothing; it is fully inert until opted into.
- Runtime, setting on (enabled through the settings API, persisted and round-tripped): repeated the swap with a different book (45s to 75s edition) and two users, one finished and one mid-listen. The finished user's flag appeared on the new edition with the original finishedAt preserved exactly; the mid-listen user was untouched, keeping their position on the old item with no row created on the new one; the carry log line fired; and the API reflected all of it immediately (the relink PR's user-cache eviction is reused here).
- Ambiguity: two byte-identical missing books with the same title and author, then one new different-duration edition. The pass logged "skipping" as ambiguous and carried nothing.
- The field representation mirrors the real mark-finished flow (client toggle payload through `PATCH /api/me/progress/:id` into `createUpdateMediaProgress` and `applyProgressUpdate`) and matches how the client and `PlaybackSessionManager` consume `isFinished`.

## Screenshots

The new toggle in Settings > Scanner (enabled state), from the built web client running against this branch:

![Scanner settings with the new carry-finished toggle](https://raw.githubusercontent.com/mels0n/audiobookshelf/pr-assets/settings-scanner-toggle.png)
