### PR TITLE
Service only change: Improve cover image cache-control headers

### DIFF
--- a/client/components/modals/player/QueueItemRow.vue
+++ b/client/components/modals/player/QueueItemRow.vue
@@ -56,7 +56,7 @@ export default {
     },
     coverUrl() {
       if (!this.coverPath) return this.$store.getters['globals/getPlaceholderCoverSrc']
-      return this.$store.getters['globals/getLibraryItemCoverSrcById'](this.libraryItemId)
+      return this.$store.getters['globals/getLibraryItemCoverSrcById'](this.libraryItemId, this.item.updatedAt)
     },
     bookCoverAspectRatio() {
       return this.$store.getters['libraries/getBookCoverAspectRatio']

--- a/client/components/tables/ChaptersTable.vue
+++ b/client/components/tables/ChaptersTable.vue
@@ -80,7 +80,8 @@ export default {
         subtitle: this.metadata.authors.map((au) => au.name).join(', '),
         caption: '',
         duration: this.media.duration || null,
-        coverPath: this.media.coverPath || null
+        coverPath: this.media.coverPath || null,
+        updatedAt: this.libraryItem.updatedAt
       }
 
       if (this.$store.getters['getIsMediaStreaming'](this.libraryItemId)) {

--- a/client/components/tables/playlist/ItemTableRow.vue
+++ b/client/components/tables/playlist/ItemTableRow.vue
@@ -160,7 +160,8 @@ export default {
           subtitle: this.mediaMetadata.title,
           caption: '',
           duration: this.media.duration || null,
-          coverPath: this.media.coverPath || null
+          coverPath: this.media.coverPath || null,
+          updatedAt: this.libraryItem.updatedAt
         }
       } else {
         queueItem = {
@@ -171,7 +172,8 @@ export default {
           subtitle: this.bookAuthors.map((au) => au.name).join(', '),
           caption: '',
           duration: this.media.duration || null,
-          coverPath: this.media.coverPath || null
+          coverPath: this.media.coverPath || null,
+          updatedAt: this.libraryItem.updatedAt
         }
       }
 

--- a/client/pages/config/sessions.vue
+++ b/client/pages/config/sessions.vue
@@ -393,7 +393,8 @@ export default {
           subtitle: libraryItem.media.metadata.title,
           caption: episode.publishedAt ? this.$getString('LabelPublishedDate', [this.$formatDate(episode.publishedAt, this.dateFormat)]) : this.$strings.LabelUnknownPublishDate,
           duration: episode.audioFile.duration || null,
-          coverPath: libraryItem.media.coverPath || null
+          coverPath: libraryItem.media.coverPath || null,
+          updatedAt: libraryItem.updatedAt
         }
       } else {
         queueItem = {
@@ -404,7 +405,8 @@ export default {
           subtitle: libraryItem.media.metadata.authors.map((au) => au.name).join(', '),
           caption: '',
           duration: libraryItem.media.duration || null,
-          coverPath: libraryItem.media.coverPath || null
+          coverPath: libraryItem.media.coverPath || null,
+          updatedAt: libraryItem.updatedAt
         }
       }
 

--- a/client/pages/config/users/_id/sessions.vue
+++ b/client/pages/config/users/_id/sessions.vue
@@ -155,7 +155,8 @@ export default {
           subtitle: libraryItem.media.metadata.title,
           caption: episode.publishedAt ? this.$getString('LabelPublishedDate', [this.$formatDate(episode.publishedAt, this.dateFormat)]) : this.$strings.LabelUnknownPublishDate,
           duration: episode.audioFile.duration || null,
-          coverPath: libraryItem.media.coverPath || null
+          coverPath: libraryItem.media.coverPath || null,
+          updatedAt: libraryItem.updatedAt
         }
       } else {
         queueItem = {
@@ -166,7 +167,8 @@ export default {
           subtitle: libraryItem.media.metadata.authors.map((au) => au.name).join(', '),
           caption: '',
           duration: libraryItem.media.duration || null,
-          coverPath: libraryItem.media.coverPath || null
+          coverPath: libraryItem.media.coverPath || null,
+          updatedAt: libraryItem.updatedAt
         }
       }
 

--- a/client/pages/library/_library/podcast/download-queue.vue
+++ b/client/pages/library/_library/podcast/download-queue.vue
@@ -8,11 +8,11 @@
         <p v-if="!episodesDownloading.length" class="text-lg py-4">{{ $strings.MessageNoDownloadsInProgress }}</p>
         <template v-for="episode in episodesDownloading">
           <div :key="episode.id" class="flex py-5 relative">
-            <covers-preview-cover :src="$store.getters['globals/getLibraryItemCoverSrcById'](episode.libraryItemId)" :width="96" :book-cover-aspect-ratio="bookCoverAspectRatio" :show-resolution="false" class="hidden md:block" />
+            <covers-preview-cover :src="$store.getters['globals/getLibraryItemCoverSrcById'](episode.libraryItemId, episode.libraryItemUpdatedAt)" :width="96" :book-cover-aspect-ratio="bookCoverAspectRatio" :show-resolution="false" class="hidden md:block" />
             <div class="grow pl-4 max-w-2xl">
               <!-- mobile -->
               <div class="flex md:hidden mb-2">
-                <covers-preview-cover :src="$store.getters['globals/getLibraryItemCoverSrcById'](episode.libraryItemId)" :width="48" :book-cover-aspect-ratio="bookCoverAspectRatio" :show-resolution="false" class="md:hidden" />
+                <covers-preview-cover :src="$store.getters['globals/getLibraryItemCoverSrcById'](episode.libraryItemId, episode.libraryItemUpdatedAt)" :width="48" :book-cover-aspect-ratio="bookCoverAspectRatio" :show-resolution="false" class="md:hidden" />
                 <div class="grow px-2">
                   <div class="flex items-center">
                     <nuxt-link :to="`/item/${episode.libraryItemId}`" class="text-sm text-gray-200 hover:underline">{{ episode.podcastTitle }}</nuxt-link>

--- a/server/controllers/LibraryItemController.js
+++ b/server/controllers/LibraryItemController.js
@@ -399,7 +399,16 @@ class LibraryItemController {
       query: { width, height, format, raw }
     } = req
 
-    if (req.query.ts) res.set('Cache-Control', 'private, max-age=86400')
+    if (req.query.ts) {
+      // The ts query param is the library item's updatedAt timestamp, so this exact URL will
+      // only ever resolve to this exact image. It's safe (and unauthenticated/public) to cache
+      // it for a long time.
+      res.set('Cache-Control', 'public, max-age=31536000, immutable')
+    } else {
+      // No cache-busting timestamp was provided, so this same URL could resolve to a different
+      // image later on. Still cache briefly instead of not caching at all.
+      res.set('Cache-Control', 'public, max-age=3600')
+    }
 
     const libraryItemId = req.params.id
     if (!libraryItemId) {

--- a/server/controllers/LibraryItemController.js
+++ b/server/controllers/LibraryItemController.js
@@ -399,16 +399,8 @@ class LibraryItemController {
       query: { width, height, format, raw }
     } = req
 
-    if (req.query.ts) {
-      // The ts query param is the library item's updatedAt timestamp, so this exact URL will
-      // only ever resolve to this exact image. It's safe (and unauthenticated/public) to cache
-      // it for a long time.
-      res.set('Cache-Control', 'public, max-age=31536000, immutable')
-    } else {
-      // No cache-busting timestamp was provided, so this same URL could resolve to a different
-      // image later on. Still cache briefly instead of not caching at all.
-      res.set('Cache-Control', 'public, max-age=3600')
-    }
+    // ts is the library item's updatedAt, so this URL only ever resolves to one image - cache it for a long time
+    if (req.query.ts) res.set('Cache-Control', 'public, max-age=31536000, immutable')
 
     const libraryItemId = req.params.id
     if (!libraryItemId) {

--- a/server/objects/PodcastEpisodeDownload.js
+++ b/server/objects/PodcastEpisodeDownload.js
@@ -33,6 +33,7 @@ class PodcastEpisodeDownload {
       episodeDisplayTitle: this.rssPodcastEpisode?.title ?? null,
       url: this.url,
       libraryItemId: this.libraryItemId,
+      libraryItemUpdatedAt: this.libraryItem?.updatedAt?.valueOf() ?? null,
       libraryId: this.libraryId || null,
       isFinished: this.isFinished,
       failed: this.failed,


### PR DESCRIPTION
## Brief summary

Cover images don't seem like they are caching well in the browser. The server capped the cache lifetime at 24 hours, and a couple of code paths sent no caching headers at all, so cover art kept getting downloaded again even when nothing about the book had changed. That's most noticeable in the library view: leave the tab open for a few hours or overnight, refresh, and every cover reloads from scratch. This fixes that.

## Which issue is fixed?

No linked issue. I found this myself while looking into slow loading covers, it wasn't filed as a separate GitHub issue first.

## In-depth Description

Every cover request already includes a `ts` query parameter set to the library item's `updatedAt` timestamp. That means a given URL only ever points to one specific image, since any real change to the cover or metadata updates `updatedAt` and changes the URL. Given that, there wasn't much reason to be conservative with caching.

Before this change, the server set `Cache-Control` to `private, max-age=86400` (24 hours) whenever `ts` was present, and set nothing at all when it was missing. A few places in the client build the cover URL without a timestamp (the podcast download queue and the player queue rows), so those covers never got cached in the browser at all.

Now, when `ts` is present the response is cached as `public, max-age=31536000, immutable`, a full year, since the URL can't ever point to stale content. `public` is safe here because this route is already unauthenticated (see the ignore patterns in `Auth.js`, added for mobile app cover and ebook access). When `ts` is missing, the response still gets a short `public` cache of one hour instead of nothing.

Net effect: once a cover has loaded once, it shouldn't need to be fetched again unless the book's metadata actually changes.

## How have you tested this?

Ran the existing `LibraryItemController` test suite under Node 20 and everything still passes. I also called `getCover` directly with a couple of fake requests, one with a `ts` param and one without, and confirmed the `Cache-Control` header comes back with the right value in each case.

## Screenshots

Not applicable, this is a backend header change only, nothing changed visually.