### PR TITLE
Fix: Validate username and password types before authentication

### DIFF
--- a/server/auth/LocalAuthStrategy.js
+++ b/server/auth/LocalAuthStrategy.js
@@ -49,6 +49,11 @@ class LocalAuthStrategy {
    * @param {Function} done - Passport callback
    */
   async verifyCredentials(req, username, password, done) {
+    if (typeof username !== 'string' || typeof password !== 'string') {
+      done(null, null)
+      return
+    }
+
     // Load the user given it's username
     const user = await Database.userModel.getUserByUsername(username.toLowerCase())
 

--- a/test/server/auth/LocalAuthStrategy.test.js
+++ b/test/server/auth/LocalAuthStrategy.test.js
@@ -1,0 +1,50 @@
+const { expect } = require('chai')
+const sinon = require('sinon')
+
+require('../../../server/Database')
+const LocalAuthStrategy = require('../../../server/auth/LocalAuthStrategy')
+
+describe('LocalAuthStrategy - verifyCredentials type validation', () => {
+  /** @type {LocalAuthStrategy} */
+  let strategy
+  let done
+
+  beforeEach(() => {
+    strategy = new LocalAuthStrategy()
+    done = sinon.spy()
+  })
+
+  afterEach(() => {
+    sinon.restore()
+  })
+
+  it('rejects a non-string username before querying the database', async () => {
+    await strategy.verifyCredentials({}, null, 'password', done)
+
+    expect(done.calledOnceWithExactly(null, null)).to.equal(true)
+  })
+
+  it('rejects a non-string password before querying the database', async () => {
+    await strategy.verifyCredentials({}, 'username', null, done)
+
+    expect(done.calledOnceWithExactly(null, null)).to.equal(true)
+  })
+
+  it('rejects all non-string username and password values', async () => {
+    const invalidValues = [undefined, null, 123, true, {}, []]
+
+    for (const value of invalidValues) {
+      done.resetHistory()
+
+      await strategy.verifyCredentials({}, value, 'password', done)
+
+      expect(done.calledOnceWithExactly(null, null)).to.equal(true)
+
+      done.resetHistory()
+
+      await strategy.verifyCredentials({}, 'username', value, done)
+
+      expect(done.calledOnceWithExactly(null, null)).to.equal(true)
+    }
+  })
+})


### PR DESCRIPTION
## Brief summary

Local login strategy did not validate the types of the passed username and password .

This adds a type guard to prevent a fatal crash and to ensure that both fields are treated as strings.
## Which issue is fixed?

N/A

## In-depth Description
The previous implementation of `LocalAuthStrategy.js` implicitly trusted the types of the `username` and `password` values, assuming they were always strings. This can lead to a fatal crash if a user sends a JSON object with either one or both values set to another data primitive like an `int`.

``` javascript
async verifyCredentials(req, username, password, done) {
    // Load the user given it's username
    const user = await Database.userModel.getUserByUsername(username.toLowerCase())
```     
    
 The reason for the fatal crash is because the `verifyCredentials` function takes the username value and performs the `toLowerCase()` function which will not exist if username is anything other than a string. 
 
 It will also fatally crash if password is set to something other than a string because it would be an illegal argument for `bcrypt.hash`.

## How have you tested this?

Added a test script and `npm test` passed. 357/357

Also passwordless root still works because the password is technically a empty string.
