### PR TITLE
fix: resolve EoC sleep timer edge cases with chapter zero and state sync

### DIFF
--- a/client/components/app/MediaPlayerContainer.vue
+++ b/client/components/app/MediaPlayerContainer.vue
@@ -243,7 +243,8 @@ export default {
       // Track chapter transitions by comparing current chapter with last chapter
       if (this.lastChapterId !== this.currentChapter.id) {
         // Chapter changed - if we had a previous chapter, this means we crossed a boundary
-        if (this.lastChapterId) {
+        //To prevent the value of id from being judged as false when it is 0.
+        if (this.lastChapterId !== null && this.lastChapterId !== undefined) {
           this.sleepTimerEnd()
         }
         this.lastChapterId = this.currentChapter.id

--- a/client/components/app/MediaPlayerContainer.vue
+++ b/client/components/app/MediaPlayerContainer.vue
@@ -218,7 +218,11 @@ export default {
       this.showSleepTimerModal = false
 
       this.sleepTimerType = time.timerType
-      if (this.sleepTimerType === this.$constants.SleepTimerTypes.COUNTDOWN) {
+      if (this.sleepTimerType === this.$constants.SleepTimerTypes.CHAPTER) {
+        // Sync lastChapterId to the current chapter so the timer doesn't
+        // fire immediately when the user enables it mid-chapter.
+        this.lastChapterId = this.currentChapter?.id ?? null
+      } else if (this.sleepTimerType === this.$constants.SleepTimerTypes.COUNTDOWN) {
         this.runSleepTimer(time)
       }
     },
@@ -295,6 +299,11 @@ export default {
     },
     seek(time) {
       this.playerHandler.seek(time)
+      // After a manual seek, re-anchor lastChapterId so that landing in a
+      // different chapter is not mistaken for a chapter-boundary crossing.
+      if (this.sleepTimerType === this.$constants.SleepTimerTypes.CHAPTER && this.sleepTimerSet) {
+        this.lastChapterId = this.currentChapter?.id ?? null
+      }
     },
     playbackTimeUpdate(time) {
       // When updating progress from another session


### PR DESCRIPTION
## Brief summary

This PR fixes state management edge cases with the End of Chapter (EoC) sleep timer where it fails on the first chapter and triggers prematurely after seeking backwards.

## Which issue is fixed?

Fixes #5394

## In-depth Description

This PR addresses two specific scenarios:
* **Chapter 0 Failure**: When playing the first chapter, the timer fails to pause playback at the end. This was due to an implicit falsy check on `lastChapterId === 0`. This is resolved by explicitly checking for `null` and `undefined`.
* **Premature Trigger on Seek**: If the EoC timer was triggered on a later chapter, seeking backwards into the first chapter and re-enabling it causes the timer to trigger instantly. `lastChapterId` is now properly synchronized with `currentChapter.id` during manual seeks or timer initialization to prevent stale state evaluation.

## How have you tested this?

Scenario A:
1. Opened the web client and played the very first chapter of an audiobook.
2. Set the sleep timer to "EoC" (End of Chapter).
3. Sought the playback position to a few seconds before the end of the first chapter.
4. Observed that playback correctly pauses at the end instead of continuing into the next chapter.

Scenario B:
1. Played Chapter 3 (or any later chapter).
2. Set the sleep timer to "EoC".
3. Allowed the playback to reach the end of the chapter so the EoC timer triggers and pauses the audio.
4. Clicked on the progress bar to seek backwards into Chapter 1.
5. Set the sleep timer to "EoC" again.
6. Pressed play.
7. Observed that the EoC timer does not trigger immediately.

## Screenshots

N/A. No UI changes were made.