### PR TITLE
Fix percent encoding in X-Accel paths

### DIFF
--- a/server/utils/fileUtils.js
+++ b/server/utils/fileUtils.js
@@ -443,7 +443,7 @@ module.exports.encodeUriPath = (path) => {
   const uri = new URL('/', 'file://')
   // we assign the path here to assure that URL control characters like # are
   // actually interpreted as part of the URL path
-  uri.pathname = path
+  uri.pathname = path.replaceAll('%', '%25')
   return uri.pathname
 }
 

--- a/test/server/controllers/LibraryItemController.test.js
+++ b/test/server/controllers/LibraryItemController.test.js
@@ -8,6 +8,7 @@ const LibraryItemController = require('../../../server/controllers/LibraryItemCo
 const ApiCacheManager = require('../../../server/managers/ApiCacheManager')
 const Auth = require('../../../server/Auth')
 const Logger = require('../../../server/Logger')
+const fs = require('../../../server/libs/fsExtra')
 
 describe('LibraryItemController', () => {
   /** @type {ApiRouter} */
@@ -297,6 +298,47 @@ describe('LibraryItemController', () => {
       }
       await LibraryItemController.batchDelete.bind(apiRouter)(fakeReq, fakeRes)
       expect(fakeRes.sendStatus.calledWith(403)).to.be.true
+    })
+  })
+
+  describe('getCover', () => {
+    let originalXAccel
+
+    beforeEach(() => {
+      originalXAccel = global.XAccel
+    })
+
+    afterEach(() => {
+      global.XAccel = originalXAccel
+    })
+
+    it('sets an encoded X-Accel-Redirect header for raw covers with percent characters', async () => {
+      const coverPath = '/Test 1% Book/cover.jpg'
+      global.XAccel = '/internal'
+
+      sinon.stub(Database.libraryItemModel, 'getCoverPath').resolves(coverPath)
+      sinon.stub(fs, 'pathExists').resolves(true)
+      sinon.stub(Logger, 'debug')
+
+      const fakeReq = {
+        params: { id: 'test-item-id' },
+        query: { raw: '1' }
+      }
+      const fakeRes = {
+        set: sinon.stub().returnsThis(),
+        sendStatus: sinon.spy(),
+        status: sinon.stub().returnsThis(),
+        header: sinon.stub().returnsThis(),
+        send: sinon.spy(),
+        sendFile: sinon.spy()
+      }
+
+      await LibraryItemController.getCover.bind(apiRouter)(fakeReq, fakeRes)
+
+      expect(fakeRes.status.calledWith(204)).to.be.true
+      expect(fakeRes.header.calledWith({ 'X-Accel-Redirect': '/internal/Test%201%25%20Book/cover.jpg' })).to.be.true
+      expect(fakeRes.send.calledOnce).to.be.true
+      expect(fakeRes.sendFile.notCalled).to.be.true
     })
   })
 })

--- a/test/server/utils/fileUtils.test.js
+++ b/test/server/utils/fileUtils.test.js
@@ -6,6 +6,25 @@ const fs = require('fs')
 const Logger = require('../../../server/Logger')
 
 describe('fileUtils', () => {
+  describe('encodeUriPath', () => {
+    it('encodes path segments while preserving path separators', () => {
+      const testCases = [
+        { path: '/Test Book/cover.jpg', expected: '/Test%20Book/cover.jpg' },
+        { path: '/Test 1% Book/cover.jpg', expected: '/Test%201%25%20Book/cover.jpg' },
+        { path: '/100% Complete/cover.jpg', expected: '/100%25%20Complete/cover.jpg' },
+        { path: '/%/cover.jpg', expected: '/%25/cover.jpg' },
+        { path: '/%20/cover.jpg', expected: '/%2520/cover.jpg' },
+        { path: '/%25/cover.jpg', expected: '/%2525/cover.jpg' },
+        { path: '/Test%Book/cover.jpg', expected: '/Test%25Book/cover.jpg' },
+        { path: '/Tést Book/cover.jpg', expected: '/T%C3%A9st%20Book/cover.jpg' }
+      ]
+
+      testCases.forEach(({ path, expected }) => {
+        expect(fileUtils.encodeUriPath(path)).to.equal(expected)
+      })
+    })
+  })
+
   it('shouldIgnoreFile', () => {
     global.isWin = process.platform === 'win32'
 


### PR DESCRIPTION
## Brief summary

Literal percent signs in filesystem paths were not safely encoded before being placed in `X-Accel-Redirect` headers.

This updates the shared `encodeUriPath()` helper so literal `%` characters are encoded as `%25` while preserving normal path separators and existing URI encoding behavior.

## Which issue is fixed?

Fixes #5420

## In-depth Description

The previous implementation assigned raw filesystem paths directly to `URL.pathname`.

This caused percent-looking sequences such as `%20` and `%25` to be treated as existing percent-encoding, while standalone percent signs could produce malformed redirect paths.

For example:

`/Test 1% Book/cover.jpg`

Previously became:

`/Test%201%%20Book/cover.jpg`

It now becomes:

`/Test%201%25%20Book/cover.jpg`

Because `encodeUriPath()` is shared, this change applies to X-Accel paths used for covers, audio, ebooks, cached files, shares, and backups.

## How have you tested this?

I tested the updated encoding locally with paths containing spaces, literal percent signs, `%20`, `%25`, and Unicode characters.

The full server test suite passed locally with 369 tests.

## Follow-up investigation

I reviewed all current `encodeUriPath()` call sites to verify that this change does not double-encode already encoded URI paths.

All production call sites pass raw filesystem paths generated or stored by the application, including backup, cover, audio, ebook, cache, and share paths. I did not find any production call site passing an already percent-encoded URI path.

`global.XAccel` comes from `USE_X_ACCEL` and is expected to be an unencoded internal URI prefix such as `/internal`.

This also matches the historical behavior of the helper. Before it was changed to use `URL.pathname`, literal `%` characters were explicitly encoded as `%25`.

Because Nginx treats `X-Accel-Redirect` as an internal URI redirect, literal percent sequences in filenames must be protected before the redirect path is interpreted:

- literal `%20` becomes `%2520`
- literal `%25` becomes `%2525`
- literal `%2F` becomes `%252F`
- real Unicode `é` becomes `%C3%A9`

After one URI decoding step, these resolve to the intended filesystem names.

The expected configuration is that `USE_X_ACCEL` contains an unencoded internal URI prefix. A pre-encoded prefix such as `/some%20prefix` would be outside this input contract.