### PR TITLE
fix: Firefox warning about soon disallowing reading over CORS

### DIFF
--- a/server/Server.js
+++ b/server/Server.js
@@ -269,7 +269,7 @@ class Server {
         if (global.AllowCors || Logger.isDev || allowedOrigins.some((o) => o === req.get('origin'))) {
           res.header('Access-Control-Allow-Origin', req.get('origin'))
           res.header('Access-Control-Allow-Methods', 'GET, POST, PATCH, PUT, DELETE, OPTIONS')
-          res.header('Access-Control-Allow-Headers', '*')
+          res.header('Access-Control-Allow-Headers', req.get('Access-Control-Request-Headers') || '*')
           res.header('Access-Control-Allow-Credentials', true)
           if (req.method === 'OPTIONS') {
             return res.sendStatus(200)


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary
Returns an explicit list, allowing the headers that was requested instead of `*`

## Which issue is fixed?

Firefox is showing the warning: "Cross-Origin Request Warning: The Same Origin Policy will disallow reading the remote resource at https://example.com/api/libraries soon. (Reason: When the `Access-Control-Allow-Headers` is `*`, the `Authorization` header is not covered. To include the `Authorization` header, it must be explicitly listed in CORS header `Access-Control-Allow-Headers`)."

Meaning that CORS requests that uses a token will stop working in a future version of Firefox.

This is documented in MDN: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Access-Control-Allow-Headers#sect

> The [Authorization](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Authorization) header doesn't accept wildcard and always needs to be listed explicitly.

## In-depth Description

<!--
Describe your solution in more depth.
How does it work? Why is this the best solution?
Does it solve a problem that affects multiple users or is this an edge case for your setup?
-->

To preserve the old `*` behavior, allowing every header to be used. The code now returns the headers that the CORS request asks about unconditionally, falling back to `*` if the request headers are missing.

This is the smallest possible change to preserve the old behavior while supporting upcoming browser changes. The other alternative is to explicitly list the headers ABS accepts, however that will require maintaining the list as new ones are added.

This solves an upcoming problem for all users that calls the ABS API over CORS.

## How have you tested this?

I have built the docker image from by branch using the config:

```yaml
  image: audiobookshelf:cors-headers-warning
  build:
    context: https://github.com/Pajn/audiobookshelf.git#cors-headers-warning
```

Configured **Security > Allowed CORS Origins** to the domain of the app calling
Get an API Key from the "API Key" page
The app is calling ABS like:
```javascript
await fetch(`https://example.com/api/libraries`, {
  headers: {
    Authorization: `Bearer ${ token }`,
    Accept: 'application/json'
  }
})
```

Confirmed the browser console warning is gone, the OPTIONS request now returns `access-control-allow-headers: authorization`

## Screenshots

<!-- If your PR includes any changes to the web client, please include screenshots or a short video from before and after your changes. -->
