### PR TITLE
Enforce per-item access checks on bulk library download

### DIFF
--- a/server/controllers/LibraryController.js
+++ b/server/controllers/LibraryController.js
@@ -1432,13 +1432,16 @@ class LibraryController {
 
     const itemIds = req.query.ids.split(',')
 
-    const libraryItems = await Database.libraryItemModel.findAll({
-      attributes: ['id', 'libraryId', 'path', 'isFile'],
-      where: {
-        id: itemIds,
-        libraryId: req.library.id
-      }
+    const libraryItems = await Database.libraryItemModel.findAllExpandedWhere({
+      id: itemIds,
+      libraryId: req.library.id
     })
+
+    for (const libraryItem of libraryItems) {
+      if (!req.user.checkCanAccessLibraryItem(libraryItem)) {
+        return res.sendStatus(403)
+      }
+    }
 
     if (libraryItems.length < itemIds.length) {
       Logger.warn(`[LibraryController] User "${req.user.username}" requested ${itemIds.length} items but only ${libraryItems.length} are in library "${req.library.id}"`)

--- a/test/server/controllers/LibraryController.test.js
+++ b/test/server/controllers/LibraryController.test.js
@@ -1,0 +1,178 @@
+const { expect } = require('chai')
+const { Sequelize } = require('sequelize')
+const sinon = require('sinon')
+
+const Database = require('../../../server/Database')
+const LibraryController = require('../../../server/controllers/LibraryController')
+const zipHelpers = require('../../../server/utils/zipHelpers')
+const Logger = require('../../../server/Logger')
+
+describe('LibraryController.downloadMultiple', () => {
+  let library
+  let libraryFolder
+  let allowedItemId
+  let explicitItemId
+  let taggedItemId
+  let restrictedUser
+  let libraryRecord
+
+  beforeEach(async () => {
+    global.ServerSettings = {}
+    Database.sequelize = new Sequelize({ dialect: 'sqlite', storage: ':memory:', logging: false })
+    Database.sequelize.uppercaseFirst = (str) => (str ? `${str[0].toUpperCase()}${str.substr(1)}` : '')
+    await Database.buildModels()
+
+    library = await Database.libraryModel.create({ name: 'Test Library', mediaType: 'book' })
+    libraryFolder = await Database.libraryFolderModel.create({ path: '/test-lib', libraryId: library.id })
+    libraryRecord = await Database.libraryModel.findByIdWithFolders(library.id)
+
+    const allowedBook = await Database.bookModel.create({
+      title: 'Allowed Book',
+      explicit: false,
+      audioFiles: [],
+      tags: ['allowed-tag'],
+      narrators: [],
+      genres: [],
+      chapters: []
+    })
+    const allowedItem = await Database.libraryItemModel.create({
+      path: '/test-lib/allowed',
+      isFile: false,
+      libraryFiles: [],
+      mediaId: allowedBook.id,
+      mediaType: 'book',
+      libraryId: library.id,
+      libraryFolderId: libraryFolder.id
+    })
+    allowedItemId = allowedItem.id
+
+    const explicitBook = await Database.bookModel.create({
+      title: 'Explicit Book',
+      explicit: true,
+      audioFiles: [],
+      tags: [],
+      narrators: [],
+      genres: [],
+      chapters: []
+    })
+    const explicitItem = await Database.libraryItemModel.create({
+      path: '/test-lib/explicit',
+      isFile: false,
+      libraryFiles: [],
+      mediaId: explicitBook.id,
+      mediaType: 'book',
+      libraryId: library.id,
+      libraryFolderId: libraryFolder.id
+    })
+    explicitItemId = explicitItem.id
+
+    const taggedBook = await Database.bookModel.create({
+      title: 'Tagged Book',
+      explicit: false,
+      audioFiles: [],
+      tags: ['restricted-tag'],
+      narrators: [],
+      genres: [],
+      chapters: []
+    })
+    const taggedItem = await Database.libraryItemModel.create({
+      path: '/test-lib/tagged',
+      isFile: false,
+      libraryFiles: [],
+      mediaId: taggedBook.id,
+      mediaType: 'book',
+      libraryId: library.id,
+      libraryFolderId: libraryFolder.id
+    })
+    taggedItemId = taggedItem.id
+
+    const permissions = Database.userModel.getDefaultPermissionsForUserType('user')
+    permissions.download = true
+    permissions.accessExplicitContent = false
+    permissions.accessAllLibraries = false
+    permissions.accessAllTags = false
+    permissions.librariesAccessible = [library.id]
+    permissions.itemTagsSelected = ['allowed-tag']
+    permissions.selectedTagsNotAccessible = false
+
+    restrictedUser = await Database.userModel.create({
+      username: 'restricted',
+      pash: 'hash',
+      token: 'token',
+      type: 'user',
+      isActive: true,
+      permissions,
+      bookmarks: [],
+      extraData: {}
+    })
+
+    sinon.stub(Logger, 'info')
+    sinon.stub(Logger, 'warn')
+    sinon.stub(Logger, 'error')
+    sinon.stub(zipHelpers, 'zipDirectoriesPipe').resolves()
+  })
+
+  afterEach(async () => {
+    sinon.restore()
+    await Database.sequelize.sync({ force: true })
+  })
+
+  function makeReq(ids) {
+    return {
+      query: { ids: ids.join(',') },
+      user: restrictedUser,
+      library: libraryRecord
+    }
+  }
+
+  function makeRes() {
+    return {
+      sendStatus: sinon.spy(),
+      status: sinon.stub().returnsThis(),
+      send: sinon.spy()
+    }
+  }
+
+  it('returns 403 for bulk download of an explicit item', async () => {
+    const req = makeReq([explicitItemId])
+    const res = makeRes()
+
+    await LibraryController.downloadMultiple(req, res)
+
+    expect(res.sendStatus.calledWith(403)).to.be.true
+    expect(zipHelpers.zipDirectoriesPipe.called).to.be.false
+  })
+
+  it('returns 403 for bulk download of a tag-restricted item', async () => {
+    const req = makeReq([taggedItemId])
+    const res = makeRes()
+
+    await LibraryController.downloadMultiple(req, res)
+
+    expect(res.sendStatus.calledWith(403)).to.be.true
+    expect(zipHelpers.zipDirectoriesPipe.called).to.be.false
+  })
+
+  it('returns 403 when bulk download includes both allowed and forbidden items', async () => {
+    const req = makeReq([allowedItemId, explicitItemId])
+    const res = makeRes()
+
+    await LibraryController.downloadMultiple(req, res)
+
+    expect(res.sendStatus.calledWith(403)).to.be.true
+    expect(zipHelpers.zipDirectoriesPipe.called).to.be.false
+  })
+
+  it('starts zip download for allowed items only', async () => {
+    const req = makeReq([allowedItemId])
+    const res = makeRes()
+
+    await LibraryController.downloadMultiple(req, res)
+
+    expect(res.sendStatus.called).to.be.false
+    expect(zipHelpers.zipDirectoriesPipe.calledOnce).to.be.true
+    const pathObjects = zipHelpers.zipDirectoriesPipe.firstCall.args[0]
+    expect(pathObjects).to.have.length(1)
+    expect(pathObjects[0].path).to.equal('/test-lib/allowed')
+  })
+})


### PR DESCRIPTION
## Brief summary

This fixes a permissions bypass where users could download library items via the bulk download endpoint (`GET /api/libraries/:id/download`) even when those items were blocked by explicit-content or tag restrictions.

## Which issue is fixed?

No issue.

## In-depth Description

- Fix missing per-item access enforcement in `LibraryController.downloadMultiple()` - the endpoint only verified library membership, not whether the user could access each requested item
- Load expanded library items via `findAllExpandedWhere()` so media metadata (explicit flag, tags) is available for permission checks
  - *Note: I chose to load the fully expanded items even though most of the expanded item is not needed. The main reason being to make it future-proof, and since the query seems not to be a very expensive one. I can change to a slimmer query if you think that makes more sense.*
- Call `req.user.checkCanAccessLibraryItem()` for every requested item before starting the zip; return 403 if any item is forbidden (including mixed allowed + forbidden requests)
- Add regression tests covering explicit items, tag-restricted items, mixed bulk requests (403), and allowed-only downloads (200)

## How have you tested this?

This now passes regression testing (part of CI).
`npx mocha test/server/controllers/LibraryController.test.js`