### PR TITLE
Replace server axios with node fetch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,13 @@
       "version": "2.36.0",
       "license": "GPL-3.0",
       "dependencies": {
-        "axios": "^0.27.2",
         "cookie-parser": "^1.4.6",
         "express": "^4.17.1",
         "express-rate-limit": "^7.5.1",
         "express-session": "^1.17.3",
         "graceful-fs": "^4.2.10",
         "htmlparser2": "^8.0.1",
+        "ipaddr.js": "^2.2.0",
         "lru-cache": "^10.0.3",
         "node-unrar-js": "^2.0.2",
         "nodemailer": "^6.9.13",
@@ -27,7 +27,7 @@
         "sequelize": "^6.35.2",
         "socket.io": "^4.5.4",
         "sqlite3": "^5.1.7",
-        "ssrf-req-filter": "^1.1.0",
+        "undici": "^7.29.0",
         "xml2js": "^0.5.0"
       },
       "bin": {
@@ -902,20 +902,6 @@
         "node": "*"
       }
     },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
-    },
-    "node_modules/axios": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
-      "dependencies": {
-        "follow-redirects": "^1.14.9",
-        "form-data": "^4.0.0"
-      }
-    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -1359,17 +1345,6 @@
         "color-support": "bin.js"
       }
     },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/commondir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
@@ -1541,14 +1516,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/delegates": {
@@ -2009,25 +1976,6 @@
         "flat": "cli.js"
       }
     },
-    "node_modules/follow-redirects": {
-      "version": "1.15.5",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
-      "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/foreground-child": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-2.0.0.tgz",
@@ -2039,19 +1987,6 @@
       },
       "engines": {
         "node": ">=8.0.0"
-      }
-    },
-    "node_modules/form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/forwarded": {
@@ -2523,11 +2458,12 @@
       "optional": true
     },
     "node_modules/ipaddr.js": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
-      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.5.0.tgz",
+      "integrity": "sha512-aq+t5NAc+cS6rZQQVWC2x98CPqGtKKTMDd4Gaodv0wShnItdKg/51djkGJ1hqH+Oy0ivDftCbSLCQob8zso01w==",
+      "license": "MIT",
       "engines": {
-        "node": ">= 0.10"
+        "node": ">= 10"
       }
     },
     "node_modules/is-binary-path": {
@@ -4257,6 +4193,15 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/proxy-addr/node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/pstree.remy": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
@@ -4991,22 +4936,6 @@
         }
       }
     },
-    "node_modules/ssrf-req-filter": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/ssrf-req-filter/-/ssrf-req-filter-1.1.0.tgz",
-      "integrity": "sha512-YUyTinAEm52NsoDvkTFN9BQIa5nURNr2aN0BwOiJxHK3tlyGUczHa+2LjcibKNugAk/losB6kXOfcRzy0LQ4uA==",
-      "dependencies": {
-        "ipaddr.js": "^2.1.0"
-      }
-    },
-    "node_modules/ssrf-req-filter/node_modules/ipaddr.js": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.1.0.tgz",
-      "integrity": "sha512-LlbxQ7xKzfBusov6UMi4MFpEg0m+mAm9xyNGEduwXMEDuf4WfzB/RZwMVYEd7IKGvh4IUkEXYxtAVu9T3OelJQ==",
-      "engines": {
-        "node": ">= 10"
-      }
-    },
     "node_modules/ssri": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.1.tgz",
@@ -5279,6 +5208,15 @@
       "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
       "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
       "dev": true
+    },
+    "node_modules/undici": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
     },
     "node_modules/unique-filename": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -38,13 +38,13 @@
   "author": "advplyr",
   "license": "GPL-3.0",
   "dependencies": {
-    "axios": "^0.27.2",
     "cookie-parser": "^1.4.6",
     "express": "^4.17.1",
     "express-rate-limit": "^7.5.1",
     "express-session": "^1.17.3",
     "graceful-fs": "^4.2.10",
     "htmlparser2": "^8.0.1",
+    "ipaddr.js": "^2.2.0",
     "lru-cache": "^10.0.3",
     "node-unrar-js": "^2.0.2",
     "nodemailer": "^6.9.13",
@@ -56,7 +56,7 @@
     "sequelize": "^6.35.2",
     "socket.io": "^4.5.4",
     "sqlite3": "^5.1.7",
-    "ssrf-req-filter": "^1.1.0",
+    "undici": "^7.29.0",
     "xml2js": "^0.5.0"
   },
   "devDependencies": {

--- a/server/Server.js
+++ b/server/Server.js
@@ -6,7 +6,6 @@ const util = require('util')
 const fs = require('./libs/fsExtra')
 const fileUpload = require('./libs/expressFileupload')
 const cookieParser = require('cookie-parser')
-const axios = require('axios')
 
 const { version } = require('../package.json')
 
@@ -63,20 +62,6 @@ class Server {
       Logger.info(`[Server] Experimental Proxy Support Enabled, SSRF Request Filter was Disabled`)
       global.DisableSsrfRequestFilter = () => true
 
-      axios.defaults.maxRedirects = 0
-      axios.interceptors.response.use(
-        (response) => response,
-        (error) => {
-          if ([301, 302].includes(error.response?.status)) {
-            return axios({
-              ...error.config,
-              url: error.response.headers.location
-            })
-          }
-
-          return Promise.reject(error)
-        }
-      )
     } else if (process.env.DISABLE_SSRF_REQUEST_FILTER === '1') {
       Logger.info(`[Server] SSRF Request Filter Disabled`)
       global.DisableSsrfRequestFilter = () => true

--- a/server/auth/OidcAuthStrategy.js
+++ b/server/auth/OidcAuthStrategy.js
@@ -1,10 +1,10 @@
 const { Request, Response } = require('express')
 const passport = require('passport')
 const OpenIDClient = require('openid-client')
-const axios = require('axios')
 const Database = require('../Database')
 const Logger = require('../Logger')
 const { getRequestOrigin } = require('../utils/requestUtils')
+const { safeFetchJson } = require('../utils/fetchUtils')
 
 /**
  * OpenID Connect authentication strategy
@@ -452,7 +452,7 @@ class OidcAuthStrategy {
     }
 
     try {
-      const { data } = await axios.get(configUrl.toString())
+      const data = await safeFetchJson(configUrl.toString())
       return {
         issuer: data.issuer,
         authorization_endpoint: data.authorization_endpoint,

--- a/server/auth/OidcAuthStrategy.js
+++ b/server/auth/OidcAuthStrategy.js
@@ -4,7 +4,7 @@ const OpenIDClient = require('openid-client')
 const Database = require('../Database')
 const Logger = require('../Logger')
 const { getRequestOrigin } = require('../utils/requestUtils')
-const { safeFetchJson } = require('../utils/fetchUtils')
+const { fetchJson } = require('../utils/fetchUtils')
 
 /**
  * OpenID Connect authentication strategy
@@ -452,7 +452,7 @@ class OidcAuthStrategy {
     }
 
     try {
-      const data = await safeFetchJson(configUrl.toString())
+      const data = await fetchJson(configUrl.toString())
       return {
         issuer: data.issuer,
         authorization_endpoint: data.authorization_endpoint,

--- a/server/managers/BinaryManager.js
+++ b/server/managers/BinaryManager.js
@@ -2,13 +2,14 @@ const child_process = require('child_process')
 const { promisify } = require('util')
 const exec = promisify(child_process.exec)
 const os = require('os')
-const axios = require('axios')
+const { Readable } = require('node:stream')
 const path = require('path')
 const which = require('../libs/which')
 const fs = require('../libs/fsExtra')
 const Logger = require('../Logger')
 const fileUtils = require('../utils/fileUtils')
 const StreamZip = require('../libs/nodeStreamZip')
+const { fetchJson, fetchResponse } = require('../utils/fetchUtils')
 
 class ZippedAssetDownloader {
   constructor() {
@@ -38,10 +39,10 @@ class ZippedAssetDownloader {
     } else {
       // Get the release information
       const releaseUrl = this.getReleaseUrl(releaseTag)
-      const releaseResponse = await axios.get(releaseUrl, { headers: { 'User-Agent': 'axios' } })
+      const releaseData = await fetchJson(releaseUrl, { headers: { 'User-Agent': 'audiobookshelf' } })
 
       // Cache the assets information for the release tag
-      this.assetCache[releaseTag] = releaseResponse.data
+      this.assetCache[releaseTag] = releaseData
       Logger.debug(`[ZippedAssetDownloader] release ${releaseTag}: assets fetched from API.`)
     }
 
@@ -55,9 +56,10 @@ class ZippedAssetDownloader {
     const zipPath = path.join(destDir, 'temp.zip')
     const writer = fs.createWriteStream(zipPath)
 
-    const assetResponse = await axios({ url: assetUrl, responseType: 'stream' })
+    const assetResponse = await fetchResponse(assetUrl)
+    if (!assetResponse.body) throw new Error(`Empty response body for ${assetUrl}`)
 
-    assetResponse.data.pipe(writer)
+    Readable.fromWeb(assetResponse.body).pipe(writer)
 
     await new Promise((resolve, reject) => {
       writer.on('finish', () => {

--- a/server/managers/NotificationManager.js
+++ b/server/managers/NotificationManager.js
@@ -1,8 +1,8 @@
-const axios = require('axios')
 const Logger = require('../Logger')
 const SocketAuthority = require('../SocketAuthority')
 const Database = require('../Database')
 const { notificationData } = require('../utils/notifications')
+const { safeFetchResponse } = require('../utils/fetchUtils')
 
 class NotificationManager {
   constructor() {
@@ -221,10 +221,14 @@ class NotificationManager {
 
   sendNotification(notification, eventData) {
     const payload = notification.getApprisePayload(eventData)
-    return axios
-      .post(Database.notificationSettings.appriseApiUrl, payload, { timeout: 6000 })
+    return safeFetchResponse(Database.notificationSettings.appriseApiUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+      timeout: 6000
+    })
       .then((response) => {
-        Logger.debug(`[NotificationManager] sendNotification: ${notification.eventName}/${notification.id} response=`, response.data)
+        Logger.debug(`[NotificationManager] sendNotification: ${notification.eventName}/${notification.id} response=${response.status}`)
         return true
       })
       .catch((error) => {

--- a/server/managers/NotificationManager.js
+++ b/server/managers/NotificationManager.js
@@ -2,7 +2,7 @@ const Logger = require('../Logger')
 const SocketAuthority = require('../SocketAuthority')
 const Database = require('../Database')
 const { notificationData } = require('../utils/notifications')
-const { safeFetchResponse } = require('../utils/fetchUtils')
+const { fetchResponse } = require('../utils/fetchUtils')
 
 class NotificationManager {
   constructor() {
@@ -221,7 +221,7 @@ class NotificationManager {
 
   sendNotification(notification, eventData) {
     const payload = notification.getApprisePayload(eventData)
-    return safeFetchResponse(Database.notificationSettings.appriseApiUrl, {
+    return fetchResponse(Database.notificationSettings.appriseApiUrl, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload),

--- a/server/providers/Audible.js
+++ b/server/providers/Audible.js
@@ -1,6 +1,6 @@
-const axios = require('axios').default
 const Logger = require('../Logger')
 const { isValidASIN } = require('../utils/index')
+const { fetchJson } = require('../utils/fetchUtils')
 
 class Audible {
   #responseTimeout = 10000
@@ -102,13 +102,10 @@ class Audible {
     var regionQuery = region ? `?region=${region}` : ''
     var url = `https://api.audnex.us/books/${asin}${regionQuery}`
     Logger.debug(`[Audible] ASIN url: ${url}`)
-    return axios
-      .get(url, {
-        timeout
-      })
-      .then((res) => {
-        if (!res?.data?.asin) return null
-        return res.data
+    return fetchJson(url, { timeout })
+      .then((data) => {
+        if (!data?.asin) return null
+        return data
       })
       .catch((error) => {
         Logger.error('[Audible] ASIN search error', error.message)
@@ -154,13 +151,10 @@ class Audible {
       const tld = region ? this.regionMap[region] : '.com'
       const url = `https://api.audible${tld}/1.0/catalog/products?${queryString}`
       Logger.debug(`[Audible] Search url: ${url}`)
-      items = await axios
-        .get(url, {
-          timeout
-        })
-        .then((res) => {
-          if (!res?.data?.products) return null
-          return Promise.all(res.data.products.map((result) => this.asinSearch(result.asin, region, timeout)))
+      items = await fetchJson(url, { timeout })
+        .then((data) => {
+          if (!data?.products) return null
+          return Promise.all(data.products.map((result) => this.asinSearch(result.asin, region, timeout)))
         })
         .catch((error) => {
           Logger.error('[Audible] query search error', error.message)

--- a/server/providers/AudiobookCovers.js
+++ b/server/providers/AudiobookCovers.js
@@ -1,5 +1,5 @@
-const axios = require('axios')
 const Logger = require('../Logger')
+const { fetchJson } = require('../utils/fetchUtils')
 
 class AudiobookCovers {
   #responseTimeout = 10000
@@ -15,14 +15,10 @@ class AudiobookCovers {
   async search(search, timeout = this.#responseTimeout) {
     if (!timeout || isNaN(timeout)) timeout = this.#responseTimeout
 
-    const url = `https://api.audiobookcovers.com/cover/bytext/`
-    const params = new URLSearchParams([['q', search]])
-    const items = await axios
-      .get(url, {
-        params,
-        timeout
-      })
-      .then((res) => res?.data || [])
+    const url = new URL('https://api.audiobookcovers.com/cover/bytext/')
+    url.searchParams.set('q', search)
+    const items = await fetchJson(url, { timeout })
+      .then((data) => data || [])
       .catch((error) => {
         Logger.error('[AudiobookCovers] Cover search error', error.message)
         return []

--- a/server/providers/Audnexus.js
+++ b/server/providers/Audnexus.js
@@ -1,8 +1,8 @@
-const axios = require('axios').default
 const Throttle = require('p-throttle')
 const Logger = require('../Logger')
 const { levenshteinDistance } = require('../utils/index')
 const { isValidASIN } = require('../utils/index')
+const { fetchJson } = require('../utils/fetchUtils')
 
 /**
  * @typedef AuthorSearchObj
@@ -52,8 +52,8 @@ class Audnexus {
     const authorRequestUrl = `${this.baseUrl}/authors?${searchParams.toString()}`
     Logger.info(`[Audnexus] Searching for author "${authorRequestUrl}"`)
 
-    return this._processRequest(this.limiter(() => axios.get(authorRequestUrl)))
-      .then((res) => res.data || [])
+    return this._processRequest(this.limiter(() => fetchJson(authorRequestUrl)))
+      .then((data) => data || [])
       .catch((error) => {
         Logger.error(`[Audnexus] Author ASIN request failed for ${name}`, error.message)
         return []
@@ -79,8 +79,8 @@ class Audnexus {
 
     Logger.info(`[Audnexus] Searching for author "${authorRequestUrl}"`)
 
-    return this._processRequest(this.limiter(() => axios.get(authorRequestUrl.toString())))
-      .then((res) => res.data)
+    return this._processRequest(this.limiter(() => fetchJson(authorRequestUrl.toString())))
+      .then((data) => data)
       .catch((error) => {
         Logger.error(`[Audnexus] Author request failed for ${asin}`, error.message)
         return null
@@ -155,8 +155,8 @@ class Audnexus {
     const chaptersRequestUrl = new URL(`${this.baseUrl}/books/${asin}/chapters`)
     if (region) chaptersRequestUrl.searchParams.set('region', region)
 
-    return this._processRequest(this.limiter(() => axios.get(chaptersRequestUrl.toString())))
-      .then((res) => res.data)
+    return this._processRequest(this.limiter(() => fetchJson(chaptersRequestUrl.toString())))
+      .then((data) => data)
       .catch((error) => {
         Logger.error(`[Audnexus] Chapter ASIN request failed for ${asin}/${region}`, error.message)
         return null

--- a/server/providers/CustomProviderAdapter.js
+++ b/server/providers/CustomProviderAdapter.js
@@ -54,7 +54,7 @@ class CustomProviderAdapter {
       }
     }
 
-    const matches = await safeFetchJson(url, fetchOptions)
+    const matches = await safeFetchJson(url, { ...fetchOptions, allowPrivateNetwork: true })
       .then((data) => {
         if (!data || !Array.isArray(data.matches)) return null
         return data.matches

--- a/server/providers/CustomProviderAdapter.js
+++ b/server/providers/CustomProviderAdapter.js
@@ -1,7 +1,7 @@
-const axios = require('axios').default
 const Database = require('../Database')
 const Logger = require('../Logger')
 const htmlSanitizer = require('../utils/htmlSanitizer')
+const { safeFetchJson } = require('../utils/fetchUtils')
 
 class CustomProviderAdapter {
   #responseTimeout = 10000
@@ -45,20 +45,19 @@ class CustomProviderAdapter {
     Logger.debug(`[CustomMetadataProvider] Search url: ${url}`)
 
     // Setup headers
-    const axiosOptions = {
+    const fetchOptions = {
       timeout
     }
     if (provider.authHeaderValue) {
-      axiosOptions.headers = {
+      fetchOptions.headers = {
         Authorization: provider.authHeaderValue
       }
     }
 
-    const matches = await axios
-      .get(url, axiosOptions)
-      .then((res) => {
-        if (!res?.data || !Array.isArray(res.data.matches)) return null
-        return res.data.matches
+    const matches = await safeFetchJson(url, fetchOptions)
+      .then((data) => {
+        if (!data || !Array.isArray(data.matches)) return null
+        return data.matches
       })
       .catch((error) => {
         Logger.error('[CustomMetadataProvider] Search error', error.message)

--- a/server/providers/FantLab.js
+++ b/server/providers/FantLab.js
@@ -1,5 +1,5 @@
-const axios = require('axios')
 const Logger = require('../Logger')
+const { fetchJson } = require('../utils/fetchUtils')
 
 class FantLab {
   #responseTimeout = 10000
@@ -40,12 +40,9 @@ class FantLab {
     }
     const url = `${this._baseUrl}/search-works?q=${searchString}&page=1&onlymatches=1`
     Logger.debug(`[FantLab] Search url: ${url}`)
-    const items = await axios
-      .get(url, {
-        timeout
-      })
-      .then((res) => {
-        return res.data || []
+    const items = await fetchJson(url, { timeout })
+      .then((data) => {
+        return data || []
       })
       .catch((error) => {
         Logger.error('[FantLab] search error', error.message)
@@ -69,12 +66,9 @@ class FantLab {
     }
 
     const url = `${this._baseUrl}/work/${work_id}/extended`
-    const bookData = await axios
-      .get(url, {
-        timeout
-      })
-      .then((resp) => {
-        return resp.data || null
+    const bookData = await fetchJson(url, { timeout })
+      .then((data) => {
+        return data || null
       })
       .catch((error) => {
         Logger.error(`[FantLab] work info request for url "${url}" error`, error.message)
@@ -185,12 +179,9 @@ class FantLab {
 
     const url = `${this._baseUrl}/edition/${editionId}`
 
-    const editionInfo = await axios
-      .get(url, {
-        timeout
-      })
-      .then((resp) => {
-        return resp.data || null
+    const editionInfo = await fetchJson(url, { timeout })
+      .then((data) => {
+        return data || null
       })
       .catch((error) => {
         Logger.error(`[FantLab] search cover from edition with url "${url}" error`, error.message)

--- a/server/providers/GoogleBooks.js
+++ b/server/providers/GoogleBooks.js
@@ -1,5 +1,5 @@
-const axios = require('axios')
 const Logger = require('../Logger')
+const { fetchJson } = require('../utils/fetchUtils')
 
 class GoogleBooks {
   #responseTimeout = 10000
@@ -58,13 +58,10 @@ class GoogleBooks {
     }
     const url = `https://www.googleapis.com/books/v1/volumes?${queryString}`
     Logger.debug(`[GoogleBooks] Search url: ${url}`)
-    const items = await axios
-      .get(url, {
-        timeout
-      })
-      .then((res) => {
-        if (!res || !res.data || !res.data.items) return []
-        return res.data.items
+    const items = await fetchJson(url, { timeout })
+      .then((data) => {
+        if (!data?.items) return []
+        return data.items
       })
       .catch((error) => {
         Logger.error('[GoogleBooks] Volume search error', error.message)

--- a/server/providers/MusicBrainz.js
+++ b/server/providers/MusicBrainz.js
@@ -1,7 +1,7 @@
-const axios = require('axios')
 const packageJson = require('../../package.json')
 const Logger = require('../Logger')
 const { isNullOrNaN } = require('../utils/index')
+const { fetchJson } = require('../utils/fetchUtils')
 
 class MusicBrainz {
   constructor() { }
@@ -35,13 +35,10 @@ class MusicBrainz {
       limit: isNullOrNaN(options.limit) ? 15 : Number(options.limit),
       fmt: 'json'
     }
-    const config = {
-      headers: {
-        'User-Agent': this.userAgentString
-      }
-    }
-    return axios.get('https://musicbrainz.org/ws/2/recording', { params: query }, config).then((response) => {
-      return response.data.recordings || []
+    const url = new URL('https://musicbrainz.org/ws/2/recording')
+    for (const [key, value] of Object.entries(query)) url.searchParams.set(key, value)
+    return fetchJson(url, { headers: { 'User-Agent': this.userAgentString } }).then((data) => {
+      return data.recordings || []
     }).catch((error) => {
       Logger.error(`[MusicBrainz] search request error`, error)
       return []

--- a/server/providers/OpenLibrary.js
+++ b/server/providers/OpenLibrary.js
@@ -1,4 +1,4 @@
-const axios = require('axios').default
+const { fetchJson } = require('../utils/fetchUtils')
 
 class OpenLibrary {
   #responseTimeout = 10000
@@ -15,13 +15,7 @@ class OpenLibrary {
    */
   get(uri, timeout = this.#responseTimeout) {
     if (!timeout || isNaN(timeout)) timeout = this.#responseTimeout
-    return axios
-      .get(`${this.baseUrl}/${uri}`, {
-        timeout
-      })
-      .then((res) => {
-        return res.data
-      })
+    return fetchJson(`${this.baseUrl}/${uri}`, { timeout })
       .catch((error) => {
         console.error('Failed', error.message)
         return null

--- a/server/providers/iTunes.js
+++ b/server/providers/iTunes.js
@@ -1,6 +1,6 @@
-const axios = require('axios')
 const Logger = require('../Logger')
 const htmlSanitizer = require('../utils/htmlSanitizer')
+const { fetchJson } = require('../utils/fetchUtils')
 
 /**
  * @typedef iTunesSearchParams
@@ -54,13 +54,13 @@ class iTunes {
       limit: options.limit,
       country: options.country
     }
-    return axios
-      .get('https://itunes.apple.com/search', {
-        params: query,
-        timeout
-      })
-      .then((response) => {
-        return response.data.results || []
+    const url = new URL('https://itunes.apple.com/search')
+    for (const [key, value] of Object.entries(query)) {
+      if (value !== undefined) url.searchParams.set(key, value)
+    }
+    return fetchJson(url, { timeout })
+      .then((data) => {
+        return data.results || []
       })
       .catch((error) => {
         Logger.error(`[iTunes] search request error`, error.message)

--- a/server/utils/fetchUtils.js
+++ b/server/utils/fetchUtils.js
@@ -6,10 +6,7 @@
  * @returns {Promise<Response>}
  */
 async function fetchResponse(url, { timeout, ...options } = {}) {
-  return assertOk(await fetch(url, {
-    ...options,
-    signal: getRequestSignal(timeout, options.signal)
-  }))
+  return assertOk(await fetchWithTimeout(url, options, timeout, getDispatcher(false)))
 }
 
 /**
@@ -32,7 +29,7 @@ async function safeFetchJson(url, options) {
 module.exports = { fetchJson, fetchResponse, safeFetch, safeFetchJson, safeFetchResponse }
 const dns = require('node:dns')
 const ipaddr = require('ipaddr.js')
-const { Agent } = require('undici')
+const { Agent, EnvHttpProxyAgent, getGlobalDispatcher } = require('undici')
 
 function getAddressRange(address) {
   if (!ipaddr.isValid(address)) return null
@@ -100,11 +97,48 @@ function safeLookup(hostname, options, callback) {
 }
 
 const safeDispatcher = new Agent({ connect: { lookup: safeLookup } })
+let proxyDispatcher = null
 
-function getRequestSignal(timeout, signal) {
-  if (!timeout) return signal
-  const timeoutSignal = AbortSignal.timeout(timeout)
-  return signal ? AbortSignal.any([signal, timeoutSignal]) : timeoutSignal
+function getDispatcher(useSsrfFilter) {
+  if (process.env.EXP_PROXY_SUPPORT === '1') {
+    if (!proxyDispatcher) proxyDispatcher = new EnvHttpProxyAgent()
+    return proxyDispatcher
+  }
+  return useSsrfFilter ? safeDispatcher : getGlobalDispatcher()
+}
+
+/**
+ * Apply the configured timeout while connecting and receiving headers. Once
+ * headers arrive, Undici's bodyTimeout continues to enforce the same timeout
+ * as an inactivity limit between body chunks rather than a total transfer
+ * duration.
+ */
+async function fetchWithTimeout(url, options, timeout, dispatcher) {
+  if (!timeout) {
+    return fetch(url, { ...options, dispatcher })
+  }
+
+  const timeoutController = new AbortController()
+  const timeoutHandle = setTimeout(() => timeoutController.abort(new Error(`Request timed out after ${timeout}ms`)), timeout)
+  timeoutHandle.unref?.()
+  const signal = options.signal
+    ? AbortSignal.any([options.signal, timeoutController.signal])
+    : timeoutController.signal
+
+  try {
+    const timeoutDispatcher = dispatcher.compose((dispatch) => (options, handler) => dispatch({
+      ...options,
+      headersTimeout: timeout,
+      bodyTimeout: timeout
+    }, handler))
+    return await fetch(url, {
+      ...options,
+      signal,
+      dispatcher: timeoutDispatcher
+    })
+  } finally {
+    clearTimeout(timeoutHandle)
+  }
 }
 
 function isRedirect(response) {
@@ -133,21 +167,21 @@ function getRedirectOptions(options, status, currentUrl, nextUrl) {
  * followed manually so each destination receives the same validation.
  *
  * @param {string|URL} url
- * @param {RequestInit & { timeout?: number, maxRedirects?: number }} [options]
+ * @param {RequestInit & { timeout?: number, maxRedirects?: number, allowPrivateNetwork?: boolean }} [options]
  * @returns {Promise<Response>}
  */
-async function safeFetch(url, { timeout, maxRedirects = 5, signal, ...options } = {}) {
+async function safeFetch(url, { timeout, maxRedirects = 5, signal, allowPrivateNetwork = false, ...options } = {}) {
   let currentUrl = getUrl(url)
-  let currentOptions = { ...options, signal: getRequestSignal(timeout, signal) }
+  let currentOptions = { ...options, signal }
 
   for (let redirectCount = 0; ; redirectCount++) {
-    const bypassFilter = global.DisableSsrfRequestFilter?.(currentUrl.toString())
+    const bypassFilter = allowPrivateNetwork || global.DisableSsrfRequestFilter?.(currentUrl.toString())
     if (!bypassFilter) assertAllowedUrl(currentUrl)
-    const response = await fetch(currentUrl, {
+    const dispatcher = getDispatcher(!bypassFilter)
+    const response = await fetchWithTimeout(currentUrl, {
       ...currentOptions,
-      redirect: 'manual',
-      dispatcher: bypassFilter ? undefined : safeDispatcher
-    })
+      redirect: 'manual'
+    }, timeout, dispatcher)
 
     if (!isRedirect(response)) return response
     if (redirectCount >= maxRedirects) {

--- a/server/utils/fetchUtils.js
+++ b/server/utils/fetchUtils.js
@@ -7,16 +7,10 @@
  * @returns {Promise<Response>}
  */
 async function fetchResponse(url, { timeout, ...options } = {}) {
-  const response = await fetch(url, {
+  return assertOk(await fetch(url, {
     ...options,
-    signal: timeout ? AbortSignal.timeout(timeout) : options.signal
-  })
-
-  if (!response.ok) {
-    throw new Error(`HTTP ${response.status}: ${response.statusText}`)
-  }
-
-  return response
+    signal: getRequestSignal(timeout, options.signal)
+  }))
 }
 
 /**
@@ -28,4 +22,145 @@ async function fetchJson(url, options) {
   return (await fetchResponse(url, options)).json()
 }
 
-module.exports = { fetchJson, fetchResponse }
+async function safeFetchResponse(url, options) {
+  return assertOk(await safeFetch(url, options))
+}
+
+async function safeFetchJson(url, options) {
+  return (await safeFetchResponse(url, options)).json()
+}
+
+module.exports = { fetchJson, fetchResponse, safeFetch, safeFetchJson, safeFetchResponse }
+const dns = require('node:dns')
+const ipaddr = require('ipaddr.js')
+const { Agent } = require('undici')
+
+function getAddressRange(address) {
+  if (!ipaddr.isValid(address)) return null
+
+  const parsed = ipaddr.parse(address)
+  if (parsed.kind() === 'ipv6' && parsed.isIPv4MappedAddress()) {
+    return parsed.toIPv4Address().range()
+  }
+  return parsed.range()
+}
+
+function isAllowedAddress(address) {
+  const range = getAddressRange(address)
+  return range === null || range === 'unicast'
+}
+
+function isAllowedResolvedAddress(address) {
+  return typeof address === 'string' && ipaddr.isValid(address) && getAddressRange(address) === 'unicast'
+}
+
+function getUrl(url) {
+  const parsedUrl = new URL(url)
+  if (!['http:', 'https:'].includes(parsedUrl.protocol)) {
+    throw new Error(`Unsupported URL protocol: ${parsedUrl.protocol}`)
+  }
+
+  return parsedUrl
+}
+
+function assertAllowedUrl(url) {
+  const parsedUrl = getUrl(url)
+  const hostname = parsedUrl.hostname.replace(/^\[|\]$/g, '')
+  if (!isAllowedAddress(hostname)) {
+    throw new Error(`Call to ${hostname} is blocked.`)
+  }
+  return parsedUrl
+}
+
+/**
+ * Resolve every DNS result and hand Undici only an allowed address. Because
+ * this lookup is used to create the socket, it cannot be bypassed through a
+ * second lookup after validation.
+ */
+function safeLookup(hostname, options, callback) {
+  if (!isAllowedAddress(hostname)) {
+    callback(new Error(`Call to ${hostname} is blocked.`))
+    return
+  }
+
+  dns.lookup(hostname, { all: true, verbatim: true }, (error, addresses) => {
+    if (error) return callback(error)
+
+    // `dns.lookup` normally returns address objects when `all` is enabled, but
+    // do not pass a malformed resolver result to Undici as an undefined IP.
+    const address = addresses.find((result) =>
+      isAllowedResolvedAddress(result?.address)
+    )
+    if (!address) return callback(new Error(`Call to ${hostname} is blocked.`))
+
+    // Undici requests every address (`all: true`). Match Node's DNS lookup
+    // callback shape in that mode: an array of { address, family } objects.
+    if (options.all) return callback(null, [address])
+    callback(null, address.address, address.family)
+  })
+}
+
+const safeDispatcher = new Agent({ connect: { lookup: safeLookup } })
+
+function getRequestSignal(timeout, signal) {
+  if (!timeout) return signal
+  const timeoutSignal = AbortSignal.timeout(timeout)
+  return signal ? AbortSignal.any([signal, timeoutSignal]) : timeoutSignal
+}
+
+function isRedirect(response) {
+  return [301, 302, 303, 307, 308].includes(response.status)
+}
+
+function getRedirectOptions(options, status) {
+  const method = options.method?.toUpperCase()
+  if (status !== 303 && !([301, 302].includes(status) && method === 'POST')) return options
+
+  const headers = new Headers(options.headers)
+  headers.delete('content-length')
+  headers.delete('content-type')
+  return { ...options, method: 'GET', body: undefined, headers }
+}
+
+/**
+ * Fetch an external URL with connection-time SSRF protection. Redirects are
+ * followed manually so each destination receives the same validation.
+ *
+ * @param {string|URL} url
+ * @param {RequestInit & { timeout?: number, maxRedirects?: number }} [options]
+ * @returns {Promise<Response>}
+ */
+async function safeFetch(url, { timeout, maxRedirects = 5, signal, ...options } = {}) {
+  let currentUrl = getUrl(url)
+  let currentOptions = { ...options, signal: getRequestSignal(timeout, signal) }
+
+  for (let redirectCount = 0; ; redirectCount++) {
+    const bypassFilter = global.DisableSsrfRequestFilter?.(currentUrl.toString())
+    if (!bypassFilter) assertAllowedUrl(currentUrl)
+    const response = await fetch(currentUrl, {
+      ...currentOptions,
+      redirect: 'manual',
+      dispatcher: bypassFilter ? undefined : safeDispatcher
+    })
+
+    if (!isRedirect(response)) return response
+    if (redirectCount >= maxRedirects) {
+      await response.body?.cancel()
+      throw new Error(`Too many redirects while requesting ${currentUrl}`)
+    }
+
+    const location = response.headers.get('location')
+    if (!location) return response
+
+    await response.body?.cancel()
+    currentUrl = getUrl(new URL(location, currentUrl))
+    currentOptions = getRedirectOptions(currentOptions, response.status)
+  }
+}
+
+function assertOk(response) {
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status}: ${response.statusText}`)
+  }
+  return response
+}

--- a/server/utils/fetchUtils.js
+++ b/server/utils/fetchUtils.js
@@ -50,6 +50,10 @@ function isAllowedResolvedAddress(address) {
   return typeof address === 'string' && ipaddr.isValid(address) && getAddressRange(address) === 'unicast'
 }
 
+function isPrivateAddress(address) {
+  return typeof address === 'string' && ipaddr.isValid(address) && getAddressRange(address) !== 'unicast'
+}
+
 function getUrl(url) {
   const parsedUrl = new URL(url)
   if (!['http:', 'https:'].includes(parsedUrl.protocol)) {
@@ -97,13 +101,35 @@ function safeLookup(hostname, options, callback) {
 }
 
 const safeDispatcher = new Agent({ connect: { lookup: safeLookup } })
+// Record how the trusted provider hostname resolved on the connection used for
+// its initial request. Only providers resolving exclusively to blocked/local
+// ranges may carry private-network trust across redirects.
+const trustedLocalHostnames = new Map()
+
+function trustedLookup(hostname, options, callback) {
+  dns.lookup(hostname, { all: true, verbatim: true }, (error, addresses) => {
+    if (error) return callback(error)
+
+    const validAddresses = addresses.filter((result) => typeof result?.address === 'string' && ipaddr.isValid(result.address))
+    if (!validAddresses.length) return callback(new Error(`Unable to resolve ${hostname}.`))
+
+    trustedLocalHostnames.set(hostname, validAddresses.every((result) => isPrivateAddress(result.address)))
+    if (options.all) return callback(null, validAddresses)
+
+    const address = validAddresses[0]
+    callback(null, address.address, address.family)
+  })
+}
+
+const trustedDispatcher = new Agent({ connect: { lookup: trustedLookup } })
 let proxyDispatcher = null
 
-function getDispatcher(useSsrfFilter) {
+function getDispatcher(useSsrfFilter, allowPrivateNetwork = false) {
   if (process.env.EXP_PROXY_SUPPORT === '1') {
     if (!proxyDispatcher) proxyDispatcher = new EnvHttpProxyAgent()
     return proxyDispatcher
   }
+  if (allowPrivateNetwork) return trustedDispatcher
   return useSsrfFilter ? safeDispatcher : getGlobalDispatcher()
 }
 
@@ -173,15 +199,22 @@ function getRedirectOptions(options, status, currentUrl, nextUrl) {
 async function safeFetch(url, { timeout, maxRedirects = 5, signal, allowPrivateNetwork = false, ...options } = {}) {
   let currentUrl = getUrl(url)
   let currentOptions = { ...options, signal }
+  const originalHostname = currentUrl.hostname.replace(/^\[|\]$/g, '')
+  let originalProviderIsLocal = isPrivateAddress(originalHostname)
 
   for (let redirectCount = 0; ; redirectCount++) {
-    const bypassFilter = allowPrivateNetwork || global.DisableSsrfRequestFilter?.(currentUrl.toString())
+    const allowPrivateForRequest = allowPrivateNetwork && (redirectCount === 0 || originalProviderIsLocal)
+    const bypassFilter = allowPrivateForRequest || global.DisableSsrfRequestFilter?.(currentUrl.toString())
     if (!bypassFilter) assertAllowedUrl(currentUrl)
-    const dispatcher = getDispatcher(!bypassFilter)
+    const dispatcher = getDispatcher(!bypassFilter, allowPrivateForRequest)
     const response = await fetchWithTimeout(currentUrl, {
       ...currentOptions,
       redirect: 'manual'
     }, timeout, dispatcher)
+
+    if (allowPrivateNetwork && redirectCount === 0 && !originalProviderIsLocal) {
+      originalProviderIsLocal = trustedLocalHostnames.get(originalHostname) === true
+    }
 
     if (!isRedirect(response)) return response
     if (redirectCount >= maxRedirects) {

--- a/server/utils/fetchUtils.js
+++ b/server/utils/fetchUtils.js
@@ -1,6 +1,5 @@
 /**
- * Fetch a successful response, applying the timeout semantics previously
- * provided by Axios. Callers that need a parsed body should use fetchJson.
+ * Fetch a successful response.
  *
  * @param {string|URL} url
  * @param {RequestInit & { timeout?: number }} [options]
@@ -112,11 +111,18 @@ function isRedirect(response) {
   return [301, 302, 303, 307, 308].includes(response.status)
 }
 
-function getRedirectOptions(options, status) {
-  const method = options.method?.toUpperCase()
-  if (status !== 303 && !([301, 302].includes(status) && method === 'POST')) return options
-
+function getRedirectOptions(options, status, currentUrl, nextUrl) {
   const headers = new Headers(options.headers)
+  if (currentUrl.origin !== nextUrl.origin) {
+    headers.delete('authorization')
+    headers.delete('cookie')
+  }
+
+  const method = options.method?.toUpperCase()
+  if (status !== 303 && !([301, 302].includes(status) && method === 'POST')) {
+    return { ...options, headers }
+  }
+
   headers.delete('content-length')
   headers.delete('content-type')
   return { ...options, method: 'GET', body: undefined, headers }
@@ -152,9 +158,10 @@ async function safeFetch(url, { timeout, maxRedirects = 5, signal, ...options } 
     const location = response.headers.get('location')
     if (!location) return response
 
+    const nextUrl = getUrl(new URL(location, currentUrl))
     await response.body?.cancel()
-    currentUrl = getUrl(new URL(location, currentUrl))
-    currentOptions = getRedirectOptions(currentOptions, response.status)
+    currentOptions = getRedirectOptions(currentOptions, response.status, currentUrl, nextUrl)
+    currentUrl = nextUrl
   }
 }
 

--- a/server/utils/fetchUtils.js
+++ b/server/utils/fetchUtils.js
@@ -1,0 +1,31 @@
+/**
+ * Fetch a successful response, applying the timeout semantics previously
+ * provided by Axios. Callers that need a parsed body should use fetchJson.
+ *
+ * @param {string|URL} url
+ * @param {RequestInit & { timeout?: number }} [options]
+ * @returns {Promise<Response>}
+ */
+async function fetchResponse(url, { timeout, ...options } = {}) {
+  const response = await fetch(url, {
+    ...options,
+    signal: timeout ? AbortSignal.timeout(timeout) : options.signal
+  })
+
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status}: ${response.statusText}`)
+  }
+
+  return response
+}
+
+/**
+ * @param {string|URL} url
+ * @param {RequestInit & { timeout?: number }} [options]
+ * @returns {Promise<any>}
+ */
+async function fetchJson(url, options) {
+  return (await fetchResponse(url, options)).json()
+}
+
+module.exports = { fetchJson, fetchResponse }

--- a/server/utils/fetchUtils.js
+++ b/server/utils/fetchUtils.js
@@ -1,36 +1,16 @@
-/**
- * Fetch a successful response.
- *
- * @param {string|URL} url
- * @param {RequestInit & { timeout?: number }} [options]
- * @returns {Promise<Response>}
- */
-async function fetchResponse(url, { timeout, ...options } = {}) {
-  return assertOk(await fetchWithTimeout(url, options, timeout, getDispatcher(false)))
-}
-
-/**
- * @param {string|URL} url
- * @param {RequestInit & { timeout?: number }} [options]
- * @returns {Promise<any>}
- */
-async function fetchJson(url, options) {
-  return (await fetchResponse(url, options)).json()
-}
-
-async function safeFetchResponse(url, options) {
-  return assertOk(await safeFetch(url, options))
-}
-
-async function safeFetchJson(url, options) {
-  return (await safeFetchResponse(url, options)).json()
-}
-
-module.exports = { fetchJson, fetchResponse, safeFetch, safeFetchJson, safeFetchResponse }
 const dns = require('node:dns')
 const ipaddr = require('ipaddr.js')
 const { Agent, EnvHttpProxyAgent, getGlobalDispatcher } = require('undici')
 
+/**
+ * Get the IP range classification for an address.
+ *
+ * IPv4-mapped IPv6 addresses are classified by their embedded IPv4 address so
+ * they cannot bypass the IPv4 restrictions.
+ *
+ * @param {string} address
+ * @returns {string|null}
+ */
 function getAddressRange(address) {
   if (!ipaddr.isValid(address)) return null
 
@@ -41,41 +21,55 @@ function getAddressRange(address) {
   return parsed.range()
 }
 
+/**
+ * Check whether an address is permitted by the SSRF filter.
+ *
+ * Hostnames return true here and receive their definitive validation in
+ * `safeLookup` after DNS resolution.
+ *
+ * @param {string} address
+ * @returns {boolean}
+ */
 function isAllowedAddress(address) {
   const range = getAddressRange(address)
   return range === null || range === 'unicast'
 }
 
-function isAllowedResolvedAddress(address) {
-  return typeof address === 'string' && ipaddr.isValid(address) && getAddressRange(address) === 'unicast'
+/**
+ * Check whether an address belongs to a range blocked by the SSRF filter.
+ *
+ * @param {string} address
+ * @returns {boolean}
+ */
+function isBlockedAddress(address) {
+  const range = getAddressRange(address)
+  return range !== null && range !== 'unicast'
 }
 
-function isPrivateAddress(address) {
-  return typeof address === 'string' && ipaddr.isValid(address) && getAddressRange(address) !== 'unicast'
-}
-
+/**
+ * Parse and validate an HTTP(S) URL.
+ *
+ * @param {string|URL} url
+ * @returns {URL}
+ */
 function getUrl(url) {
   const parsedUrl = new URL(url)
   if (!['http:', 'https:'].includes(parsedUrl.protocol)) {
     throw new Error(`Unsupported URL protocol: ${parsedUrl.protocol}`)
   }
-
-  return parsedUrl
-}
-
-function assertAllowedUrl(url) {
-  const parsedUrl = getUrl(url)
-  const hostname = parsedUrl.hostname.replace(/^\[|\]$/g, '')
-  if (!isAllowedAddress(hostname)) {
-    throw new Error(`Call to ${hostname} is blocked.`)
-  }
   return parsedUrl
 }
 
 /**
- * Resolve every DNS result and hand Undici only an allowed address. Because
- * this lookup is used to create the socket, it cannot be bypassed through a
- * second lookup after validation.
+ * Resolve a hostname for an SSRF-protected connection.
+ *
+ * Only a public unicast address is returned to Undici, which pins validation
+ * and connection establishment to the same DNS result.
+ *
+ * @param {string} hostname
+ * @param {{ all?: boolean }} options
+ * @param {Function} callback
+ * @returns {void}
  */
 function safeLookup(hostname, options, callback) {
   if (!isAllowedAddress(hostname)) {
@@ -86,34 +80,39 @@ function safeLookup(hostname, options, callback) {
   dns.lookup(hostname, { all: true, verbatim: true }, (error, addresses) => {
     if (error) return callback(error)
 
-    // `dns.lookup` normally returns address objects when `all` is enabled, but
-    // do not pass a malformed resolver result to Undici as an undefined IP.
     const address = addresses.find((result) =>
-      isAllowedResolvedAddress(result?.address)
+      typeof result?.address === 'string' && getAddressRange(result.address) === 'unicast'
     )
     if (!address) return callback(new Error(`Call to ${hostname} is blocked.`))
 
-    // Undici requests every address (`all: true`). Match Node's DNS lookup
-    // callback shape in that mode: an array of { address, family } objects.
     if (options.all) return callback(null, [address])
     callback(null, address.address, address.family)
   })
 }
 
-const safeDispatcher = new Agent({ connect: { lookup: safeLookup } })
-// Record how the trusted provider hostname resolved on the connection used for
-// its initial request. Only providers resolving exclusively to blocked/local
-// ranges may carry private-network trust across redirects.
+// A trusted provider may make its initial connection to any address. Record
+// whether that connection resolved exclusively to blocked/local ranges so only
+// genuinely local providers can carry private-network trust across redirects.
 const trustedLocalHostnames = new Map()
 
+/**
+ * Resolve a hostname for an administrator-configured provider.
+ *
+ * @param {string} hostname
+ * @param {{ all?: boolean }} options
+ * @param {Function} callback
+ * @returns {void}
+ */
 function trustedLookup(hostname, options, callback) {
   dns.lookup(hostname, { all: true, verbatim: true }, (error, addresses) => {
     if (error) return callback(error)
 
-    const validAddresses = addresses.filter((result) => typeof result?.address === 'string' && ipaddr.isValid(result.address))
+    const validAddresses = addresses.filter((result) =>
+      typeof result?.address === 'string' && ipaddr.isValid(result.address)
+    )
     if (!validAddresses.length) return callback(new Error(`Unable to resolve ${hostname}.`))
 
-    trustedLocalHostnames.set(hostname, validAddresses.every((result) => isPrivateAddress(result.address)))
+    trustedLocalHostnames.set(hostname, validAddresses.every((result) => isBlockedAddress(result.address)))
     if (options.all) return callback(null, validAddresses)
 
     const address = validAddresses[0]
@@ -121,9 +120,21 @@ function trustedLookup(hostname, options, callback) {
   })
 }
 
+const safeDispatcher = new Agent({ connect: { lookup: safeLookup } })
 const trustedDispatcher = new Agent({ connect: { lookup: trustedLookup } })
 let proxyDispatcher = null
 
+/**
+ * Select the dispatcher for a request.
+ *
+ * Proxy mode intentionally supersedes SSRF filtering. Outside proxy mode,
+ * trusted requests can reach private destinations while protected requests
+ * use the DNS-pinning SSRF dispatcher.
+ *
+ * @param {boolean} useSsrfFilter
+ * @param {boolean} [allowPrivateNetwork=false]
+ * @returns {import('undici').Dispatcher}
+ */
 function getDispatcher(useSsrfFilter, allowPrivateNetwork = false) {
   if (process.env.EXP_PROXY_SUPPORT === '1') {
     if (!proxyDispatcher) proxyDispatcher = new EnvHttpProxyAgent()
@@ -134,43 +145,55 @@ function getDispatcher(useSsrfFilter, allowPrivateNetwork = false) {
 }
 
 /**
- * Apply the configured timeout while connecting and receiving headers. Once
- * headers arrive, Undici's bodyTimeout continues to enforce the same timeout
- * as an inactivity limit between body chunks rather than a total transfer
- * duration.
+ * Fetch a response with Axios-compatible timeout behavior.
+ *
+ * The timer covers connection establishment and response headers. Once the
+ * headers arrive, Undici applies the timeout as the maximum inactivity gap
+ * between response body chunks rather than as a total transfer duration.
+ *
+ * @param {string|URL} url
+ * @param {RequestInit} options
+ * @param {number|undefined} timeout
+ * @param {import('undici').Dispatcher} dispatcher
+ * @returns {Promise<Response>}
  */
 async function fetchWithTimeout(url, options, timeout, dispatcher) {
-  if (!timeout) {
-    return fetch(url, { ...options, dispatcher })
-  }
+  if (!timeout) return fetch(url, { ...options, dispatcher })
 
   const timeoutController = new AbortController()
-  const timeoutHandle = setTimeout(() => timeoutController.abort(new Error(`Request timed out after ${timeout}ms`)), timeout)
+  const timeoutHandle = setTimeout(() => {
+    timeoutController.abort(new Error(`Request timed out after ${timeout}ms`))
+  }, timeout)
   timeoutHandle.unref?.()
+
   const signal = options.signal
     ? AbortSignal.any([options.signal, timeoutController.signal])
     : timeoutController.signal
+  const timeoutDispatcher = dispatcher.compose((dispatch) => (dispatchOptions, handler) => dispatch({
+    ...dispatchOptions,
+    headersTimeout: timeout,
+    bodyTimeout: timeout
+  }, handler))
 
   try {
-    const timeoutDispatcher = dispatcher.compose((dispatch) => (options, handler) => dispatch({
-      ...options,
-      headersTimeout: timeout,
-      bodyTimeout: timeout
-    }, handler))
-    return await fetch(url, {
-      ...options,
-      signal,
-      dispatcher: timeoutDispatcher
-    })
+    return await fetch(url, { ...options, signal, dispatcher: timeoutDispatcher })
   } finally {
     clearTimeout(timeoutHandle)
   }
 }
 
-function isRedirect(response) {
-  return [301, 302, 303, 307, 308].includes(response.status)
-}
-
+/**
+ * Build the request options for a redirect.
+ *
+ * Sensitive credentials are removed when the origin changes. Redirects that
+ * conventionally switch to GET also discard their request body headers.
+ *
+ * @param {RequestInit} options
+ * @param {number} status
+ * @param {URL} currentUrl
+ * @param {URL} nextUrl
+ * @returns {RequestInit}
+ */
 function getRedirectOptions(options, status, currentUrl, nextUrl) {
   const headers = new Headers(options.headers)
   if (currentUrl.origin !== nextUrl.origin) {
@@ -189,8 +212,47 @@ function getRedirectOptions(options, status, currentUrl, nextUrl) {
 }
 
 /**
- * Fetch an external URL with connection-time SSRF protection. Redirects are
- * followed manually so each destination receives the same validation.
+ * Require a successful HTTP response.
+ *
+ * @param {Response} response
+ * @returns {Response}
+ */
+function assertOk(response) {
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status}: ${response.statusText}`)
+  }
+  return response
+}
+
+/**
+ * Fetch a successful response without SSRF filtering.
+ *
+ * @param {string|URL} url
+ * @param {RequestInit & { timeout?: number }} [options]
+ * @returns {Promise<Response>}
+ */
+async function fetchResponse(url, { timeout, ...options } = {}) {
+  return assertOk(await fetchWithTimeout(url, options, timeout, getDispatcher(false)))
+}
+
+/**
+ * Fetch and parse a successful JSON response without SSRF filtering.
+ *
+ * @param {string|URL} url
+ * @param {RequestInit & { timeout?: number }} [options]
+ * @returns {Promise<any>}
+ */
+async function fetchJson(url, options) {
+  return (await fetchResponse(url, options)).json()
+}
+
+/**
+ * Fetch an external URL with connection-time SSRF protection.
+ *
+ * Redirects are followed manually so every destination is validated. When
+ * `allowPrivateNetwork` is enabled, the administrator-configured initial URL
+ * is trusted, but private redirects remain trusted only if that initial
+ * provider resolved exclusively to blocked/local address ranges.
  *
  * @param {string|URL} url
  * @param {RequestInit & { timeout?: number, maxRedirects?: number, allowPrivateNetwork?: boolean }} [options]
@@ -200,23 +262,26 @@ async function safeFetch(url, { timeout, maxRedirects = 5, signal, allowPrivateN
   let currentUrl = getUrl(url)
   let currentOptions = { ...options, signal }
   const originalHostname = currentUrl.hostname.replace(/^\[|\]$/g, '')
-  let originalProviderIsLocal = isPrivateAddress(originalHostname)
+  let originalProviderIsLocal = isBlockedAddress(originalHostname)
 
   for (let redirectCount = 0; ; redirectCount++) {
     const allowPrivateForRequest = allowPrivateNetwork && (redirectCount === 0 || originalProviderIsLocal)
     const bypassFilter = allowPrivateForRequest || global.DisableSsrfRequestFilter?.(currentUrl.toString())
-    if (!bypassFilter) assertAllowedUrl(currentUrl)
-    const dispatcher = getDispatcher(!bypassFilter, allowPrivateForRequest)
+    if (!bypassFilter) {
+      const hostname = currentUrl.hostname.replace(/^\[|\]$/g, '')
+      if (!isAllowedAddress(hostname)) throw new Error(`Call to ${hostname} is blocked.`)
+    }
+
     const response = await fetchWithTimeout(currentUrl, {
       ...currentOptions,
       redirect: 'manual'
-    }, timeout, dispatcher)
+    }, timeout, getDispatcher(!bypassFilter, allowPrivateForRequest))
 
     if (allowPrivateNetwork && redirectCount === 0 && !originalProviderIsLocal) {
       originalProviderIsLocal = trustedLocalHostnames.get(originalHostname) === true
     }
 
-    if (!isRedirect(response)) return response
+    if (![301, 302, 303, 307, 308].includes(response.status)) return response
     if (redirectCount >= maxRedirects) {
       await response.body?.cancel()
       throw new Error(`Too many redirects while requesting ${currentUrl}`)
@@ -232,9 +297,26 @@ async function safeFetch(url, { timeout, maxRedirects = 5, signal, allowPrivateN
   }
 }
 
-function assertOk(response) {
-  if (!response.ok) {
-    throw new Error(`HTTP ${response.status}: ${response.statusText}`)
-  }
-  return response
+/**
+ * Fetch a successful response with SSRF filtering.
+ *
+ * @param {string|URL} url
+ * @param {RequestInit & { timeout?: number, maxRedirects?: number, allowPrivateNetwork?: boolean }} [options]
+ * @returns {Promise<Response>}
+ */
+async function safeFetchResponse(url, options) {
+  return assertOk(await safeFetch(url, options))
 }
+
+/**
+ * Fetch and parse a successful JSON response with SSRF filtering.
+ *
+ * @param {string|URL} url
+ * @param {RequestInit & { timeout?: number, maxRedirects?: number, allowPrivateNetwork?: boolean }} [options]
+ * @returns {Promise<any>}
+ */
+async function safeFetchJson(url, options) {
+  return (await safeFetchResponse(url, options)).json()
+}
+
+module.exports = { fetchJson, fetchResponse, safeFetch, safeFetchJson, safeFetchResponse }

--- a/server/utils/ffmpegHelpers.js
+++ b/server/utils/ffmpegHelpers.js
@@ -1,11 +1,11 @@
-const axios = require('axios')
-const ssrfFilter = require('ssrf-req-filter')
+const { Readable } = require('node:stream')
 const Ffmpeg = require('../libs/fluentFfmpeg')
 const ffmpgegUtils = require('../libs/fluentFfmpeg/utils')
 const fs = require('../libs/fsExtra')
 const Path = require('path')
 const Logger = require('../Logger')
 const { filePathToPOSIX, copyToExisting } = require('./fileUtils')
+const { safeFetchResponse } = require('./fetchUtils')
 
 function escapeSingleQuotes(path) {
   // A ' within a quoted string is escaped with '\'' in ffmpeg (see https://www.ffmpeg.org/ffmpeg-utils.html#Quoting-and-escaping)
@@ -116,17 +116,12 @@ module.exports.downloadPodcastEpisode = (podcastEpisodeDownload) => {
 
     for (const userAgent of userAgents) {
       try {
-        response = await axios({
-          url: podcastEpisodeDownload.url,
-          method: 'GET',
-          responseType: 'stream',
+        response = await safeFetchResponse(podcastEpisodeDownload.url, {
           headers: {
             Accept: '*/*',
             'User-Agent': userAgent
           },
-          timeout: global.PodcastDownloadTimeout,
-          httpAgent: global.DisableSsrfRequestFilter?.(podcastEpisodeDownload.url) ? null : ssrfFilter(podcastEpisodeDownload.url),
-          httpsAgent: global.DisableSsrfRequestFilter?.(podcastEpisodeDownload.url) ? null : ssrfFilter(podcastEpisodeDownload.url)
+          timeout: global.PodcastDownloadTimeout
         })
 
         Logger.debug(`[ffmpegHelpers] Successfully connected with User-Agent: ${userAgent}`)
@@ -150,7 +145,10 @@ module.exports.downloadPodcastEpisode = (podcastEpisodeDownload) => {
     }
 
     /** @type {import('../libs/fluentFfmpeg/index').FfmpegCommand} */
-    const ffmpeg = Ffmpeg(response.data)
+    if (!response.body) {
+      return resolve({ success: false, isRequestError: true })
+    }
+    const ffmpeg = Ffmpeg(Readable.fromWeb(response.body))
     ffmpeg.addOption('-loglevel debug') // Debug logs printed on error
     ffmpeg.outputOptions('-c:a', 'copy', '-map', '0:a', '-metadata', 'podcast=1')
 

--- a/server/utils/fileUtils.js
+++ b/server/utils/fileUtils.js
@@ -1,5 +1,5 @@
 const Path = require('path')
-const { Readable } = require('node:stream')
+const { Readable, pipeline } = require('node:stream')
 const exec = require('child_process').exec
 const fs = require('../libs/fsExtra')
 const rra = require('../libs/recursiveReaddirAsync')
@@ -329,9 +329,10 @@ module.exports.downloadFile = (url, filepath, contentTypeFilter = null) => {
           }
         })
 
-        stream.pipe(writer)
-        writer.on('finish', resolve)
-        writer.on('error', reject)
+        pipeline(stream, writer, (error) => {
+          if (error) return reject(error)
+          resolve()
+        })
       })
       .catch((err) => {
         Logger.error(`[fileUtils] Failed to download file "${filepath}"`, err)

--- a/server/utils/fileUtils.js
+++ b/server/utils/fileUtils.js
@@ -1,11 +1,11 @@
-const axios = require('axios')
 const Path = require('path')
-const ssrfFilter = require('ssrf-req-filter')
+const { Readable } = require('node:stream')
 const exec = require('child_process').exec
 const fs = require('../libs/fsExtra')
 const rra = require('../libs/recursiveReaddirAsync')
 const Logger = require('../Logger')
 const { AudioMimeType } = require('./constants')
+const { safeFetchResponse } = require('./fetchUtils')
 
 /**
  * Make sure folder separator is POSIX for Windows file paths. e.g. "C:\Users\Abs" becomes "C:/Users/Abs"
@@ -298,32 +298,29 @@ module.exports.getFilePathItemFromFileUpdate = (fileUpdate) => {
 module.exports.downloadFile = (url, filepath, contentTypeFilter = null) => {
   return new Promise(async (resolve, reject) => {
     Logger.debug(`[fileUtils] Downloading file to ${filepath}`)
-    axios({
-      url,
-      method: 'GET',
-      responseType: 'stream',
+    safeFetchResponse(url, {
       headers: {
         'User-Agent': 'audiobookshelf (+https://audiobookshelf.org)'
       },
-      timeout: 30000,
-      httpAgent: global.DisableSsrfRequestFilter?.(url) ? null : ssrfFilter(url),
-      httpsAgent: global.DisableSsrfRequestFilter?.(url) ? null : ssrfFilter(url)
+      timeout: 30000
     })
       .then((response) => {
         // Validate content type
-        if (contentTypeFilter && !contentTypeFilter?.(response.headers?.['content-type'])) {
-          return reject(new Error(`Invalid content type "${response.headers?.['content-type'] || ''}"`))
+        const contentType = response.headers.get('content-type') || ''
+        if (contentTypeFilter && !contentTypeFilter?.(contentType)) {
+          return reject(new Error(`Invalid content type "${contentType}"`))
         }
 
-        const totalSize = parseInt(response.headers['content-length'], 10)
+        const totalSize = parseInt(response.headers.get('content-length'), 10)
         let downloadedSize = 0
 
         // Write to filepath
         const writer = fs.createWriteStream(filepath)
-        response.data.pipe(writer)
+        if (!response.body) return reject(new Error(`Empty response body for ${url}`))
+        const stream = Readable.fromWeb(response.body)
 
         let lastProgress = 0
-        response.data.on('data', (chunk) => {
+        stream.on('data', (chunk) => {
           downloadedSize += chunk.length
           const progress = totalSize ? Math.round((downloadedSize / totalSize) * 100) : 0
           if (progress >= lastProgress + 5) {
@@ -332,6 +329,7 @@ module.exports.downloadFile = (url, filepath, contentTypeFilter = null) => {
           }
         })
 
+        stream.pipe(writer)
         writer.on('finish', resolve)
         writer.on('error', reject)
       })

--- a/server/utils/podcastUtils.js
+++ b/server/utils/podcastUtils.js
@@ -1,9 +1,8 @@
-const axios = require('axios')
-const ssrfFilter = require('ssrf-req-filter')
 const Logger = require('../Logger')
 const { xmlToJSON, timestampToSeconds } = require('./index')
 const htmlSanitizer = require('../utils/htmlSanitizer')
 const Fuse = require('../libs/fusejs')
+const { safeFetchResponse } = require('./fetchUtils')
 
 /**
  * @typedef RssPodcastChapter
@@ -363,35 +362,27 @@ module.exports.getPodcastFeed = (feedUrl, excludeEpisodeMetadata = false) => {
     userAgent = 'audiobookshelf (+https://audiobookshelf.org; like iTMS) - CBC'
   }
 
-  return axios({
-    url: feedUrl,
-    method: 'GET',
+  return safeFetchResponse(feedUrl, {
     timeout: global.PodcastDownloadTimeout,
-    responseType: 'arraybuffer',
     headers: {
       Accept: 'application/rss+xml, application/xhtml+xml, application/xml, */*;q=0.8',
       'Accept-Encoding': 'gzip, compress, deflate',
       'User-Agent': userAgent
-    },
-    httpAgent: global.DisableSsrfRequestFilter?.(feedUrl) ? null : ssrfFilter(feedUrl),
-    httpsAgent: global.DisableSsrfRequestFilter?.(feedUrl) ? null : ssrfFilter(feedUrl)
+    }
   })
-    .then(async (data) => {
+    .then(async (response) => {
       // Adding support for ios-8859-1 encoded RSS feeds.
       //  See: https://github.com/advplyr/audiobookshelf/issues/1489
-      const contentType = data.headers?.['content-type'] || '' // e.g. text/xml; charset=iso-8859-1
-      if (contentType.toLowerCase().includes('iso-8859-1')) {
-        data.data = data.data.toString('latin1')
-      } else {
-        data.data = data.data.toString()
-      }
+      const contentType = response.headers.get('content-type') || '' // e.g. text/xml; charset=iso-8859-1
+      const encoding = contentType.toLowerCase().includes('iso-8859-1') ? 'latin1' : 'utf8'
+      const content = Buffer.from(await response.arrayBuffer()).toString(encoding)
 
-      if (!data?.data) {
+      if (!content) {
         Logger.error(`[podcastUtils] getPodcastFeed: Invalid podcast feed request response (${feedUrl})`)
         return null
       }
       Logger.debug(`[podcastUtils] getPodcastFeed for "${feedUrl}" success - parsing xml`)
-      const payload = await this.parsePodcastRssFeedXml(data.data, excludeEpisodeMetadata)
+      const payload = await this.parsePodcastRssFeedXml(content, excludeEpisodeMetadata)
       if (!payload) {
         return null
       }
@@ -402,14 +393,6 @@ module.exports.getPodcastFeed = (feedUrl, excludeEpisodeMetadata = false) => {
       return payload.podcast
     })
     .catch((error) => {
-      // Check for failures due to redirecting from http to https. If original url was http, upgrade to https and try again
-      if (error.code === 'ERR_FR_REDIRECTION_FAILURE' && error.cause.code === 'ERR_INVALID_PROTOCOL') {
-        if (feedUrl.startsWith('http://') && error.request._options.protocol === 'https:') {
-          Logger.info('Redirection from http to https detected. Upgrading Request', error.request._options.href)
-          feedUrl = feedUrl.replace('http://', 'https://')
-          return this.getPodcastFeed(feedUrl, excludeEpisodeMetadata)
-        }
-      }
       Logger.error('[podcastUtils] getPodcastFeed Error', error)
       return null
     })

--- a/test/server/auth/OidcAuthStrategy.test.js
+++ b/test/server/auth/OidcAuthStrategy.test.js
@@ -69,6 +69,24 @@ describe('OidcAuthStrategy - isValidWebCallbackUrl', () => {
     expect(strategy.isValidWebCallbackUrl('not a url', mockReq())).to.equal(false)
   })
 
+  it('discovers an issuer on a private network', async () => {
+    const issuer = 'http://192.168.1.66:9000/application/o/audiobookshelf'
+    sinon.stub(global, 'fetch').resolves(new Response(JSON.stringify({
+      issuer,
+      authorization_endpoint: `${issuer}/authorize`,
+      token_endpoint: `${issuer}/token`,
+      userinfo_endpoint: `${issuer}/userinfo`,
+      end_session_endpoint: `${issuer}/logout`,
+      jwks_uri: `${issuer}/jwks`,
+      id_token_signing_alg_values_supported: ['RS256']
+    })))
+
+    const config = await strategy.getIssuerConfig(issuer)
+
+    expect(config.issuer).to.equal(issuer)
+    expect(global.fetch.calledWith(`${issuer}/.well-known/openid-configuration`)).to.be.true
+  })
+
   it('uses x-forwarded-proto when determining same-origin https URLs', () => {
     const req = mockReq({ xForwardedProto: 'https' })
     expect(strategy.isValidWebCallbackUrl('https://books.example.com/login', req)).to.equal(true)

--- a/test/server/providers/CustomProviderAdapter.test.js
+++ b/test/server/providers/CustomProviderAdapter.test.js
@@ -1,0 +1,29 @@
+const { expect } = require('chai')
+const sinon = require('sinon')
+const Database = require('../../../server/Database')
+const Logger = require('../../../server/Logger')
+const CustomProviderAdapter = require('../../../server/providers/CustomProviderAdapter')
+
+describe('CustomProviderAdapter', () => {
+  afterEach(() => {
+    sinon.restore()
+  })
+
+  it('allows an administrator-configured provider on a private network', async () => {
+    sinon.stub(Logger, 'debug')
+    sinon.stub(Database, 'customMetadataProviderModel').get(() => ({
+      findByPk: sinon.stub().resolves({
+        url: 'http://127.0.0.1:8080',
+        authHeaderValue: null
+      })
+    }))
+    const fetchStub = sinon.stub(global, 'fetch').resolves(new Response(JSON.stringify({
+      matches: [{ title: 'Private provider result' }]
+    })))
+
+    const results = await new CustomProviderAdapter().search('Title', null, null, 'custom-provider-id', 'book')
+
+    expect(results).to.deep.equal([{ title: 'Private provider result' }])
+    expect(fetchStub.firstCall.args[0].toString()).to.equal('http://127.0.0.1:8080/search?mediaType=book&query=Title')
+  })
+})

--- a/test/server/utils/fetchUtils.test.js
+++ b/test/server/utils/fetchUtils.test.js
@@ -30,6 +30,44 @@ describe('fetchUtils', () => {
     expect(fetchStub.firstCall.args[1].redirect).to.equal('manual')
   })
 
+  it('does not forward sensitive headers across origins', async () => {
+    const fetchStub = sinon.stub(global, 'fetch')
+      .onFirstCall().resolves(new Response(null, {
+        status: 302,
+        headers: { location: 'https://redirect.example/result' }
+      }))
+      .onSecondCall().resolves(new Response('ok'))
+
+    await safeFetch('https://provider.example/search', {
+      headers: {
+        Authorization: 'Bearer secret',
+        Cookie: 'session=secret',
+        'X-Request-Id': 'request-id'
+      }
+    })
+
+    const redirectedHeaders = new Headers(fetchStub.secondCall.args[1].headers)
+    expect(redirectedHeaders.get('authorization')).to.equal(null)
+    expect(redirectedHeaders.get('cookie')).to.equal(null)
+    expect(redirectedHeaders.get('x-request-id')).to.equal('request-id')
+  })
+
+  it('keeps sensitive headers on same-origin redirects', async () => {
+    const fetchStub = sinon.stub(global, 'fetch')
+      .onFirstCall().resolves(new Response(null, {
+        status: 302,
+        headers: { location: '/result' }
+      }))
+      .onSecondCall().resolves(new Response('ok'))
+
+    await safeFetch('https://provider.example/search', {
+      headers: { Authorization: 'Bearer secret' }
+    })
+
+    const redirectedHeaders = new Headers(fetchStub.secondCall.args[1].headers)
+    expect(redirectedHeaders.get('authorization')).to.equal('Bearer secret')
+  })
+
   it('passes an Undici dispatcher to protected requests', async () => {
     const fetchStub = sinon.stub(global, 'fetch').resolves(new Response('ok'))
 

--- a/test/server/utils/fetchUtils.test.js
+++ b/test/server/utils/fetchUtils.test.js
@@ -1,0 +1,79 @@
+const { expect } = require('chai')
+const dns = require('node:dns')
+const sinon = require('sinon')
+const { safeFetch } = require('../../../server/utils/fetchUtils')
+
+describe('fetchUtils', () => {
+  afterEach(() => {
+    sinon.restore()
+    delete global.DisableSsrfRequestFilter
+  })
+
+  it('blocks private, loopback, and IPv4-mapped IPv6 destinations before connecting', async () => {
+    const fetchStub = sinon.stub(global, 'fetch')
+
+    await assertRejected(safeFetch('http://127.0.0.1'), 'Call to 127.0.0.1 is blocked.')
+    await assertRejected(safeFetch('http://10.0.0.1'), 'Call to 10.0.0.1 is blocked.')
+    await assertRejected(safeFetch('http://[::1]'), 'is blocked.')
+    await assertRejected(safeFetch('http://[::ffff:127.0.0.1]'), 'is blocked.')
+    sinon.assert.notCalled(fetchStub)
+  })
+
+  it('validates every redirect destination', async () => {
+    const fetchStub = sinon.stub(global, 'fetch').resolves(new Response(null, {
+      status: 302,
+      headers: { location: 'http://127.0.0.1' }
+    }))
+
+    await assertRejected(safeFetch('https://example.com'), 'Call to 127.0.0.1 is blocked.')
+    sinon.assert.calledOnce(fetchStub)
+    expect(fetchStub.firstCall.args[1].redirect).to.equal('manual')
+  })
+
+  it('passes an Undici dispatcher to protected requests', async () => {
+    const fetchStub = sinon.stub(global, 'fetch').resolves(new Response('ok'))
+
+    await safeFetch('https://example.com')
+
+    expect(fetchStub.firstCall.args[1].dispatcher).to.exist
+  })
+
+  it('rejects malformed DNS lookup results before connecting', async () => {
+    sinon.stub(dns, 'lookup').yields(null, ['203.0.113.10'])
+
+    await assertLookupRejected(safeFetch('https://example.com'))
+  })
+
+  it('rejects non-IP DNS lookup results before connecting', async () => {
+    sinon.stub(dns, 'lookup').yields(null, [{ address: 'redirect.example', family: 4 }])
+
+    await assertLookupRejected(safeFetch('https://example.com'))
+  })
+
+  it('honors the configured SSRF bypass for private destinations', async () => {
+    global.DisableSsrfRequestFilter = () => true
+    const fetchStub = sinon.stub(global, 'fetch').resolves(new Response('ok'))
+
+    await safeFetch('http://127.0.0.1')
+
+    expect(fetchStub.firstCall.args[1].dispatcher).to.equal(undefined)
+  })
+})
+
+async function assertRejected(promise, message) {
+  try {
+    await promise
+    throw new Error('Expected promise to reject')
+  } catch (error) {
+    expect(error.message).to.include(message)
+  }
+}
+
+async function assertLookupRejected(promise) {
+  try {
+    await promise
+    throw new Error('Expected promise to reject')
+  } catch (error) {
+    expect(error.cause.message).to.include('Call to example.com is blocked.')
+  }
+}

--- a/test/server/utils/fetchUtils.test.js
+++ b/test/server/utils/fetchUtils.test.js
@@ -110,7 +110,36 @@ describe('fetchUtils', () => {
 
     await safeFetch('http://127.0.0.1', { allowPrivateNetwork: true })
 
-    expect(fetchStub.firstCall.args[1].dispatcher).to.equal(getGlobalDispatcher())
+    expect(fetchStub.firstCall.args[1].dispatcher).not.to.equal(getGlobalDispatcher())
+  })
+
+  it('blocks a private redirect from a trusted public provider', async () => {
+    const fetchStub = sinon.stub(global, 'fetch').resolves(new Response(null, {
+      status: 302,
+      headers: { location: 'http://127.0.0.1/result' }
+    }))
+
+    await assertRejected(safeFetch('https://provider.example/search', {
+      allowPrivateNetwork: true
+    }), 'Call to 127.0.0.1 is blocked.')
+
+    sinon.assert.calledOnce(fetchStub)
+  })
+
+  it('allows a private redirect when the trusted provider is local', async () => {
+    const fetchStub = sinon.stub(global, 'fetch')
+      .onFirstCall().resolves(new Response(null, {
+        status: 302,
+        headers: { location: 'http://192.168.1.10/result' }
+      }))
+      .onSecondCall().resolves(new Response('ok'))
+
+    const response = await safeFetch('http://127.0.0.1/search', {
+      allowPrivateNetwork: true
+    })
+
+    expect(await response.text()).to.equal('ok')
+    sinon.assert.calledTwice(fetchStub)
   })
 
   it('does not apply the response timeout to the total body duration', async () => {

--- a/test/server/utils/fetchUtils.test.js
+++ b/test/server/utils/fetchUtils.test.js
@@ -1,12 +1,20 @@
 const { expect } = require('chai')
 const dns = require('node:dns')
 const sinon = require('sinon')
-const { safeFetch } = require('../../../server/utils/fetchUtils')
+const { EnvHttpProxyAgent, getGlobalDispatcher } = require('undici')
+const { fetchResponse, safeFetch } = require('../../../server/utils/fetchUtils')
+
+const originalExpProxySupport = process.env.EXP_PROXY_SUPPORT
 
 describe('fetchUtils', () => {
   afterEach(() => {
     sinon.restore()
     delete global.DisableSsrfRequestFilter
+    if (originalExpProxySupport === undefined) {
+      delete process.env.EXP_PROXY_SUPPORT
+    } else {
+      process.env.EXP_PROXY_SUPPORT = originalExpProxySupport
+    }
   })
 
   it('blocks private, loopback, and IPv4-mapped IPv6 destinations before connecting', async () => {
@@ -94,7 +102,75 @@ describe('fetchUtils', () => {
 
     await safeFetch('http://127.0.0.1')
 
-    expect(fetchStub.firstCall.args[1].dispatcher).to.equal(undefined)
+    expect(fetchStub.firstCall.args[1].dispatcher).to.equal(getGlobalDispatcher())
+  })
+
+  it('allows explicitly trusted private-network destinations', async () => {
+    const fetchStub = sinon.stub(global, 'fetch').resolves(new Response('ok'))
+
+    await safeFetch('http://127.0.0.1', { allowPrivateNetwork: true })
+
+    expect(fetchStub.firstCall.args[1].dispatcher).to.equal(getGlobalDispatcher())
+  })
+
+  it('does not apply the response timeout to the total body duration', async () => {
+    const dispatchStub = sinon.stub(getGlobalDispatcher(), 'dispatch').returns(false)
+    const fetchStub = sinon.stub(global, 'fetch').callsFake(async () => {
+      return new Response(new ReadableStream({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode('first'))
+          setTimeout(() => {
+            controller.enqueue(new TextEncoder().encode('second'))
+            controller.close()
+          }, 40)
+        }
+      }))
+    })
+
+    const response = await fetchResponse('https://example.com', { timeout: 20 })
+
+    expect(await response.text()).to.equal('firstsecond')
+    const timeoutDispatcher = fetchStub.firstCall.args[1].dispatcher
+    expect(timeoutDispatcher).not.to.equal(getGlobalDispatcher())
+    timeoutDispatcher.dispatch({ origin: 'https://example.com' }, { onError() {} })
+    expect(dispatchStub.firstCall.args[0].headersTimeout).to.equal(20)
+    expect(dispatchStub.firstCall.args[0].bodyTimeout).to.equal(20)
+  })
+
+  it('times out while waiting for response headers', async () => {
+    sinon.stub(global, 'fetch').callsFake((url, options) => {
+      return new Promise((resolve, reject) => {
+        options.signal.addEventListener('abort', () => reject(options.signal.reason), { once: true })
+      })
+    })
+
+    await assertRejected(fetchResponse('https://example.com', { timeout: 10 }), 'Request timed out after 10ms')
+  })
+
+  it('preserves a caller-provided abort signal', async () => {
+    const controller = new AbortController()
+    sinon.stub(global, 'fetch').callsFake((url, options) => {
+      return new Promise((resolve, reject) => {
+        options.signal.addEventListener('abort', () => reject(options.signal.reason), { once: true })
+      })
+    })
+
+    const responsePromise = fetchResponse('https://example.com', {
+      timeout: 1000,
+      signal: controller.signal
+    })
+    controller.abort(new Error('Caller aborted'))
+
+    await assertRejected(responsePromise, 'Caller aborted')
+  })
+
+  it('uses an environment proxy dispatcher when proxy support is enabled', async () => {
+    process.env.EXP_PROXY_SUPPORT = '1'
+    const fetchStub = sinon.stub(global, 'fetch').resolves(new Response('ok'))
+
+    await fetchResponse('https://example.com')
+
+    expect(fetchStub.firstCall.args[1].dispatcher).to.be.instanceOf(EnvHttpProxyAgent)
   })
 })
 


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

This PR replaces the `axios` and `ssrf-req-filter` server dependencies with the built-in Node `fetch` API. It adds an explicit `undici` dependency for custom dispatchers and proxy support, and an explicit `ipaddr.js` dependency for address classification and SSRF protection. Client-side Axios is unchanged.

## Which issue is fixed?

No specific issue. Supersedes https://github.com/advplyr/audiobookshelf/pull/5460.

Related to https://github.com/advplyr/audiobookshelf/pull/5112. This PR should resolve network-body stalls through Undici's inactivity timeout, but it does not provide the separate ffmpeg-progress watchdog.

## In-depth Description

Axios is one of the outdated dependencies used by the server. Server-side `axios` was used for: retrieving metadata from online or local sources, podcast feeds, episode downloads, remote file and cover downloads, OIDC discovery, Apprise notifications, and BinaryManager downloads. This PR only replaces the server side dependency, it does not touch the web client `axios` dependency.

A new `fetchUtils.js` module provides functionality similar to the previous Axios implementation:

- `fetchResponse`: perform an unfiltered request and reject non-2xx responses.
- `fetchJson`: perform an unfiltered request and parse its body as JSON.
- `safeFetch`: perform a request with SSRF-aware DNS and redirect handling while still returning non-2xx responses to the caller.
- `safeFetchResponse`: use `safeFetch` and reject non-2xx responses.
- `safeFetchJson`: use the protected response path and parse JSON.

A custom Undici Agent performs DNS validation for protected requests. It accepts only public unicast addresses and passes the validated DNS result directly to the connection to prevent a validation/connection DNS change. IPv4-mapped IPv6 addresses are classified using their embedded IPv4 address, and only HTTP and HTTPS URLs are accepted.

`safeFetch` follows redirects manually so every destination is validated before connecting. It supports 301, 302, 303, 307, and 308 responses and relative `Location` headers. To prevent information leakage, `Authorization` and `Cookie` headers are removed when the origin changes in a redirect. Redirects that switch a request to GET also remove the request body and its content headers.

Ordinary protected requests cannot access private addresses at any hop. Addresses which are administrator controlled (OIDC discovery, Apprise notifications, and local Custom Metadat Providers) remain unfiltered. Custom Metadata Providers use an explicit `allowPrivateNetwork` option so their initial destination may be on localhost or a LAN. A private redirect remains allowed as long as the source was a local/private address; public providers cannot redirect into the private network.

Timeouts cover connection establishment and response headers. After the headers arrive, Undici applies the timeout as the maximum inactivity gap between response body chunks rather than as a total transfer limit to allow long downloads to continue while data is still being received.

The following environment variables are still supported:

- `EXP_PROXY_SUPPORT=1` uses `EnvHttpProxyAgent` for requests and supersedes direct SSRF filtering, matching the existing proxy-mode trust model.
- `DISABLE_SSRF_REQUEST_FILTER=1` bypasses filtering for the `safe` functions. The non-safe helpers are already unfiltered.
- `SSRF_REQUEST_FILTER_WHITELIST` allows the `safe` functions to bypass filtering by hostname. The check is applied separately to each redirect destination.

Other changes:

- BinaryManager now uses the `audiobookshelf` user agent instead of `axios`.
- Redirect limit for `safe` functions is 5 hops. I am not sure what a good limit would be, so this may need to be higher.
- Fetch/Undici uses different default `User-Agent` and `Accept` headers than Axios, which might show provider specific issues when defaults are blocked.
- HTTP failures now produce Fetch/Undici errors rather than `AxiosError` objects. Axios-specific fields such as `error.response`, `error.request`, and `error.config` are no longer available.
- JSON responses are parsed explicitly with `Response.json()`, so empty or malformed JSON rejects during parsing.
- Fetch response bodies are Web streams and are converted to Node streams where required by ffmpeg and filesystem writers.
- Generic file downloads now use `pipeline`, so errors from either the response stream or destination stream reject the download instead of potentially leaving it pending.
- Successful Apprise notification logs now record the HTTP status instead of the response body.
- Undici `7.29.0` requires a minimum Node.js version of `20.18.1`.

## How have you tested this?

New unit tests were created using codex, and are passing after review.

I also tested the following with a server:

- Fetching metadata from existing providers
- Downloading covers
- Searching for a new podcast
- Downloading podcast episodes from RSS feeds

I will need assistance manually testing the following because I am traveling and not set up to sufficiently test these:

- Local custom metadata provider
- Local podfetcher that is normally caught by the SSRF filter

## Screenshots

No frontend or UI changes.