### PR TITLE
Fix Audible search when products are null

### DIFF
--- a/server/providers/Audible.js
+++ b/server/providers/Audible.js
@@ -159,7 +159,7 @@ class Audible {
           timeout
         })
         .then((res) => {
-          if (!res?.data?.products) return null
+          if (!res?.data?.products) return []
           return Promise.all(res.data.products.map((result) => this.asinSearch(result.asin, region, timeout)))
         })
         .catch((error) => {


### PR DESCRIPTION
## Brief summary

Audible catalog search responses can contain a null or missing products value. Returning an empty array keeps the search result type consistent and prevents filter() from being called on null.

## Which issue is fixed?

Fixes #5176

## In-depth Description

When the Audible catalog API response did not contain products, the search callback returned null. Later, Audible.search() called items.filter(...), causing TypeError: Cannot read properties of null (reading 'filter'). This change returns an empty array when products is missing or null.

## How have you tested this?

Manually simulated an Audible API response with products: null and confirmed that Audible.search() returns an empty array without throwing an error.

Ran the full server test suite with npm test; 354 tests passed.
