### PR TITLE
fix: upgrade cipher-base to 1.0.5 (CVE-2025-9287)

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -13,6 +13,7 @@
         "@nuxtjs/proxy": "^2.1.0",
         "@tailwindcss/postcss": "^4.0.13",
         "@teckel/vue-pdf": "^4.3.5",
+        "cipher-base": "^1.0.5",
         "core-js": "^3.16.0",
         "cron-parser": "^4.7.1",
         "date-fns": "^2.25.0",
@@ -7185,13 +7186,37 @@
       }
     },
     "node_modules/cipher-base": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
-      "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.5.tgz",
+      "integrity": "sha512-xq7ICKB4TMHUx7Tz1L9O2SGKOhYMOTR32oir45Bq28/AQTpHogKgHcoYFSdRbMtddl+ozNXfXY9jWcgYKmde0w==",
+      "license": "MIT",
       "dependencies": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
+        "inherits": "^2.0.4",
+        "safe-buffer": "^5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
       }
+    },
+    "node_modules/cipher-base/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/class-utils": {
       "version": "0.3.6",

--- a/client/package.json
+++ b/client/package.json
@@ -21,6 +21,7 @@
     "@nuxtjs/proxy": "^2.1.0",
     "@tailwindcss/postcss": "^4.0.13",
     "@teckel/vue-pdf": "^4.3.5",
+    "cipher-base": "^1.0.5",
     "core-js": "^3.16.0",
     "cron-parser": "^4.7.1",
     "date-fns": "^2.25.0",


### PR DESCRIPTION
## Summary
Upgrade cipher-base from 1.0.4 to 1.0.5 to fix CVE-2025-9287.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | CVE-2025-9287 |
| **Severity** | CRITICAL |
| **Scanner** | trivy |
| **Rule** | `CVE-2025-9287` |
| **File** | `client/package-lock.json` |
| **Assessment** | Likely exploitable |

**Description**: cipher-base: Cipher-base hash manipulation

## Evidence

**Scanner confirmation**: trivy rule `CVE-2025-9287` flagged this pattern.

**Production code**: This file is in the production codebase, not test-only code.

## Threat Model Context

This is a web service - vulnerabilities in request handlers are directly exploitable by remote attackers.

## Changes
- `client/package.json`
- `client/package-lock.json`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*This change addresses a pattern flagged by static analysis. The code path handles user-influenced input and the fix reduces the attack surface against both manual and automated exploitation.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
