### PR TITLE
Fix upload crash with repeated file fields

### DIFF
--- a/server/controllers/MiscController.js
+++ b/server/controllers/MiscController.js
@@ -42,7 +42,7 @@ class MiscController {
       return res.sendStatus(400)
     }
 
-    const files = Object.values(req.files)
+    const files = Object.values(req.files).flat()
     let { title, author, series, folder: folderId, library: libraryId } = req.body
     // Validate request body
     if (!libraryId || !folderId || typeof libraryId !== 'string' || typeof folderId !== 'string' || !title || typeof title !== 'string') {


### PR DESCRIPTION
## Brief summary

Fix `/api/upload` when multiple files use the same multipart field name.

## Which issue is fixed?

None.

## In-depth Description

The upload middleware turns a repeated file field into an array:

```js
{
  files: [firstFile, secondFile]
}
```

`handleUpload` treats each value in `req.files` as a single file, so `file.name` is undefined and the server exits on the unhandled rejection.

The web uploader avoids this by giving each file a different numeric field name. Flattening the values supports both forms.

## How have you tested this?

Called `handleUpload` with two files under the same field name.

Before the change:

```text
TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received type boolean (false)
```

After the change, both files are moved and the request returns 200.

## Screenshots

N/A