### PR TITLE
Prevent text selection of icon glyphs (player controls highlight)

### DIFF
--- a/client/assets/fonts.css
+++ b/client/assets/fonts.css
@@ -18,6 +18,8 @@
   direction: ltr;
   -webkit-font-smoothing: antialiased;
   vertical-align: top;
+  user-select: none;
+  -webkit-user-select: none;
 }
 
 .material-symbols.fill {


### PR DESCRIPTION
### Problem

Icons are rendered via the `material-symbols` icon font, where each glyph is ligature **text** (e.g. `pause`, `replay`, `forward_media`). Because the base `.material-symbols` class did not set `user-select`, clicking or double-clicking an icon selected that underlying text, producing a distracting blue selection box over the audio player controls (and every other icon in the UI).

### Fix

Add `user-select: none` (and `-webkit-user-select: none`) to the base `.material-symbols` class in `client/assets/fonts.css`. Icon glyphs should never be selectable text, so this is safe to apply globally and fixes the highlight everywhere icons are used, including the player playback controls.

### Notes

- CSS-only change, no logic touched.
- Verified the before/after selection behavior using the real icon font.