### PR TITLE
Fix podcast rescan emitting stale episodes on item_updated

### DIFF
--- a/server/scanner/PodcastScanner.js
+++ b/server/scanner/PodcastScanner.js
@@ -58,8 +58,12 @@ class PodcastScanner {
     /** @type {AudioFile[]} */
     let newAudioFiles = []
 
+    // Track episode add/remove/update so item_updated includes the current episode list
+    let hasEpisodeChanges = false
+
     if (libraryItemData.hasAudioFileChanges || libraryItemData.audioLibraryFiles.length !== existingPodcastEpisodes.length) {
-      // Filter out and destroy episodes that were removed
+      // Filter out and destroy episodes that were removed.
+      // filter() returns a new array — reassign to media.podcastEpisodes before emit.
       const episodesToRemove = []
       existingPodcastEpisodes = existingPodcastEpisodes.filter((ep) => {
         if (libraryItemData.checkAudioFileRemoved(ep.audioFile)) {
@@ -70,6 +74,7 @@ class PodcastScanner {
       })
 
       if (episodesToRemove.length) {
+        hasEpisodeChanges = true
         // Remove episodes from playlists and media progress
         const episodeIds = episodesToRemove.map((ep) => ep.id)
         await Database.playlistModel.removeMediaItemsFromPlaylists(episodeIds)
@@ -116,6 +121,7 @@ class PodcastScanner {
             AudioFileScanner.setPodcastEpisodeMetadataFromAudioMetaTags(podcastEpisode, libraryScan)
             libraryScan.addLog(LogLevel.INFO, `Podcast episode "${podcastEpisode.title}" keys changed [${podcastEpisode.changed()?.join(', ')}]`)
             await podcastEpisode.save()
+            hasEpisodeChanges = true
           }
         }
 
@@ -155,8 +161,12 @@ class PodcastScanner {
         libraryScan.addLog(LogLevel.INFO, `New Podcast episode "${newPodcastEpisode.title}" added`)
         await newPodcastEpisode.save()
         existingPodcastEpisodes.push(newPodcastEpisode)
+        hasEpisodeChanges = true
       }
     }
+
+    // Keep association in sync for toOldJSONExpanded() / item_updated socket payload
+    media.podcastEpisodes = existingPodcastEpisodes
 
     let hasMediaChanges = false
     if (existingPodcastEpisodes.length !== media.numEpisodes) {
@@ -250,7 +260,7 @@ class PodcastScanner {
 
     return {
       libraryItem: existingLibraryItem,
-      wasUpdated: hasMediaChanges || libraryItemUpdated
+      wasUpdated: hasMediaChanges || libraryItemUpdated || hasEpisodeChanges
     }
   }
 


### PR DESCRIPTION
## Brief summary

After a podcast library item rescan, sync `media.podcastEpisodes` with the post-scan episode list so `item_updated` socket payloads include the current episodes (adds, removals, and updates).

## Which issue is fixed?

No Issue I know of.

## In-depth Description

During `rescanExistingPodcastLibraryItem`, episode changes were applied on a local `existingPodcastEpisodes` array (filter for removals, push for new episodes, save for modified audio). That array was never written back to `media.podcastEpisodes`.

`item_updated` is built from `libraryItem.toOldJSONExpanded()`, which serializes episodes from `media.podcastEpisodes`. Clients therefore kept the pre-rescan episode list until a full reload fetched fresh data from the API.

This change:

- Reassigns `media.podcastEpisodes = existingPodcastEpisodes` after episode processing so the socket payload matches the database.
- Tracks `hasEpisodeChanges` when episodes are added, removed, or updated so `wasUpdated` is true when only episodes changed (and `item_updated` is emitted when appropriate).

No API or socket schema changes—only correct data on the existing contract.

## How have you tested this?

1. Open a podcast item page in the web client (Vue or React).
2. Remove some existing episodes without hard delete
3. Run **Re-scan** from the item context menu in React, or the edit details tab in Vue.
4. Confirm the deleted episodes return without a full page reload (via `item_updated`).
5. Confirm a full page reload still shows the same episode list.