### PR TITLE
Link listening session modal title to the library item page

### DIFF
--- a/client/components/modals/ListeningSessionModal.vue
+++ b/client/components/modals/ListeningSessionModal.vue
@@ -7,7 +7,8 @@
     </template>
     <div ref="container" class="w-full rounded-lg bg-bg box-shadow-md overflow-y-auto overflow-x-hidden p-6" style="max-height: 80vh">
       <div class="flex items-center">
-        <p class="text-base text-gray-200">{{ _session.displayTitle }}</p>
+        <nuxt-link v-if="_session.libraryItemId" :to="`/item/${_session.libraryItemId}`" class="text-base text-gray-200 hover:underline" @click.native="show = false">{{ _session.displayTitle }}</nuxt-link>
+        <p v-else class="text-base text-gray-200">{{ _session.displayTitle }}</p>
         <p v-if="_session.displayAuthor" class="text-xs text-gray-400 px-4">{{ $getString('LabelByAuthor', [_session.displayAuthor]) }}</p>
       </div>
 


### PR DESCRIPTION
## Brief summary

Makes the item title in the listening session modal (Settings → Listening Sessions → click a row) a link to that item's page, instead of static text.

## Which issue is fixed?

No existing issue — I searched open and closed issues/enhancements and didn't find one for this. Happy to open one if you'd prefer it tracked there first.

## In-depth Description

The session detail modal already displays the `Library Item Id`, but the title at the top is plain text. To get from a session to the item you either copy that UUID out of the modal and build the URL by hand, or search the library by title — which is unreliable when titles are truncated in the table or several editions share a name. Every other place a title appears in the UI is clickable, so the static title here reads as an oversight.

The change renders the title as a `nuxt-link` to `/item/${_session.libraryItemId}`, matching the existing convention used in `DownloadQueueTable.vue`, `playlist/ItemTableRow.vue`, `GlobalSearch.vue`, etc. (`hover:underline`, same text classes as before).

Two details worth calling out:

- **Fallback.** If the session has no `libraryItemId`, the title still renders as a `<p>` exactly as before, so nothing regresses for sessions without one.
- **Closing the modal on click.** `Modal.setShow()` appends the modal element to `document.body` and adds a `modal-open` class to `documentElement`, but `beforeDestroy` only unregisters the event bus listener — it never calls `setHide()`. Navigating away with the modal open would therefore leave the `modal-open` class behind and skip the `setOpenModal(null)` commit. Setting `show = false` on click makes the normal teardown path run before the route changes.

Only the modal is changed here. The **Item** column in the sessions table itself could get the same treatment, but that row already has a click handler for opening the modal, so nesting a link there is a separate decision — happy to add it if you want it.

## How have you tested this?

Ran the client dev server against a real server instance (v2.36.0) with production data:

1. Settings → Listening Sessions, clicked a session row to open the modal.
2. Confirmed the title underlines on hover and resolves to `/item/<libraryItemId>` — the URL in the status bar matches the `Library Item Id` shown in the same modal (screenshot below).
3. Clicked the title and landed on the expected item page, with the modal closed.

## Screenshots

Modal with the title hovered — link target matches the `Library Item Id` shown in the modal:
<img width="1092" height="1214" alt="Screenshot 2026-07-28 at 9 48 39 AM" src="https://github.com/user-attachments/assets/6e7ec07c-c5c3-496d-992f-84243f09cdbe" />
