### PR TITLE
add npmv12 compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2113,6 +2113,21 @@
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "devOptional": true
     },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -65,5 +65,8 @@
     "nodemon": "^2.0.20",
     "nyc": "^15.1.0",
     "sinon": "^17.0.1"
+  },
+  "allowScripts": {
+    "sqlite3@5.1.7": true
   }
 }


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

This adds the approved builds for `npm v12` to allow sqlite to work.

With npm v12 GitHub changed how default  

## Which issue is fixed?

Fixes #5412 (While this fixes the issue, the actual issue occurs, because these users use incompatible software [I think]). To my knowledge only the following Node versions support npm v12:
```
{"node":"^22.22.2 || ^24.15.0 || >=26.0.0"}
```

As ABS only supports Node 20, it should not even be applicable. But as in the future ABS should support newer versions and this is a non destructive change, I think this should be merged

## In-depth Description

Above

## How have you tested this?

Ran server

## Screenshots

<!-- If your PR includes any changes to the web client, please include screenshots or a short video from before and after your changes. -->
