### PR TITLE
Add folder-based library view

### DIFF
--- a/client/components/app/BookShelfToolbar.vue
+++ b/client/components/app/BookShelfToolbar.vue
@@ -9,6 +9,10 @@
         <p v-if="isLibraryPage || isPodcastLibrary" class="text-sm">{{ $strings.ButtonLibrary }}</p>
         <span v-else class="material-symbols text-lg">import_contacts</span>
       </nuxt-link>
+      <nuxt-link :to="`/library/${currentLibraryId}/folders`" class="grow h-full flex justify-center items-center" :class="isFoldersPage ? 'bg-primary/80' : 'bg-primary/40'">
+        <p v-if="isFoldersPage" class="text-sm">{{ $strings.LabelFolders }}</p>
+        <span v-else class="material-symbols text-lg">folder</span>
+      </nuxt-link>
       <nuxt-link v-if="isPodcastLibrary" :to="`/library/${currentLibraryId}/podcast/latest`" class="grow h-full flex justify-center items-center" :class="isPodcastLatestPage ? 'bg-primary/80' : 'bg-primary/40'">
         <p class="text-sm">{{ $strings.ButtonLatest }}</p>
       </nuxt-link>
@@ -37,7 +41,12 @@
     </div>
     <div id="toolbar" role="toolbar" aria-label="Library Toolbar" class="absolute top-10 md:top-0 left-0 w-full h-10 md:h-full z-40 flex items-center justify-end md:justify-start px-2 md:px-8">
       <!-- Series books page -->
-      <template v-if="selectedSeries">
+      <template v-if="isFoldersPage">
+        <slot name="folders">
+          <p class="pl-2 text-base md:text-lg">{{ $strings.LabelFolders }}</p>
+        </slot>
+      </template>
+      <template v-else-if="selectedSeries">
         <p class="pl-2 text-base md:text-lg">
           {{ seriesName }}
         </p>
@@ -238,6 +247,9 @@ export default {
     },
     isLibraryPage() {
       return this.page === ''
+    },
+    isFoldersPage() {
+      return this.page === 'folders'
     },
     isSeriesPage() {
       return this.page === 'series'

--- a/client/components/app/SideRail.vue
+++ b/client/components/app/SideRail.vue
@@ -28,6 +28,14 @@
         <div v-show="showLibrary" class="h-full w-0.5 bg-yellow-400 absolute top-0 left-0" />
       </nuxt-link>
 
+      <nuxt-link :to="`/library/${currentLibraryId}/folders`" class="w-full h-20 flex flex-col items-center justify-center text-white/80 border-b border-primary/70 hover:bg-primary cursor-pointer relative" :class="isFoldersPage ? 'bg-primary/80' : 'bg-bg/60'">
+        <span class="material-symbols text-2xl">folder</span>
+
+        <p class="pt-1.5 text-center leading-4" style="font-size: 0.9rem">{{ $strings.LabelFolders }}</p>
+
+        <div v-show="isFoldersPage" class="h-full w-0.5 bg-yellow-400 absolute top-0 left-0" />
+      </nuxt-link>
+
       <nuxt-link v-if="isBookLibrary" :to="`/library/${currentLibraryId}/bookshelf/series`" class="w-full h-20 flex flex-col items-center justify-center text-white/80 border-b border-primary/70 hover:bg-primary cursor-pointer relative" :class="isSeriesPage ? 'bg-primary/80' : 'bg-bg/60'">
         <span class="material-symbols text-2xl">view_column</span>
 
@@ -173,6 +181,9 @@ export default {
     },
     isNarratorsPage() {
       return this.$route.name === 'library-library-narrators'
+    },
+    isFoldersPage() {
+      return this.$route.name === 'library-library-folders'
     },
     isPlaylistsPage() {
       return this.paramId === 'playlists'

--- a/client/components/cards/FolderBookCard.vue
+++ b/client/components/cards/FolderBookCard.vue
@@ -1,0 +1,58 @@
+<template>
+  <nuxt-link :to="`/item/${item.id}`" class="block group min-w-0" :style="{ width: cardWidth + 'px' }">
+    <div class="relative rounded-sm overflow-hidden bg-primary box-shadow-book" :style="{ width: cardWidth + 'px', height: cardHeight + 'px' }">
+      <covers-book-cover :library-item="libraryItem" :width="cardWidth" :book-cover-aspect-ratio="bookCoverAspectRatio" />
+
+      <div class="absolute inset-0 z-20 bg-black/0 group-hover:bg-black/35 transition-colors flex items-center justify-center">
+        <span class="material-symbols fill text-5xl opacity-0 group-hover:opacity-90 transition-opacity">
+          {{ item.mediaType === 'podcast' ? 'podcasts' : 'menu_book' }}
+        </span>
+      </div>
+    </div>
+
+    <p class="mt-3 text-base md:text-lg font-semibold truncate group-hover:text-yellow-200">{{ item.title }}</p>
+    <p class="text-xs md:text-sm text-white/55 truncate">{{ item.author || item.diskName }}</p>
+  </nuxt-link>
+</template>
+
+<script>
+export default {
+  props: {
+    item: {
+      type: Object,
+      required: true
+    },
+    height: {
+      type: Number,
+      default: 192
+    }
+  },
+  computed: {
+    sizeMultiplier() {
+      return this.$store.getters['user/getSizeMultiplier']
+    },
+    bookCoverAspectRatio() {
+      return this.$store.getters['libraries/getBookCoverAspectRatio']
+    },
+    cardHeight() {
+      return Math.round(this.height * this.sizeMultiplier)
+    },
+    cardWidth() {
+      return Math.round(this.cardHeight / this.bookCoverAspectRatio)
+    },
+    libraryItem() {
+      return {
+        id: this.item.id,
+        updatedAt: this.item.updatedAt,
+        media: {
+          coverPath: this.item.hasCover ? 'indexed' : null,
+          metadata: {
+            title: this.item.title,
+            authors: this.item.author ? [{ name: this.item.author }] : []
+          }
+        }
+      }
+    }
+  }
+}
+</script>

--- a/client/components/cards/FolderCard.vue
+++ b/client/components/cards/FolderCard.vue
@@ -1,0 +1,66 @@
+<template>
+  <button type="button" class="block text-left group" :style="{ width: cardSize + 'px' }" :aria-label="`${folder.name}, ${numBooks} ${$strings.LabelBooks}`" @click="$emit('click', folder)">
+    <div class="relative rounded-sm overflow-hidden bg-primary box-shadow-book" :style="{ width: cardSize + 'px', height: cardSize + 'px' }">
+      <covers-group-cover :id="folder.key" :name="folder.name" :book-items="coverItems" :width="cardSize" :height="cardSize" :book-cover-aspect-ratio="bookCoverAspectRatio" />
+
+      <div class="absolute inset-0 z-20 folder-cover-overlay opacity-40 group-hover:opacity-100 transition-opacity">
+        <div class="absolute inset-0 bg-black/20 group-hover:bg-black/45 transition-colors" />
+        <span class="material-symbols fill absolute bottom-3 left-3 text-4xl text-yellow-200 drop-shadow-md">folder</span>
+      </div>
+
+      <div class="absolute z-30 top-2 right-2 rounded-full min-w-7 h-7 px-2 font-semibold text-white flex items-center justify-center box-shadow-md" style="background-color: #cd9d49dd">
+        {{ numBooks }}
+      </div>
+    </div>
+
+    <p class="mt-3 text-base md:text-lg font-semibold truncate group-hover:text-yellow-200">{{ folder.name }}</p>
+    <p class="text-xs md:text-sm text-white/55">{{ numBooks }} {{ $strings.LabelBooks }}</p>
+  </button>
+</template>
+
+<script>
+export default {
+  props: {
+    folder: {
+      type: Object,
+      required: true
+    },
+    size: {
+      type: Number,
+      default: 192
+    }
+  },
+  computed: {
+    sizeMultiplier() {
+      return this.$store.getters['user/getSizeMultiplier']
+    },
+    cardSize() {
+      return Math.round(this.size * this.sizeMultiplier)
+    },
+    bookCoverAspectRatio() {
+      return this.$store.getters['libraries/getBookCoverAspectRatio']
+    },
+    numBooks() {
+      return this.folder.items?.length || 0
+    },
+    coverItems() {
+      return (this.folder.items || [])
+        .filter((item) => item.hasCover)
+        .map((item) => ({
+          id: item.id,
+          updatedAt: item.updatedAt,
+          media: {
+            // GroupCover only needs a truthy coverPath before constructing the item cover URL.
+            coverPath: 'indexed'
+          }
+        }))
+    }
+  }
+}
+</script>
+
+<style scoped>
+.folder-cover-overlay {
+  background: linear-gradient(to top, rgb(0 0 0 / 45%), transparent 55%);
+}
+</style>

--- a/client/pages/library/_library/folders.vue
+++ b/client/pages/library/_library/folders.vue
@@ -1,0 +1,256 @@
+<template>
+  <div class="page relative" :class="streamLibraryItem ? 'streaming' : ''">
+    <app-book-shelf-toolbar page="folders">
+      <template #folders>
+        <div class="folder-toolbar">
+          <p class="folder-toolbar-count">{{ $formatNumber(currentFolderBookCount) }} {{ $strings.LabelBooks }}</p>
+          <nav aria-label="Folder breadcrumb" class="folder-breadcrumbs">
+            <button type="button" class="breadcrumb-link" @click="openRoot">
+              <span class="material-symbols text-lg mr-1">folder_open</span>
+              {{ library.name }}
+            </button>
+            <template v-if="currentRoot">
+              <span class="material-symbols breadcrumb-separator">chevron_right</span>
+              <button type="button" class="breadcrumb-link" @click="openPath(0)">{{ currentRoot.name }}</button>
+            </template>
+            <template v-for="(segment, index) in currentPath">
+              <span :key="`separator-${index}`" class="material-symbols breadcrumb-separator">chevron_right</span>
+              <button :key="`segment-${index}`" type="button" class="breadcrumb-link max-w-64 truncate" @click="openPath(index + 1)">
+                {{ segment }}
+              </button>
+            </template>
+          </nav>
+          <span class="folder-toolbar-balance" aria-hidden="true"></span>
+        </div>
+      </template>
+    </app-book-shelf-toolbar>
+
+    <div id="bookshelf" class="w-full h-full px-4 py-6 md:p-8 relative overflow-y-auto">
+      <div v-if="!loading && (visibleFolders.length || visibleItems.length)" class="folder-grid" :style="{ gridTemplateColumns: `repeat(auto-fill, ${tileSize}px)` }">
+        <cards-folder-card v-for="folder in visibleFolders" :key="folder.key" :folder="folder" @click="openFolder" />
+
+        <cards-folder-book-card v-for="item in visibleItems" :key="item.id" :item="item" />
+      </div>
+
+      <div v-if="!loading && !visibleFolders.length && !visibleItems.length" class="w-full h-full flex flex-col items-center justify-center text-white/50">
+        <span class="material-symbols text-6xl mb-3">folder_off</span>
+        <p class="text-lg">{{ $strings.MessageNoItems }}</p>
+      </div>
+    </div>
+
+    <div v-if="loading" class="absolute top-0 left-0 w-full h-[calc(100%-40px)] mt-10 flex items-center justify-center bg-black/25">
+      <ui-loading-indicator />
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  async asyncData({ store, params, redirect }) {
+    const libraryId = params.library
+    const libraryData = await store.dispatch('libraries/fetch', libraryId)
+    if (!libraryData) {
+      return redirect(`/oops?message=Library "${libraryId}" not found`)
+    }
+    return {
+      library: libraryData.library
+    }
+  },
+  data() {
+    return {
+      loading: true,
+      roots: [],
+      items: [],
+      currentRootId: null,
+      currentPath: []
+    }
+  },
+  computed: {
+    streamLibraryItem() {
+      return this.$store.state.streamLibraryItem
+    },
+    currentLibraryId() {
+      return this.$store.state.libraries.currentLibraryId
+    },
+    sizeMultiplier() {
+      return this.$store.getters['user/getSizeMultiplier']
+    },
+    tileSize() {
+      return Math.round(192 * this.sizeMultiplier)
+    },
+    currentRoot() {
+      return this.roots.find((root) => root.id === this.currentRootId) || null
+    },
+    itemsInRoot() {
+      if (!this.currentRootId) return []
+      return this.items.filter((item) => item.folderId === this.currentRootId)
+    },
+    visibleFolders() {
+      if (!this.currentRoot) {
+        return this.roots
+          .map((root) => ({
+            key: root.id,
+            name: root.name,
+            rootId: root.id,
+            path: [],
+            items: this.items.filter((item) => item.folderId === root.id)
+          }))
+          .sort(this.sortByName)
+      }
+
+      const folders = new Map()
+      for (const item of this.itemsInRoot) {
+        const segments = this.pathSegments(item.relPath)
+        if (!this.pathStartsWith(segments, this.currentPath) || segments.length <= this.currentPath.length + 1) continue
+        const name = segments[this.currentPath.length]
+        const path = [...this.currentPath, name]
+        if (!folders.has(name)) {
+          folders.set(name, {
+            key: `${this.currentRootId}:${path.join('/')}`,
+            name,
+            rootId: this.currentRootId,
+            path,
+            items: []
+          })
+        }
+        folders.get(name).items.push(item)
+      }
+      return [...folders.values()].sort(this.sortByName)
+    },
+    visibleItems() {
+      if (!this.currentRoot) return []
+      return this.itemsInRoot
+        .filter((item) => {
+          const segments = this.pathSegments(item.relPath)
+          return segments.length === this.currentPath.length + 1 && this.pathStartsWith(segments, this.currentPath)
+        })
+        .map((item) => ({
+          ...item,
+          diskName: this.pathSegments(item.relPath).slice(-1)[0] || item.title
+        }))
+        .sort((a, b) => this.sortByName({ name: a.diskName }, { name: b.diskName }))
+    },
+    currentFolderBookCount() {
+      if (!this.currentRoot) return this.items.length
+
+      return this.itemsInRoot.filter((item) => {
+        const segments = this.pathSegments(item.relPath)
+        return this.pathStartsWith(segments, this.currentPath)
+      }).length
+    }
+  },
+  watch: {
+    currentLibraryId(newValue, oldValue) {
+      if (newValue && newValue !== oldValue) this.init()
+    }
+  },
+  methods: {
+    sortByName(a, b) {
+      return a.name.localeCompare(b.name, undefined, { numeric: true, sensitivity: 'base' })
+    },
+    pathSegments(relPath) {
+      return (relPath || '').split('/').filter(Boolean)
+    },
+    pathStartsWith(path, parent) {
+      return parent.every((segment, index) => path[index] === segment)
+    },
+    openRoot() {
+      this.currentRootId = null
+      this.currentPath = []
+    },
+    openPath(length) {
+      this.currentPath = this.currentPath.slice(0, length)
+    },
+    openFolder(folder) {
+      this.currentRootId = folder.rootId
+      this.currentPath = [...folder.path]
+    },
+    async init() {
+      this.loading = true
+      this.openRoot()
+      const payload = await this.$axios.$get(`/api/libraries/${this.currentLibraryId}/folders`).catch((error) => {
+        console.error('Failed to load library folders', error)
+        this.$toast.error(this.$strings.ToastFailedToLoadData)
+        return { folders: [], items: [] }
+      })
+      this.roots = payload.folders || []
+      this.items = payload.items || []
+      this.loading = false
+    }
+  },
+  mounted() {
+    this.init()
+  }
+}
+</script>
+
+<style scoped>
+.folder-toolbar {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  min-width: 0;
+}
+
+.folder-toolbar-count,
+.folder-toolbar-balance {
+  flex: 0 0 9rem;
+}
+
+.folder-toolbar-count {
+  color: rgb(229 231 235);
+  font-size: 1.125rem;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.folder-breadcrumbs {
+  display: flex;
+  flex: 1 1 auto;
+  align-items: center;
+  justify-content: center;
+  min-width: 0;
+  overflow-x: auto;
+  padding: 0 0.5rem;
+  white-space: nowrap;
+  font-size: 1rem;
+}
+
+.folder-grid {
+  display: grid;
+  align-items: start;
+  gap: 2.5rem 2rem;
+}
+
+.breadcrumb-link {
+  display: inline-flex;
+  align-items: center;
+  color: rgb(253 224 71);
+}
+
+.breadcrumb-link:hover {
+  text-decoration: underline;
+}
+
+.breadcrumb-separator {
+  margin: 0 0.25rem;
+  color: rgb(255 255 255 / 35%);
+  font-size: 1.125rem;
+}
+
+@media (max-width: 767px) {
+  .folder-toolbar-count,
+  .folder-toolbar-balance {
+    display: none;
+  }
+
+  .folder-breadcrumbs {
+    justify-content: flex-start;
+  }
+
+  .folder-grid {
+    justify-content: center;
+    gap: 2rem 1rem;
+  }
+}
+</style>

--- a/server/controllers/LibraryController.js
+++ b/server/controllers/LibraryController.js
@@ -639,6 +639,62 @@ class LibraryController {
   }
 
   /**
+   * GET: /api/libraries/:id/folders
+   *
+   * Returns the indexed on-disk location of each accessible library item.
+   * The client derives intermediate directories from relPath, so absolute
+   * library paths never have to be exposed.
+   *
+   * @param {LibraryControllerRequest} req
+   * @param {Response} res
+   */
+  async getFolderTree(req, res) {
+    const libraryItems = await Database.libraryItemModel.findAll({
+      where: {
+        libraryId: req.library.id
+      },
+      attributes: ['id', 'libraryId', 'libraryFolderId', 'relPath', 'path', 'mediaId', 'mediaType', 'isMissing', 'isInvalid', 'updatedAt', 'authorNamesFirstLast'],
+      include: [
+        {
+          model: Database.bookModel,
+          attributes: ['title', 'tags', 'explicit', 'coverPath']
+        },
+        {
+          model: Database.podcastModel,
+          attributes: ['title', 'author', 'tags', 'explicit', 'coverPath']
+        }
+      ]
+    })
+
+    const items = libraryItems
+      .filter((libraryItem) => !libraryItem.isMissing && !libraryItem.isInvalid && libraryItem.media && req.user.checkCanAccessLibraryItem(libraryItem))
+      .map((libraryItem) => {
+        // relPath is normally POSIX already. Normalize old Windows records too.
+        const relPath = (libraryItem.relPath || Path.basename(libraryItem.path || '')).replaceAll('\\', '/').replace(/^\/+|\/+$/g, '')
+        return {
+          id: libraryItem.id,
+          folderId: libraryItem.libraryFolderId,
+          relPath,
+          title: libraryItem.media.title || Path.posix.basename(relPath),
+          author: libraryItem.mediaType === 'book' ? libraryItem.authorNamesFirstLast || '' : libraryItem.media.author || '',
+          hasCover: !!libraryItem.media.coverPath,
+          updatedAt: libraryItem.updatedAt?.valueOf(),
+          mediaType: libraryItem.mediaType
+        }
+      })
+
+    naturalSort(items).asc((item) => item.relPath)
+
+    res.json({
+      folders: req.library.libraryFolders.map((folder) => ({
+        id: folder.id,
+        name: Path.basename(folder.path) || req.library.name
+      })),
+      items
+    })
+  }
+
+  /**
    * DELETE: /api/libraries/:id/issues
    * Remove all library items missing or invalid
    *

--- a/server/routers/ApiRouter.js
+++ b/server/routers/ApiRouter.js
@@ -73,6 +73,7 @@ class ApiRouter {
     this.router.delete('/libraries/:id', LibraryController.middleware.bind(this), LibraryController.delete.bind(this))
 
     this.router.get('/libraries/:id/items', LibraryController.middleware.bind(this), LibraryController.getLibraryItems.bind(this))
+    this.router.get('/libraries/:id/folders', LibraryController.middleware.bind(this), LibraryController.getFolderTree.bind(this))
     this.router.delete('/libraries/:id/issues', LibraryController.middleware.bind(this), LibraryController.removeLibraryItemsWithIssues.bind(this))
     this.router.get('/libraries/:id/episode-downloads', LibraryController.middleware.bind(this), LibraryController.getEpisodeDownloadQueue.bind(this))
     this.router.get('/libraries/:id/series', LibraryController.middleware.bind(this), LibraryController.getAllSeriesForLibrary.bind(this))

--- a/test/server/controllers/LibraryController.test.js
+++ b/test/server/controllers/LibraryController.test.js
@@ -37,6 +37,7 @@ describe('LibraryController.downloadMultiple', () => {
     })
     const allowedItem = await Database.libraryItemModel.create({
       path: '/test-lib/allowed',
+      relPath: 'Authors/Allowed Book',
       isFile: false,
       libraryFiles: [],
       mediaId: allowedBook.id,
@@ -57,6 +58,7 @@ describe('LibraryController.downloadMultiple', () => {
     })
     const explicitItem = await Database.libraryItemModel.create({
       path: '/test-lib/explicit',
+      relPath: 'Authors/Explicit Book',
       isFile: false,
       libraryFiles: [],
       mediaId: explicitBook.id,
@@ -77,6 +79,7 @@ describe('LibraryController.downloadMultiple', () => {
     })
     const taggedItem = await Database.libraryItemModel.create({
       path: '/test-lib/tagged',
+      relPath: 'Restricted/Tagged Book',
       isFile: false,
       libraryFiles: [],
       mediaId: taggedBook.id,
@@ -174,5 +177,33 @@ describe('LibraryController.downloadMultiple', () => {
     const pathObjects = zipHelpers.zipDirectoriesPipe.firstCall.args[0]
     expect(pathObjects).to.have.length(1)
     expect(pathObjects[0].path).to.equal('/test-lib/allowed')
+  })
+
+  it('returns an indexed folder tree containing only accessible items', async () => {
+    const req = {
+      user: restrictedUser,
+      library: libraryRecord
+    }
+    const res = {
+      json: sinon.spy()
+    }
+
+    await LibraryController.getFolderTree(req, res)
+
+    expect(res.json.calledOnce).to.be.true
+    const payload = res.json.firstCall.args[0]
+    expect(payload.folders).to.deep.equal([{ id: libraryFolder.id, name: 'test-lib' }])
+    expect(payload.items).to.deep.equal([
+      {
+        id: allowedItemId,
+        folderId: libraryFolder.id,
+        relPath: 'Authors/Allowed Book',
+        title: 'Allowed Book',
+        author: '',
+        hasCover: false,
+        updatedAt: payload.items[0].updatedAt,
+        mediaType: 'book'
+      }
+    ])
   })
 })


### PR DESCRIPTION
## Brief summary

Adds a folder-based library view that lets users browse indexed books and podcasts using the same hierarchy as their library folders on disk.

## Which issue is fixed?

N/A — this adds an optional library navigation view.

## In-depth Description

- Adds a **Folders** destination to the desktop sidebar and mobile library toolbar.
- Adds `GET /api/libraries/:id/folders`, returning library-root names and normalized relative item paths without exposing absolute filesystem paths.
- Applies the requesting user's library, tag, and explicit-content access rules before returning items.
- Builds intermediate folders in the client from indexed relative paths, supporting multiple configured library roots.
- Displays folders as cover-collage tiles with a folder marker and contained-book count.
- Displays books at their actual folder level using Audiobookshelf's existing cover renderer, configured aspect ratio, title/author placeholders, and item-detail links.
- Shows the current subtree's book count and clickable breadcrumb navigation in the library toolbar.

## How have you tested this?

- `npm test` — 355 server tests passed, including a new folder-tree access-control test.
- `cd client && npm test` — all 105 Cypress component tests passed.
- `cd client && npm run generate` — production client generation completed successfully.
- Built the Docker image for `linux/amd64`, deployed it to a test Audiobookshelf instance, and verified `/status` returns HTTP 200.
- Manually verified:
  - desktop folder navigation and active sidebar state;
  - folder tiles, cover collages, and contained-book counts;
  - nested breadcrumb navigation and subtree counts;
  - leaf-level book covers, titles, authors, and item-detail links.

## Screenshots

Before: Audiobookshelf did not provide a folder navigation destination or folder-browser page.

After — folder tiles with representative covers, counts, active sidebar state, and breadcrumbs:

![Folder tiles](https://raw.githubusercontent.com/dmitrychuba/audiobookshelf/pr-assets/library-folder-view/.github/pr-assets/library-folder-view-folders.png)

After — books at a leaf folder use the normal Audiobookshelf cover presentation:

![Book cover tiles inside a folder](https://raw.githubusercontent.com/dmitrychuba/audiobookshelf/pr-assets/library-folder-view/.github/pr-assets/library-folder-view-books.png)
