### PR TITLE
Fix arrow keys hijacking player hotkeys while editing chapter timestamps (#2708)

### DIFF
--- a/client/components/ui/TimePicker.vue
+++ b/client/components/ui/TimePicker.vue
@@ -167,12 +167,16 @@ export default {
       if (!this.focusedDigit || !evt.key) return
 
       if (evt.key === 'ArrowLeft') {
+        evt.preventDefault()
         return this.shiftFocusLeft()
       } else if (evt.key === 'ArrowRight') {
+        evt.preventDefault()
         return this.shiftFocusRight()
       } else if (evt.key === 'ArrowUp') {
+        evt.preventDefault()
         return this.increaseFocused()
       } else if (evt.key === 'ArrowDown') {
+        evt.preventDefault()
         return this.decreaseFocused()
       } else if (evt.key === 'Enter' || evt.key === 'Escape' || evt.key === 'Tab') {
         return this.removeFocus()

--- a/client/components/ui/TimePicker.vue
+++ b/client/components/ui/TimePicker.vue
@@ -1,5 +1,5 @@
 <template>
-  <div tabindex="0" @focus="focusDigit('second0')" class="relative">
+  <div tabindex="0" data-hotkey-ignore @focus="focusDigit('second0')" class="relative">
     <div class="rounded-sm text-gray-200 border w-full px-3 py-2" :class="focusedDigit ? 'bg-primary/50 border-gray-300' : 'bg-primary border-gray-600'" @click="clickInput" v-click-outside="clickOutsideObj">
       <div class="flex items-center">
         <template v-for="(digit, index) in digitDisplay">

--- a/client/layouts/default.vue
+++ b/client/layouts/default.vue
@@ -505,7 +505,8 @@ export default {
     checkActiveElementIsInput() {
       const activeElement = document.activeElement
       const inputs = ['input', 'select', 'button', 'textarea', 'trix-editor']
-      return activeElement && inputs.some((i) => i === activeElement.tagName.toLowerCase())
+      return activeElement && (inputs.some((i) => i === activeElement.tagName.toLowerCase()) ||
+      activeElement.hasAttribute('data-hotkey-ignore'))
     },
     getHotkeyName(e) {
       var keyCode = e.keyCode || e.which


### PR DESCRIPTION
Fixes #2708

## What was wrong
While editing a chapter's timestamp with the arrow keys, the same key presses also controlled the audio player at the same time: left/right seeked playback, up/down changed the volume.

## Root cause
The chapter timestamp editor (`TimePicker.vue`) is built from a plain `<div>`, not a native `<input>` element. `checkActiveElementIsInput()` in `layouts/default.vue` only recognises real input tags (`input`, `select`, `textarea`, etc.), so it never skips the global player hotkeys when the timestamp editor has focus. Both the picker's own key handling and the global hotkey handler ran on every key press.

## Fix
- Added a `data-hotkey-ignore` marker attribute to the timestamp editor's container.
- Updated `checkActiveElementIsInput()` to also treat elements with that marker as inputs, so global hotkeys are skipped while the timestamp editor is focused.
- Added `evt.preventDefault()` in the timestamp editor's own arrow-key handling, since the browser's default scroll behaviour was previously (accidentally) suppressed as a side effect of the bug, and became visible once the bug was fixed.

## Testing
Reproduced locally with a real audiobook and real chapters: confirmed the player's progress and volume changed while editing a chapter timestamp before the fix. After the fix, repeated the same steps and confirmed the player no longer reacts and the page no longer scrolls.

## AI disclosure
I used Claude (Anthropic) to help me navigate the codebase, debug my local dev setup, and review my changes, as I'm still learning full-stack development. All code was written and tested by me.