### PR TITLE
Restore the mount prefix when handing requests to Next

### DIFF
--- a/server/Server.js
+++ b/server/Server.js
@@ -158,6 +158,12 @@ class Server {
     }
 
     await Database.init(false)
+
+    if (typeof global.RouterBasePath !== 'string') {
+      throw new Error('[Server] RouterBasePath must be a string before serving requests')
+    }
+    Logger.info(`[Server] Serving from base path "${global.RouterBasePath || '/'}"`)
+
     // Create or set JWT secret in token manager
     await this.auth.tokenManager.initTokenSecret()
 
@@ -409,7 +415,18 @@ class Server {
       const nextApp = next({ dev: Logger.isDev, dir: ReactClientPath })
       const handle = nextApp.getRequestHandler()
       await nextApp.prepare()
-      router.all('*', (req, res) => handle(req, res))
+      router.all('*', (req, res) => {
+        // Next is configured with the same base path as this router, but Express strips the mount
+        // prefix from req.url, so put it back. The bare mount path is passed through without a
+        // trailing slash, which Next would otherwise redirect away from on every request.
+        if (req.baseUrl) {
+          const queryIndex = req.url.indexOf('?')
+          const pathname = queryIndex === -1 ? req.url : req.url.slice(0, queryIndex)
+          const search = queryIndex === -1 ? '' : req.url.slice(queryIndex)
+          req.url = `${req.baseUrl}${pathname === '/' ? '' : pathname}${search}`
+        }
+        handle(req, res)
+      })
     }
 
     const unixSocketPrefix = 'unix/'

--- a/server/Server.js
+++ b/server/Server.js
@@ -46,6 +46,18 @@ const passport = require('passport')
 const expressSession = require('express-session')
 const MemoryStore = require('./libs/memorystore')
 
+/**
+ * `next()` for a custom server is a NextCustomServer wrapper. After prepare(),
+ * `.server` is another NextServer wrapper; the Node server with `nextConfig` is
+ * one more `.server` down. Older react clients have no basePath and must keep
+ * Express-stripped URLs.
+ */
+function getPreparedNextBasePath(nextApp) {
+  const nodeServer = nextApp.server?.server
+  const basePath = nodeServer?.nextConfig?.basePath
+  return typeof basePath === 'string' ? basePath : ''
+}
+
 class Server {
   constructor(SOURCE, PORT, HOST, CONFIG_PATH, METADATA_PATH, ROUTER_BASE_PATH) {
     this.Port = PORT
@@ -415,11 +427,18 @@ class Server {
       const nextApp = next({ dev: Logger.isDev, dir: ReactClientPath })
       const handle = nextApp.getRequestHandler()
       await nextApp.prepare()
+      const nextBasePath = getPreparedNextBasePath(nextApp)
+      if (nextBasePath) {
+        Logger.info(`[Server] Next client basePath is "${nextBasePath}"`)
+      } else {
+        Logger.info(`[Server] Next client has no basePath; leaving Express-stripped URLs as-is`)
+      }
       router.all('*', (req, res) => {
         // Next is configured with the same base path as this router, but Express strips the mount
         // prefix from req.url, so put it back. The bare mount path is passed through without a
         // trailing slash, which Next would otherwise redirect away from on every request.
-        if (req.baseUrl) {
+        // Skip when Next has no basePath (older client on master).
+        if (nextBasePath && req.baseUrl) {
           const queryIndex = req.url.indexOf('?')
           const pathname = queryIndex === -1 ? req.url : req.url.slice(0, queryIndex)
           const search = queryIndex === -1 ? '' : req.url.slice(queryIndex)


### PR DESCRIPTION
## Brief Summary

This small change is in preparation of turning on dynamic base path for the new React client. It restores the configured base path before handling the request to Next.

## Which issue is fixed?

No issue

## In-depth Description

- Restore Express's mount prefix on `req.url` before handing Next the request, so Next sees the same base path the server was configured with
  - only do this if 
    - react client has basePath support (for backward compatibility) 
    - basePath is not empty
- Fail fast if `RouterBasePath` was never set, and log the path we are serving from (defensive)

## How have you tested this?
- 'npm run start-dev' works with ReactClientPath unset
- 'npm run start-dev' works with ReactClientPath set
- 'npm run start-dev' works with ReactClientPath set with basePath support ([client PR 249](https://github.com/audiobookshelf/audiobookshelf-client-react/pull/249))
  - with no `RouterBasePath` set
    - should serve under `/audiobookshelf` (like the Vue client)
  - with `RouterBasePath=''`
    - should serve under `/` (empty base path)
  - with `RouterBasePath='/abs'`
    - should serve under `/abs`
