### PR TITLE
fix: normalize published year dates

### DIFF
--- a/client/components/widgets/BookDetailsEdit.vue
+++ b/client/components/widgets/BookDetailsEdit.vue
@@ -16,7 +16,7 @@
           <ui-multi-select-query-input ref="authorsSelect" v-model="details.authors" :label="$strings.LabelAuthors" filter-key="authors" @input="handleInputChange" />
         </div>
         <div class="grow px-1 mt-2 md:mt-0">
-          <ui-text-input-with-label ref="publishYearInput" v-model="details.publishedYear" type="number" :label="$strings.LabelPublishYear" @input="handleInputChange" />
+          <ui-text-input-with-label ref="publishYearInput" v-model="details.publishedYear" :label="$strings.LabelPublishYear" @input="handleInputChange" />
         </div>
       </div>
 

--- a/server/models/Book.js
+++ b/server/models/Book.js
@@ -1,6 +1,7 @@
 const { DataTypes, Model } = require('sequelize')
 const Logger = require('../Logger')
 const { getTitlePrefixAtEnd, getTitleIgnorePrefix } = require('../utils')
+const { normalizePublishedYear } = require('../utils/metadataUtils')
 const parseNameString = require('../utils/parsers/parseNameString')
 const htmlSanitizer = require('../utils/htmlSanitizer')
 const libraryItemsBookFilters = require('../utils/queries/libraryItemsBookFilters')
@@ -377,6 +378,10 @@ class Book extends Model {
       metadataStringKeys.forEach((key) => {
         if (typeof payload.metadata[key] == 'number') {
           payload.metadata[key] = String(payload.metadata[key])
+        }
+
+        if (key === 'publishedYear') {
+          payload.metadata[key] = normalizePublishedYear(payload.metadata[key])
         }
 
         if ((typeof payload.metadata[key] === 'string' || payload.metadata[key] === null) && this[key] !== payload.metadata[key]) {

--- a/server/scanner/BookScanner.js
+++ b/server/scanner/BookScanner.js
@@ -3,6 +3,7 @@ const Path = require('path')
 const sequelize = require('sequelize')
 const { LogLevel } = require('../utils/constants')
 const { getTitleIgnorePrefix, areEquivalent } = require('../utils/index')
+const { normalizePublishedYear } = require('../utils/metadataUtils')
 const parseNameString = require('../utils/parsers/parseNameString')
 const parseEbookMetadata = require('../utils/parsers/parseEbookMetadata')
 const globals = require('../utils/globals')
@@ -690,6 +691,9 @@ class BookScanner {
         libraryScan.addLog(LogLevel.ERROR, `Invalid metadata source "${metadataSource}"`)
       }
     }
+
+    // Metadata precedence may leave a full ISO date in the year-only field.
+    bookMetadata.publishedYear = normalizePublishedYear(bookMetadata.publishedYear)
 
     // Set cover from library file if one is found otherwise check audiofile
     if (libraryItemData.imageLibraryFiles.length) {

--- a/server/utils/metadataUtils.js
+++ b/server/utils/metadataUtils.js
@@ -1,0 +1,14 @@
+/**
+ * Normalize ISO-style published dates to the book metadata year format.
+ *
+ * @param {*} value
+ * @returns {*}
+ */
+function normalizePublishedYear(value) {
+  if (typeof value !== 'string') return value
+
+  const match = value.match(/^(\d{4})(?:-|$)/)
+  return match ? match[1] : value
+}
+
+module.exports = { normalizePublishedYear }

--- a/test/server/models/Book.test.js
+++ b/test/server/models/Book.test.js
@@ -1,0 +1,24 @@
+const { expect } = require('chai')
+const sinon = require('sinon')
+const Book = require('../../../server/models/Book')
+
+describe('Book', () => {
+  describe('updateFromRequest', () => {
+    it('normalizes an ISO date submitted as the published year', async () => {
+      const book = {
+        title: 'Test Book',
+        publishedYear: null,
+        save: sinon.stub().resolves(),
+        changed: sinon.stub().returns(['publishedYear'])
+      }
+
+      const updated = await Book.prototype.updateFromRequest.call(book, {
+        metadata: { publishedYear: '2013-01-01' }
+      })
+
+      expect(updated).to.equal(true)
+      expect(book.publishedYear).to.equal('2013')
+      expect(book.save.calledOnce).to.equal(true)
+    })
+  })
+})

--- a/test/server/scanner/BookScanner.test.js
+++ b/test/server/scanner/BookScanner.test.js
@@ -1,0 +1,33 @@
+const chai = require('chai')
+const expect = chai.expect
+const BookScanner = require('../../../server/scanner/BookScanner')
+
+describe('BookScanner', () => {
+  let serverSettings
+
+  beforeEach(() => {
+    serverSettings = global.ServerSettings
+    global.ServerSettings = { sortingPrefixes: [] }
+  })
+
+  afterEach(() => {
+    if (serverSettings === undefined) delete global.ServerSettings
+    else global.ServerSettings = serverSettings
+  })
+
+  describe('getBookMetadataFromScanData', () => {
+    it('normalizes an ISO date from audio metadata after sources are applied', async () => {
+      const libraryItemData = {
+        mediaMetadata: { title: 'Test Book' },
+        imageLibraryFiles: []
+      }
+      const libraryScan = { addLog() {} }
+
+      const metadata = await BookScanner.getBookMetadataFromScanData([{ metaTags: { tagDate: '2013-01-01' }, chapters: [] }], null, libraryItemData, libraryScan, {
+        metadataPrecedence: ['audioMetatags']
+      })
+
+      expect(metadata.publishedYear).to.equal('2013')
+    })
+  })
+})

--- a/test/server/utils/metadataUtils.test.js
+++ b/test/server/utils/metadataUtils.test.js
@@ -1,0 +1,22 @@
+const chai = require('chai')
+const expect = chai.expect
+const { normalizePublishedYear } = require('../../../server/utils/metadataUtils')
+
+describe('normalizePublishedYear', () => {
+  it('keeps a four-digit year unchanged', () => {
+    expect(normalizePublishedYear('2013')).to.equal('2013')
+  })
+
+  it('extracts the year from ISO-style dates', () => {
+    expect(normalizePublishedYear('2013-01')).to.equal('2013')
+    expect(normalizePublishedYear('2013-01-01')).to.equal('2013')
+    expect(normalizePublishedYear('2013-01-01T12:34:56')).to.equal('2013')
+  })
+
+  it('leaves unsupported values unchanged', () => {
+    expect(normalizePublishedYear(null)).to.equal(null)
+    expect(normalizePublishedYear(2013)).to.equal(2013)
+    expect(normalizePublishedYear('01-01-2013')).to.equal('01-01-2013')
+    expect(normalizePublishedYear('2013/01/01')).to.equal('2013/01/01')
+  })
+})


### PR DESCRIPTION
## Brief summary

Normalizes ISO-style dates submitted or scanned as a book's publish year to a four-digit year.

## Which issue is fixed?

Fixes #2270

## In-depth Description

The scanner normalizes metadata after source precedence is resolved. Manual metadata edits now accept ISO dates and the server normalizes them before persisting, so API clients follow the same rule.

Only values beginning with `YYYY` or `YYYY-` are normalized. `publishedDate` is unchanged.

## How have you tested this?

- `npm test` (359 passing)
- Targeted unit tests for the normalizer, scanner, and manual update path
- Manual Chrome test: entered `2013-02-01` in Publish Year and confirmed the saved value is `2013`

## Screenshots

Not included; this is a small metadata edit field behavior change.