### PR TITLE
Fix: preserve client lastUpdate when creating MediaProgress on local session sync

### DIFF
--- a/server/models/User.js
+++ b/server/models/User.js
@@ -822,6 +822,21 @@ class User extends Model {
         newMediaProgressPayload.finishedAt = null
       }
       mediaProgress = await this.sequelize.models.mediaProgress.create(newMediaProgressPayload)
+
+      // For local sync: preserve the client's lastUpdate on create too (parity with the "For local sync"
+      // block in MediaProgress.applyProgressUpdate, MediaProgress.js:253-262, which only ran on update).
+      // Without this, Sequelize stamps updatedAt = now, and the sync guard then rejects every session
+      // with an older-but-real timestamp (including a finished one), freezing progress at the first-synced session.
+      if (progressPayload.lastUpdate) {
+        if (isNaN(new Date(progressPayload.lastUpdate))) {
+          Logger.warn(`[User] Invalid date provided for lastUpdate: ${progressPayload.lastUpdate} (media item ${mediaItemId})`)
+        } else {
+          const escapedDate = this.sequelize.escape(new Date(progressPayload.lastUpdate))
+          await this.sequelize.query(`UPDATE "mediaProgresses" SET "updatedAt" = ${escapedDate} WHERE "id" = '${mediaProgress.id}'`)
+          await mediaProgress.reload()
+        }
+      }
+
       this.mediaProgresses.push(mediaProgress)
     }
     userCache.maybeInvalidate(this)

--- a/test/server/models/User.test.js
+++ b/test/server/models/User.test.js
@@ -1,0 +1,73 @@
+const { expect } = require('chai')
+const { Sequelize } = require('sequelize')
+
+const Database = require('../../../server/Database')
+
+describe('User model - createUpdateMediaProgressFromPayload', () => {
+  let user
+  let libraryItem
+
+  beforeEach(async () => {
+    global.ServerSettings = {}
+    Database.sequelize = new Sequelize({ dialect: 'sqlite', storage: ':memory:', logging: false })
+    Database.sequelize.uppercaseFirst = (str) => (str ? `${str[0].toUpperCase()}${str.substr(1)}` : '')
+    await Database.buildModels()
+
+    const library = await Database.libraryModel.create({ name: 'Book Library', mediaType: 'book' })
+    const libraryFolder = await Database.libraryFolderModel.create({ path: '/books', libraryId: library.id })
+    const book = await Database.bookModel.create({
+      title: 'Test Book',
+      duration: 4788.529,
+      audioFiles: [],
+      chapters: [],
+      tags: [],
+      narrators: [],
+      genres: []
+    })
+    libraryItem = await Database.libraryItemModel.create({
+      libraryFiles: [],
+      mediaId: book.id,
+      mediaType: 'book',
+      libraryId: library.id,
+      libraryFolderId: libraryFolder.id
+    })
+
+    user = await Database.userModel.create({ username: 'user', type: 'user' })
+    user.mediaProgresses = []
+  })
+
+  afterEach(async () => {
+    await Database.sequelize.close()
+  })
+
+  // Regression test: on local session sync the create path must keep the client's real
+  // timestamp. Otherwise Sequelize stamps updatedAt = now, which makes the just-created
+  // progress look newer than every remaining queued session and the sync guard skips them.
+  it('preserves the client lastUpdate when creating a new media progress', async () => {
+    const lastUpdate = 1787618968277 // real client timestamp, in the past
+
+    const { mediaProgress } = await user.createUpdateMediaProgressFromPayload({
+      libraryItemId: libraryItem.id,
+      duration: 4788.529,
+      currentTime: 1831,
+      progress: 0.382,
+      lastUpdate
+    })
+
+    expect(mediaProgress).to.exist
+    expect(mediaProgress.updatedAt.valueOf()).to.equal(lastUpdate)
+  })
+
+  it('stamps the current time when lastUpdate is absent', async () => {
+    const before = Date.now()
+    const { mediaProgress } = await user.createUpdateMediaProgressFromPayload({
+      libraryItemId: libraryItem.id,
+      duration: 4788.529,
+      currentTime: 1831,
+      progress: 0.382
+    })
+    const after = Date.now()
+
+    expect(mediaProgress.updatedAt.valueOf()).to.be.within(before, after)
+  })
+})


### PR DESCRIPTION
### Problem

When an offline device reconnects and flushes queued playback sessions via `POST /api/session/local-all`, the **first** session for an item that has no existing server progress hits the CREATE branch of `User.createUpdateMediaProgressFromPayload`. That branch calls `mediaProgress.create(...)` without preserving the client's `lastUpdate`, so Sequelize stamps `updatedAt = now` (the reconnect moment).

The sync guard in `PlaybackSessionManager.syncLocalSession` then compares `existing.updatedAt > session.updatedAt` and skips every remaining queued session — including a genuinely finished one — because their real (older) timestamps now look stale. The reconnect-time server timestamp then propagates back to the client and reverts correct local progress (e.g. a finished audiobook jumping back to an early position).

### Root cause

An asymmetry between the two paths in `User.createUpdateMediaProgressFromPayload`:

- The **UPDATE** path (`MediaProgress.applyProgressUpdate`) already preserves the client `lastUpdate`.
- The **CREATE** path did not, so a newly created row was stamped `updatedAt = now`.

### Fix

After `mediaProgress.create(...)`, apply the client `lastUpdate` to the new row's `updatedAt`, mirroring the existing block in `MediaProgress.applyProgressUpdate` (same `sequelize.escape` and invalid-date guard). It is a no-op for callers that don't send `lastUpdate` (e.g. the normal online session-close path).

### Testing

Reproduced against the real Sequelize models on an in-memory SQLite DB:

- **Before:** first (older) session creates the row stamped at processing time; the later finished session is skipped by the guard and progress reverts.
- **After:** the finished session is applied and wins; the two control scenarios (existing progress + normal sync) are unchanged.
