### PR TITLE
Add built-in Docker health check

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,5 +69,8 @@ ENV SOURCE="docker"
 ENV NUSQLITE3_DIR=${NUSQLITE3_DIR}
 ENV NUSQLITE3_PATH=${NUSQLITE3_PATH}
 
+HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
+  CMD ["node", "-e", "const http = require('http'); const request = http.get({ hostname: '127.0.0.1', port: process.env.PORT || 80, path: '/healthcheck' }, (response) => { response.resume(); process.exit(response.statusCode === 200 ? 0 : 1) }); request.on('error', () => process.exit(1))"]
+
 ENTRYPOINT ["tini", "--"]
 CMD ["node", "index.js"]


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

Adds a built-in Docker health check to the Audiobookshelf image, removing the need to define one separately in Docker Compose.

## Which issue is fixed?

No associated issue.

## In-depth Description

The Docker image now periodically requests the existing `/healthcheck` endpoint from inside the container.

  The health check:

  - runs every 30 seconds
  - uses a 5-second timeout
  - allows 30 seconds for application startup
  - marks the container as unhealthy after three consecutive failures
  - respects the configured internal `PORT`
  - uses Node.js directly, avoiding additional runtime dependencies such as `curl`

  This verifies that the Audiobookshelf HTTP server is responding successfully instead of only checking whether the Node.js process is running.

  Because the health check is defined directly in the Docker image, it works automatically with `docker run` and Docker Compose without requiring users to duplicate the configuration.


## How have you tested this?

 - Ran `docker build --check .` successfully with no warnings.
  - Built the complete Docker image successfully.
  - Started an Audiobookshelf container and confirmed that its health status changed to `healthy`.
  - Started a test container that returned HTTP 503 and confirmed that its health status changed to `unhealthy` after the configured number of retries.



## Screenshots

 Not applicable. This change does not affect the web client.

