### PR TITLE
Fix loose files merging sibling book subfolders during scan

### DIFF
--- a/server/utils/scandir.js
+++ b/server/utils/scandir.js
@@ -65,54 +65,44 @@ function groupFileItemsIntoLibraryItemDirs(mediaType, fileItems, audiobooksOnly,
     }
   })
 
-  // Step 3: Group media files (or non-media files if includeNonMediaFiles is true) in library items
+  // Step 3: Group media files (or non-media files if includeNonMediaFiles is true) into library items.
+  //
+  // Each file's own directory is its natural group (so every subfolder becomes its own book), except
+  // when the deepest path segment is a CD/Disc split, in which case the file belongs to the book one
+  // level up. Deciding the group from the file's own path - instead of walking up and merging into
+  // whichever ancestor happens to already be registered - keeps a loose file sitting next to book
+  // subfolders (e.g. a stray track directly in a series folder) from swallowing every book beneath it.
   const libraryItemGroup = {}
   mediaFileItems.forEach((item) => {
-    const dirparts = item.reldirpath.split('/').filter((p) => !!p)
-    const numparts = dirparts.length
-    let _path = ''
-
-    if (!dirparts.length) {
+    if (!item.reldirpath) {
       // Media file in root
       libraryItemGroup[item.name] = item.name
-    } else {
-      // Iterate over directories in path
-      for (let i = 0; i < numparts; i++) {
-        const dirpart = dirparts.shift()
-        _path = Path.posix.join(_path, dirpart)
+      return
+    }
 
-        if (libraryItemGroup[_path]) {
-          // Directory already has files, add file
-          const relpath = Path.posix.join(dirparts.join('/'), item.name)
-          libraryItemGroup[_path].push(relpath)
-          return
-        } else if (!dirparts.length) {
-          // This is the last directory, create group
-          libraryItemGroup[_path] = [item.name]
-          return
-        } else if (dirparts.length === 1 && /^(cd|dis[ck])\s*\d{1,3}$/i.test(dirparts[0])) {
-          // Next directory is the last and is a CD dir, create group
-          libraryItemGroup[_path] = [Path.posix.join(dirparts[0], item.name)]
-          return
-        }
-      }
+    const dirparts = item.reldirpath.split('/').filter((p) => !!p)
+    const isCdFolder = dirparts.length > 1 && /^(cd|dis[ck])\s*\d{1,3}$/i.test(dirparts[dirparts.length - 1])
+    const groupPath = isCdFolder ? dirparts.slice(0, -1).join('/') : item.reldirpath
+    const relpath = Path.posix.join(Path.posix.relative(groupPath, item.reldirpath), item.name)
+
+    if (libraryItemGroup[groupPath]) {
+      libraryItemGroup[groupPath].push(relpath)
+    } else {
+      libraryItemGroup[groupPath] = [relpath]
     }
   })
 
-  // Step 4: Add other files into library item groups
+  // Step 4: Add other files into library item groups, preferring the most specific (deepest) group
+  // that owns the file - e.g. a cover.jpg belongs to its own book folder, not a shallower ancestor
+  // that only happens to be a registered group too.
   otherFileItems.forEach((item) => {
-    const dirparts = item.reldirpath.split('/')
-    const numparts = dirparts.length
-    let _path = ''
+    const dirparts = item.reldirpath ? item.reldirpath.split('/').filter((p) => !!p) : []
 
-    // Iterate over directories in path
-    for (let i = 0; i < numparts; i++) {
-      const dirpart = dirparts.shift()
-      _path = Path.posix.join(_path, dirpart)
-      if (libraryItemGroup[_path]) {
-        // Directory is audiobook group
-        const relpath = Path.posix.join(dirparts.join('/'), item.name)
-        libraryItemGroup[_path].push(relpath)
+    for (let i = dirparts.length; i > 0; i--) {
+      const ancestorPath = dirparts.slice(0, i).join('/')
+      if (libraryItemGroup[ancestorPath]) {
+        const relpath = Path.posix.join(dirparts.slice(i).join('/'), item.name)
+        libraryItemGroup[ancestorPath].push(relpath)
         return
       }
     }

--- a/test/server/utils/scandir.test.js
+++ b/test/server/utils/scandir.test.js
@@ -49,4 +49,34 @@ describe('scanUtils', async () => {
       'Author/Series2/Book5/deeply/nested': ['cd 01/audiofile.mp3', 'cd 02/audiofile.mp3']
     })
   })
+
+  it('should not merge sibling book subfolders into a loose file sitting next to them', async () => {
+    global.isWin = process.platform === 'win32'
+    global.ServerSettings = {
+      scannerParseSubtitle: true
+    }
+
+    // A loose track dropped directly in a series folder used to cause every book subfolder
+    // in that same series to be swallowed into a single library item alongside it.
+    const filePaths = ['Author2/Series3/loose-track.mp3', 'Author2/Series3/Book6/audiofile.mp3', 'Author2/Series3/Book7/audiofile.mp3']
+
+    const fileItems = []
+    for (const filePath of filePaths) {
+      const dirname = Path.dirname(filePath)
+      fileItems.push({
+        name: Path.basename(filePath),
+        reldirpath: dirname === '.' ? '' : dirname,
+        extension: Path.extname(filePath),
+        deep: filePath.split('/').length - 1
+      })
+    }
+
+    const libraryItemGrouping = scanUtils.groupFileItemsIntoLibraryItemDirs('book', fileItems, false)
+
+    expect(libraryItemGrouping).to.deep.equal({
+      'Author2/Series3': ['loose-track.mp3'],
+      'Author2/Series3/Book6': ['audiofile.mp3'],
+      'Author2/Series3/Book7': ['audiofile.mp3']
+    })
+  })
 })


### PR DESCRIPTION
groupFileItemsIntoLibraryItemDirs decided a file's library item group by walking from the shallowest directory down and merging into the first ancestor path that already had a registered group. That works for the intended case (a loose track sitting next to CD/Disc split subfolders belongs to the same book), but breaks when a loose file sits next to real book subfolders that are not CD splits: whichever file got processed first claims the shared parent directory as its group, and every subsequent file under a deeper sibling subfolder gets merged into that same group too, because the check only looks for "is some ancestor already a group" rather than "does this file's own directory deserve to be its own group."

Concretely: a series folder containing one stray audio file plus 30+ book subfolders got scanned as a single 1700+ file "book" instead of 30+ separate books, because the stray file's directory (the series folder itself) happened to get registered as a group before the subfolders were processed.

Fixed by keying each file's group off its own directory (walking up only for the CD/Disc-split case, which is now detected directly from the last path segment rather than inferred from a previous ancestor registration), so group assignment no longer depends on processing order and sibling subfolders can't be pulled into an unrelated loose file's book. Also fixed Step 4 (attaching non-media files like covers) to prefer the deepest matching group instead of the shallowest, which matters once Step 3 can produce nested groups.

Added a regression test for the loose-file/sibling-subfolder case.


Claude-Session: https://claude.ai/code/session_01GGgGjy1s9F3ETzDTvmzpad

<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

<!-- Please provide a brief summary of what your PR attempts to achieve. -->

## Which issue is fixed?

<!-- Which issue number does this PR fix? Ex: "Fixes #1234" -->

## In-depth Description

<!--
Describe your solution in more depth.
How does it work? Why is this the best solution?
Does it solve a problem that affects multiple users or is this an edge case for your setup?
-->

## How have you tested this?

<!-- Please describe in detail with reproducible steps how you tested your changes. -->

## Screenshots

<!-- If your PR includes any changes to the web client, please include screenshots or a short video from before and after your changes. -->
