### PR TITLE
AudioMetadataManager: Fix logging error

### DIFF
--- a/server/managers/AudioMetadataManager.js
+++ b/server/managers/AudioMetadataManager.js
@@ -272,7 +272,7 @@ class AudioMetadataMangaer {
     this.tasksRunning = this.tasksRunning.filter((t) => t.id !== task.id)
 
     if (this.tasksRunning.length < this.MAX_CONCURRENT_TASKS && this.tasksQueued.length) {
-      Logger.info(`[AudioMetadataManager] Task finished and dequeueing next task. ${this.tasksQueued} tasks queued.`)
+      Logger.info(`[AudioMetadataManager] Task finished and dequeueing next task. ${this.tasksQueued.length} tasks queued.`)
       const nextTask = this.tasksQueued.shift()
       SocketAuthority.emitter('metadata_embed_queue_update', {
         libraryItemId: nextTask.data.libraryItemId,


### PR DESCRIPTION
## Brief summary

Fix erroneous logging of number of queued tasks in `AudioMetadataManager`

## Which issue is fixed?

No issue.

## In-depth Description

The modifed log message printed `[object object]` because it used the array object rather than it's length.

## How have you tested this?

Checked that the logger now prints the proper message.
