### PR TITLE
Add workflow to parse weblate commits

### DIFF
--- a/.github/workflows/contribute-credits.yml
+++ b/.github/workflows/contribute-credits.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   release-notes:
+    if: github.event_name == 'workflow_dispatch' || contains(github.event.head_commit.message, 'weblate')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -17,10 +18,8 @@ jobs:
           fetch-depth: 0
 
       - id: translator-credits
-        uses: audiobookshelf/get-translator-credits@v1
-        with:
-          token: ${{ github.token }}
+        uses: audiobookshelf/get-translator-credits@v1.0.0
 
       - name: Show translator credits
         run: |
-          printf '%s\\n' "${{ steps.translator-credits.outputs.credits }}"
+          printf '%s\n' "${{ steps.translator-credits.outputs.credits }}"

--- a/.github/workflows/contribute-credits.yml
+++ b/.github/workflows/contribute-credits.yml
@@ -1,0 +1,26 @@
+name: Prepare contributor credits
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+jobs:
+  release-notes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - id: translator-credits
+        uses: audiobookshelf/get-translator-credits@v1
+        with:
+          token: ${{ github.token }}
+
+      - name: Show translator credits
+        run: |
+          printf '%s\\n' "${{ steps.translator-credits.outputs.credits }}"

--- a/.github/workflows/translate-credits.yml
+++ b/.github/workflows/translate-credits.yml
@@ -18,7 +18,7 @@ jobs:
           fetch-depth: 0
 
       - id: translator-credits
-        uses: audiobookshelf/get-translator-credits@v1.0.0
+        uses: audiobookshelf/get-translator-credits@v1.1.0
 
       - name: Show translator credits
         run: |

--- a/.github/workflows/translate-credits.yml
+++ b/.github/workflows/translate-credits.yml
@@ -1,4 +1,4 @@
-name: Prepare contributor credits
+name: Prepare translation credits
 
 on:
   push:


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

This PR adds a workflow to make crediting translators easier for the release notes.

## Which issue is fixed?

No issue

## In-depth Description

This workflow uses the https://github.com/audiobookshelf/get-translator-credits action to make crediting translators in the release workflow much easier. It:
- Searches through commits between HEAD the most recent tag for the "Weblate commit" template
- Extracts the language and author information for the commit
- Filters out a unique mapping of author e-mails to language
- Uses the unauthenticated GitHub REST API to look up GitHub users against the commits and replaces author names with GitHub usernames, is present
- Prints the "More Strings Translated" to the action log in the `Show translator credits` for easy copying

The workflow can be ran as either a dispatch or will run automatically on commits to master which include `weblate` in the title. I have included the title on this PR so the output can be seen immediately.

## How have you tested this?

Tested in my fork of the server. My fork does not have the tags, so testing was done against the most recent 50 commits on `master`. The action output can be seen here https://github.com/nichwall/audiobookshelf/actions/runs/34640360980

## Screenshots

<img width="971" height="741" alt="workflow update" src="https://github.com/user-attachments/assets/42082975-6f4f-4cb9-9a89-6e97422f5b91" />
