### PR TITLE
Fix Dockerfile COPY destination missing trailing slash

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN apk add --no-cache --update \
   unzip
 
 WORKDIR /server
-COPY index.js package* /server
+COPY index.js package* /server/
 COPY /server /server/server
 
 RUN case "$TARGETPLATFORM" in \


### PR DESCRIPTION
COPY index.js package* /server matches multiple source files (package.json and package-lock.json) via the glob, which requires the destination to be explicitly a directory. The classic (non-BuildKit) docker builder enforces this and refuses to build with "the destination must be a directory and end with a /"; BuildKit is more lenient and silently accepts it, which is presumably why this has gone unnoticed if CI builds with BuildKit. Found while building this project on a host without the buildx component installed.


Claude-Session: https://claude.ai/code/session_01GGgGjy1s9F3ETzDTvmzpad

<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

<!-- Please provide a brief summary of what your PR attempts to achieve. -->

## Which issue is fixed?

<!-- Which issue number does this PR fix? Ex: "Fixes #1234" -->

## In-depth Description

<!--
Describe your solution in more depth.
How does it work? Why is this the best solution?
Does it solve a problem that affects multiple users or is this an edge case for your setup?
-->

## How have you tested this?

<!-- Please describe in detail with reproducible steps how you tested your changes. -->

## Screenshots

<!-- If your PR includes any changes to the web client, please include screenshots or a short video from before and after your changes. -->
