### PR TITLE
Add logout all devices button and extend auth logout endpoint

### DIFF
--- a/client/pages/account.vue
+++ b/client/pages/account.vue
@@ -69,8 +69,9 @@
         </app-settings-content>
       </div>
 
-      <div class="py-4 mt-8 flex">
-        <ui-btn color="bg-primary flex items-center text-lg" @click="logout"><span class="material-symbols mr-4 icon-text">logout</span>{{ $strings.ButtonLogout }}</ui-btn>
+      <div class="py-4 mt-8 flex flex-wrap gap-2">
+        <ui-btn v-if="!isGuest" color="bg-primary flex items-center text-lg" :disabled="loggingOut" @click="logout(true)"> <span class="material-symbols mr-4 icon-text">devices</span>{{ $strings.ButtonLogoutAllDevices }} </ui-btn>
+        <ui-btn color="bg-primary flex items-center text-lg" :disabled="loggingOut" @click="logout"><span class="material-symbols mr-4 icon-text">logout</span>{{ $strings.ButtonLogout }}</ui-btn>
       </div>
 
       <modals-emails-user-e-reader-device-modal v-model="showEReaderDeviceModal" :existing-devices="revisedEreaderDevices" :ereader-device="selectedEReaderDevice" @update="ereaderDevicesUpdated" />
@@ -87,6 +88,7 @@ export default {
       newPassword: null,
       confirmPassword: null,
       changingPassword: false,
+      loggingOut: false,
       selectedLanguage: '',
       newEReaderDevice: {
         name: '',
@@ -135,7 +137,7 @@ export default {
     updateLocalLanguage(lang) {
       this.$setLanguageCode(lang)
     },
-    logout() {
+    logout(allDevices = false) {
       // Disconnect from socket
       if (this.$root.socket) {
         console.log('Disconnecting from socket', this.$root.socket.id)
@@ -149,8 +151,10 @@ export default {
       this.$store.commit('libraries/setUserPlaylists', [])
       this.$store.commit('libraries/setCollections', [])
 
+      this.loggingOut = true
+      const url = allDevices ? '/logout?allDevices=1' : '/logout'
       this.$axios
-        .$post('/logout')
+        .$post(url)
         .then((logoutPayload) => {
           const redirect_url = logoutPayload.redirect_url
 
@@ -162,6 +166,9 @@ export default {
         })
         .catch((error) => {
           console.error(error)
+        })
+        .finally(() => {
+          this.loggingOut = false
         })
     },
     resetForm() {

--- a/client/strings/en-us.json
+++ b/client/strings/en-us.json
@@ -46,6 +46,7 @@
   "ButtonLatest": "Latest",
   "ButtonLibrary": "Library",
   "ButtonLogout": "Logout",
+  "ButtonLogoutAllDevices": "Logout All Devices",
   "ButtonLookup": "Lookup",
   "ButtonManageTracks": "Manage Tracks",
   "ButtonMapChapterTitles": "Map Chapter Titles",

--- a/server/Auth.js
+++ b/server/Auth.js
@@ -471,18 +471,23 @@ class Auth {
       res.json(openIdIssuerConfig)
     })
 
-    // Logout route
+    /**
+     * Logout route
+     * Use ?allDevices=1 to destroy every session for this user instead of just the current one
+     */
     router.post('/logout', async (req, res) => {
       // Refresh token be alternatively be sent in the header
       const refreshToken = req.cookies.refresh_token || req.headers['x-refresh-token']
+      const allDevices = req.query.allDevices === '1'
 
       // Clear refresh token cookie
       res.clearCookie('refresh_token', {
         path: '/'
       })
 
-      // Invalidate the session in database using refresh token
-      if (refreshToken) {
+      if (allDevices) {
+        await this.tokenManager.invalidateAllSessionsForRefreshToken(refreshToken)
+      } else if (refreshToken) {
         await this.tokenManager.invalidateRefreshToken(refreshToken)
       } else {
         Logger.info(`[Auth] logout: No refresh token on request`)

--- a/server/auth/TokenManager.js
+++ b/server/auth/TokenManager.js
@@ -506,6 +506,25 @@ class TokenManager {
   }
 
   /**
+   * Destroy all JWT sessions for the user that owns this refresh token
+   *
+   * @param {string} refreshToken
+   */
+  async invalidateAllSessionsForRefreshToken(refreshToken) {
+    if (!refreshToken) return
+
+    const session = await Database.sessionModel.findOne({
+      where: {
+        [Op.or]: [{ refreshToken: refreshToken }, { lastRefreshToken: refreshToken }]
+      }
+    })
+    if (!session) return
+
+    const numDeleted = await Database.sessionModel.destroy({ where: { userId: session.userId } })
+    Logger.info(`[TokenManager] Invalidated all JWT sessions for user ${session.userId}, ${numDeleted} deleted`)
+  }
+
+  /**
    * Invalidate a refresh token - used for logout
    *
    * @param {string} refreshToken


### PR DESCRIPTION
## Brief summary

Account page has a logout all devices button

## Which issue is fixed?

This addresses auth improvements discussed in https://github.com/advplyr/audiobookshelf/issues/5281#issuecomment-5052019404

## In-depth Description

Logout API endpoint now supports a query parameter `?allDevices=1` that will destroy all sessions for the user.

Other devices are not immediately logged out. They will be forced to re-login when their access token expires.

## Screenshots

<img width="527" height="191" alt="image" src="https://github.com/user-attachments/assets/d1b35944-1b09-41e1-8469-ac3a53f2b8e9" />
