### PR TITLE
Fix out of memory in /api/me/items-in-progress

### DIFF
--- a/server/controllers/MeController.js
+++ b/server/controllers/MeController.js
@@ -485,16 +485,54 @@ class MeController {
   async getAllLibraryItemsInProgress(req, res) {
     const limit = !isNaN(req.query.limit) ? Number(req.query.limit) || 25 : 25
 
-    const mediaProgressesInProgress = req.user.mediaProgresses.filter((mp) => !mp.isFinished && (mp.currentTime > 0 || mp.ebookProgress > 0))
+    const mediaProgressesInProgress = req.user.mediaProgresses
+      .filter((mp) => !mp.isFinished && (mp.currentTime > 0 || mp.ebookProgress > 0))
+      .sort((a, b) => b.updatedAt - a.updatedAt)
+      .slice(0, limit)
 
     const libraryItemsIds = [...new Set(mediaProgressesInProgress.map((mp) => mp.extraData?.libraryItemId).filter((id) => id))]
-    const libraryItems = await Database.libraryItemModel.findAllExpandedWhere({ id: libraryItemsIds })
+    const episodeIds = mediaProgressesInProgress.filter((mp) => mp.mediaItemType === 'podcastEpisode').map((mp) => mp.mediaItemId)
+    const libraryItems = await Database.libraryItemModel.findAll({
+      where: { id: libraryItemsIds },
+      include: [
+        {
+          model: Database.bookModel,
+          include: [
+            {
+              model: Database.authorModel,
+              through: {
+                attributes: []
+              }
+            },
+            {
+              model: Database.seriesModel,
+              through: {
+                attributes: ['id', 'sequence']
+              }
+            }
+          ]
+        },
+        {
+          model: Database.podcastModel,
+          include: {
+            model: Database.podcastEpisodeModel,
+            where: { id: episodeIds },
+            required: false
+          }
+        }
+      ],
+      order: [
+        [Database.bookModel, Database.authorModel, Database.sequelize.models.bookAuthor, 'createdAt', 'ASC'],
+        [Database.bookModel, Database.seriesModel, 'bookSeries', 'createdAt', 'ASC']
+      ]
+    })
+    const libraryItemsById = new Map(libraryItems.map((li) => [li.id, li]))
 
     let itemsInProgress = []
 
     for (const mediaProgress of mediaProgressesInProgress) {
       const oldMediaProgress = mediaProgress.getOldMediaProgress()
-      const libraryItem = libraryItems.find((li) => li.id === oldMediaProgress.libraryItemId)
+      const libraryItem = libraryItemsById.get(oldMediaProgress.libraryItemId)
       if (libraryItem) {
         if (oldMediaProgress.episodeId && libraryItem.isPodcast) {
           const episode = libraryItem.media.podcastEpisodes.find((ep) => ep.id === oldMediaProgress.episodeId)
@@ -504,6 +542,7 @@ class MeController {
               recentEpisode: episode.toOldJSON(libraryItem.id),
               progressLastUpdate: oldMediaProgress.lastUpdate
             }
+            libraryItemWithEpisode.media.numEpisodes = libraryItem.media.numEpisodes
             itemsInProgress.push(libraryItemWithEpisode)
           }
         } else if (!oldMediaProgress.episodeId) {


### PR DESCRIPTION
## Brief summary

`/api/me/items-in-progress` loads every podcast episode of every in-progress item, which duplicates each item's `libraryFiles` JSON once per episode and can exhaust the heap. This loads only the episodes actually referenced.

## Which issue is fixed?

Fixes #5483

## In-depth Description

`getAllLibraryItemsInProgress` loads in-progress items via `findAllExpandedWhere`, which eager-loads every podcast episode. Sequelize repeats the parent `libraryItem` row for each joined episode, so the `libraryFiles` JSON is duplicated per episode. For a podcast with 1409 episodes and a 1 MB `libraryFiles` blob that is roughly 1.4 GB of raw rows from one item, and the limit is applied only after the response is built.

Changes:

- Scope the `podcastEpisode` include to the episode ids the progress records reference, instead of loading every episode.
- Sort and limit the media progresses before querying, so at most `limit` items are loaded.
- Restore `numEpisodes` from the stored `podcasts.numEpisodes` column, since the episodes are no longer all loaded. That is the same column `LibraryItem.js` already uses when building minified JSON, and `PodcastManager` keeps it in sync.
- Replace the `libraryItems.find()` inside the loop with a Map lookup.

`findAllExpandedWhere` is left alone so its other callers are unaffected.

One behavior change: progress records pointing at a deleted item or a missing episode are no longer backfilled by later records, so a response can return fewer than `limit` entries.

## How have you tested this?

Run locally against a copy of my production database with `--max-old-space-size=2048`. That library has 21,360 podcast episodes across 72 items and 48 in-progress media progress records.

Before: the request ran 35s, then the process died with `FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory`.

After: 200 in 0.48s cold and 0.04s warm, 75,093 byte response, process RSS 108.6 MB.

Checked that the response has 25 items sorted by progress descending, the correct `recentEpisode` on each of the 19 podcast entries, and `numEpisodes` matching the database (1197 for a 1197 episode podcast).

Also verified that an include with an empty episode id array still returns book items, for users with no podcast progress.

354 unit tests passing.

## Screenshots

No web client changes.
